### PR TITLE
util: Create a generic upsert pine helper method

### DIFF
--- a/lib/util/index.d.ts
+++ b/lib/util/index.d.ts
@@ -1,7 +1,9 @@
 import * as BalenaSdk from '../../typings/balena-sdk';
 
 /** Use with: `findCallback(arguments)`. */
-export function findCallback(args: IArguments): (() => void);
+export function findCallback(args: IArguments): () => void;
+
+export function isUniqueKeyViolationResponse(err: Error): boolean;
 
 /**
  * Merging two sets of pine options sensibly is more complicated than it sounds.

--- a/lib/util/upsert.ts
+++ b/lib/util/upsert.ts
@@ -1,0 +1,62 @@
+import * as errors from 'balena-errors';
+import * as Promise from 'bluebird';
+import find = require('lodash/find');
+import isArray = require('lodash/isArray');
+import isEmpty = require('lodash/isEmpty');
+import omit = require('lodash/omit');
+import pick = require('lodash/pick');
+import * as BalenaPine from '../../typings/balena-pine';
+import * as PineClient from '../../typings/pinejs-client-core';
+import { isUniqueKeyViolationResponse } from './index';
+
+export const getUpsertHelper = ({ pine }: { pine: BalenaPine.Pine }) => {
+	const upsert = <T>(
+		params: PineClient.PineParamsFor<T>,
+		naturalKeyProps: Array<keyof T & string>,
+	) =>
+		Promise.try(() => {
+			if (!isArray(naturalKeyProps) || isEmpty(naturalKeyProps)) {
+				throw new errors.BalenaInvalidParameterError(
+					'naturalKeyProps',
+					'The properties that consist the natural key of the model were not provided',
+				);
+			}
+
+			if (params.options && params.options.$filter) {
+				throw new errors.BalenaInvalidParameterError(
+					'params',
+					'The options.$filter pine parameter is not supported on upserts',
+				);
+			}
+
+			const body = params.body;
+			if (!body) {
+				throw new errors.BalenaInvalidParameterError(
+					'params',
+					'The body property is missing from the provided pine parameters',
+				);
+			}
+
+			const missingProp = find(naturalKeyProps, prop => !(prop in body));
+			if (missingProp) {
+				throw new errors.BalenaInvalidParameterError(
+					'naturalKeyProps',
+					`Natural key property "${missingProp}" not defined in the provided body`,
+				);
+			}
+
+			return pine.post<T>(params).catch(isUniqueKeyViolationResponse, () => {
+				const patchParams = {
+					...params,
+					options: {
+						...params.options,
+						$filter: pick(body, naturalKeyProps) as PineClient.Filter<T>,
+					},
+					body: omit(body, naturalKeyProps),
+				};
+				return pine.patch<T>(patchParams);
+			});
+		});
+
+	return upsert;
+};

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -578,15 +578,18 @@ declare namespace BalenaSdk {
 
 	interface BalenaSDK {
 		auth: {
-			register: (
-				credentials: { email: string; password: string },
-			) => Promise<string>;
-			authenticate: (
-				credentials: { email: string; password: string },
-			) => Promise<string>;
-			login: (
-				credentials: { email: string; password: string },
-			) => Promise<void>;
+			register: (credentials: {
+				email: string;
+				password: string;
+			}) => Promise<string>;
+			authenticate: (credentials: {
+				email: string;
+				password: string;
+			}) => Promise<string>;
+			login: (credentials: {
+				email: string;
+				password: string;
+			}) => Promise<void>;
 			loginWithToken: (authToken: string) => Promise<void>;
 			logout: () => Promise<void>;
 			getToken: () => Promise<string>;


### PR DESCRIPTION
Essentially this is re-opening #629, since I did merge it in the wrong branch :(


That's on top of #628 so that the diff is cleaner and is planned to end-up in the next major sdk version (v12).
This might better at some point end up in PineClient (if @Page- likes it).
For now, since we rely on an API translation for the detection of the unique complex key violation, we better make it part of the SDK, which is aware of both plain pine behavior (as in the OSS API) and the cloud API one w/ the translation.

Resolves: #627
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>