### PR TITLE
**BREAKING** Drop pine 6 emulated upsert logic on dependent resources

### DIFF
--- a/lib/util/dependent-resource.coffee
+++ b/lib/util/dependent-resource.coffee
@@ -99,13 +99,6 @@ exports.buildDependentResource = (
 						"#{parentResourceName}": parentId
 						"#{resourceKeyField}": key
 						value: value
-				.tap (result) ->
-					# On Pine 6, when the post adds nothing to the DB
-					# then the associated parent resource was not found.
-					# If we never checked that the resource actually exists
-					# then we should reject an appropriate error.
-					if isId(parentParam) && isEmpty(result)
-						throw new ResourceNotFoundError(parentParam)
 				.tapCatch unauthorizedError, ->
 					# On Pine 7, when the post throws a 401
 					# then the associated parent resource might not exist.


### PR DESCRIPTION
I don't expect this to actually break anything, since both
the cloud api & the open-balena-api are on pine 10. Still
decided to wait for a major release to do this change

Resolves: #626
Change-type: major
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>