### PR TITLE
Improve the verbosity & stability of os.getSupportedVersions tests

### DIFF
--- a/tests/integration/models/os.spec.coffee
+++ b/tests/integration/models/os.spec.coffee
@@ -91,13 +91,20 @@ describe 'OS model', ->
 		describe 'given a valid device slug', ->
 
 			areValidVersions = (osVersions) ->
-				sortedVersions = _.clone(osVersions.versions)
-				sortedVersions.sort(osVersionRCompare)
-				return osVersions and
-					osVersions.versions and osVersions.versions.length and
-					_.isEqual(osVersions.versions, sortedVersions)
-					osVersions.latest and osVersions.recommended and osVersions.default and
-					osVersions.default is osVersions.recommended
+				m.chai.expect(osVersions).to.be.an('object')
+				m.chai.expect(osVersions).to.have.property('versions').that.is.an('array')
+				m.chai.expect(osVersions.versions).to.not.have.lengthOf(0)
+
+				sortedVersions = osVersions.versions.slice().sort(osVersionRCompare)
+				m.chai.expect(osVersions.versions).to.deep.equal(sortedVersions)
+
+				m.chai.expect(osVersions).to.have.property('latest').that.is.a('string')
+				m.chai.expect(osVersions).to.have.property('latest').that.is.a('string')
+				m.chai.expect(osVersions).to.have.property('recommended').that.is.a('string')
+				m.chai.expect(osVersions).to.have.property('default').that.is.a('string')
+				m.chai.expect(osVersions.default).to.equal(osVersions.recommended)
+
+				return true
 
 			it 'should eventually return the valid versions object', ->
 				promise = balena.models.os.getSupportedVersions('raspberry-pi')

--- a/tests/integration/models/os.spec.coffee
+++ b/tests/integration/models/os.spec.coffee
@@ -90,15 +90,24 @@ describe 'OS model', ->
 
 		describe 'given a valid device slug', ->
 
+			expectSorted = (array, comparator) ->
+				# re-sorting could fail when the system is not using a stable
+				# sorting algorithm, in which case items of the same value
+				# might swap positions in the array
+				array.forEach (item, i) ->
+					if i == 0
+						return
+
+					previousItem = array[i - 1]
+					m.chai.expect(comparator(previousItem, item)).to.be.lte(0)
+
 			areValidVersions = (osVersions) ->
 				m.chai.expect(osVersions).to.be.an('object')
 				m.chai.expect(osVersions).to.have.property('versions').that.is.an('array')
 				m.chai.expect(osVersions.versions).to.not.have.lengthOf(0)
 
-				sortedVersions = osVersions.versions.slice().sort(osVersionRCompare)
-				m.chai.expect(osVersions.versions).to.deep.equal(sortedVersions)
+				expectSorted(osVersions.versions, osVersionRCompare)
 
-				m.chai.expect(osVersions).to.have.property('latest').that.is.a('string')
 				m.chai.expect(osVersions).to.have.property('latest').that.is.a('string')
 				m.chai.expect(osVersions).to.have.property('recommended').that.is.a('string')
 				m.chai.expect(osVersions).to.have.property('default').that.is.a('string')


### PR DESCRIPTION
Without the `expectSorted` change the tests might fail on staging when the `versions` array contains items of the same normalized semver value, depending on the length of the array.
Found this edge case when sorting the versions from
https://api.balena-staging.com/device-types/v1/raspberry-pi/images/
in which case `"2.0.0+rev1"` & `"2.0.0.rev1"` (which have the same normalized semver value) swapped positions after resorting.
Demo: https://runkit.com/embed/690i3z8wz9q2

Resolves: #667
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
