### PR TITLE
host os updates: vendor latest utils with new device types

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "abortcontroller-polyfill": "^1.1.9",
     "balena-auth": "^3.0.0",
     "balena-errors": "^4.0.0",
-    "balena-hup-action-utils": "~1.0.0",
+    "balena-hup-action-utils": "~1.1.0",
     "balena-pine": "^9.0.0",
     "balena-request": "^10.0.0",
     "balena-settings-client": "^4.0.0",


### PR DESCRIPTION
These device types are added in the upstream module:

* `cl-som-imx8`
* `imx7-var-som`
* `imx8m-var-dart`
* `nitrogen6xq2g`
* `npe-x500-m3`
* `n510-tx2`
* `orange-pi-one`
* `orange-pi-zero`
* `spacely-tx2`
* `var-som-mx6`

Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
