### PR TITLE
Pin @types/lodash to 4.14.121 as the last TS 2.6 compatible release

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@resin.io/types-mochainon": "^2.0.1",
-    "@types/lodash": "^4.14.85",
+    "@types/lodash": "4.14.121",
     "@types/mocha": "^5.2.5",
     "balena-config-karma": "^2.3.1",
     "browserify": "^14.3.0",


### PR DESCRIPTION
Resolves: #642
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>