### PR TITLE
Use balena-register-device instead of resin-register-device

### DIFF
--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -68,7 +68,7 @@ getDeviceModel = (deps, opts) ->
 	{ pine, request } = deps
 	{ apiUrl, dashboardUrl, deviceUrlsBase } = opts
 
-	registerDevice = require('resin-register-device')({ request })
+	registerDevice = require('balena-register-device')({ request })
 	configModel = once -> require('./config')(deps, opts)
 	applicationModel = once -> require('./application')(deps, opts)
 	osModel = once -> require('./os')(deps, opts)

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "balena-errors": "^4.0.0",
     "balena-hup-action-utils": "~1.1.0",
     "balena-pine": "^9.0.0",
+    "balena-register-device": "^6.0.0",
     "balena-request": "^10.0.0",
     "balena-settings-client": "^4.0.0",
     "bluebird": "^3.3.1",
@@ -112,7 +113,6 @@
     "ndjson": "^1.5.0",
     "promise-memoize": "^1.2.0",
     "resin-device-status": "^1.0.1",
-    "resin-register-device": "^5.0.0",
     "resin-semver": "^1.5.0",
     "semver": "^5.3.0"
   },


### PR DESCRIPTION
Resolves: #661
Depends-on: https://github.com/balena-io-modules/resin-register-device/pull/37
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
