### PR TITLE
Support tags on the open-balena-api

### DIFF
--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -40,7 +40,7 @@ deviceStatus = require('resin-device-status')
 	treatAsMissingDevice,
 	LOCKED_STATUS_CODE,
 	timeSince,
-	uniqueKeyViolated
+	isUniqueKeyViolationResponse
 } = require('../util')
 { normalizeDeviceOsVersion } = require('../util/device-os-version')
 
@@ -2785,7 +2785,7 @@ getDeviceModel = (deps, opts) ->
 						service_install: serviceInstallId
 						name: key
 						value: value
-				.catch uniqueKeyViolated, ->
+				.catch isUniqueKeyViolationResponse, ->
 					pine.patch
 						resource: 'device_service_environment_variable'
 						options:

--- a/lib/util/dependent-resource.coffee
+++ b/lib/util/dependent-resource.coffee
@@ -28,7 +28,7 @@ errors = require('balena-errors')
 	isId
 	mergePineOptions
 	unauthorizedError
-	uniqueKeyViolated
+	isUniqueKeyViolationResponse
 } = require('../util')
 
 exports.buildDependentResource = (
@@ -114,7 +114,7 @@ exports.buildDependentResource = (
 					if not isId(parentParam)
 						return
 					getResourceId(parentParam)
-				.catch uniqueKeyViolated, ->
+				.catch isUniqueKeyViolationResponse, ->
 					pine.patch
 						resource: resourceName
 						options:

--- a/lib/util/index.coffee
+++ b/lib/util/index.coffee
@@ -84,9 +84,14 @@ exports.noApplicationForKeyResponse =
 	statusCode: 500
 	body: 'No application found to associate with the api key'
 
-exports.uniqueKeyViolated =
-	code: 'BalenaRequestError'
-	body: 'Unique key constraint violated'
+exports.isUniqueKeyViolationResponse = ({code, body}) ->
+	code == 'BalenaRequestError' &&
+	(
+		# api translated response
+		body == 'Unique key constraint violated' ||
+		# pine response (tested on pine 10)
+		/^".*" must be unique\.$/.test(body)
+	)
 
 exports.treatAsMissingApplication = (nameOrId) ->
 	return (err) ->


### PR DESCRIPTION
Properly detects unique violation errors so that upserts
wort both on balenaCloud & open-balena-api / plain pine
instances. Adds support for tags on the open-balena-api
and fixes a device service envvar issue.

Resolves: #622
See: https://github.com/balena-io/open-balena-api/pull/45
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>