### PR TITLE
Use the open-balena-api endpoints for device type & version info

### DIFF
--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -2270,7 +2270,7 @@ getDeviceModel = (deps, opts) ->
 	# @memberof balena.models.device
 	#
 	# @description
-	# utility method exported for testability
+	# Utility method exported for testability
 	#
 	# @param {Object} device - A device object
 	# @param {String} targetOsVersion - semver-compatible version for the target device

--- a/lib/models/os.coffee
+++ b/lib/models/os.coffee
@@ -63,13 +63,23 @@ getOsModel = (deps, opts) ->
 			if not isValid
 				throw new errors.BalenaInvalidDeviceType('No such device type')
 
-	getDownloadSize = imgMakerHelper.buildApiRequester
-		buildUrl: ({ deviceType, version }) -> "/size_estimate?deviceType=#{deviceType}&version=#{version}"
-		postProcess: ({ body }) -> body.size
+	getDownloadSize = (deviceType, version) ->
+		request.send
+			method: 'GET'
+			url: "/device-types/v1/#{deviceType}/images/#{version}/download-size"
+			baseUrl: apiUrl
+			sendToken: false
+		.get('body')
+		.get('size')
 
-	getOsVersions = imgMakerHelper.buildApiRequester
-		buildUrl: ({ deviceType }) -> "/image/#{deviceType}/versions"
-		postProcess: ({ body: { versions, latest } }) ->
+	getOsVersions = (deviceType) ->
+		request.send
+			method: 'GET'
+			url: "/device-types/v1/#{deviceType}/images"
+			baseUrl: apiUrl
+			sendToken: false
+		.get('body')
+		.then ({ versions, latest }) ->
 
 			versions.sort(bSemver.rcompare)
 			potentialRecommendedVersions = reject versions, (version) ->

--- a/lib/models/os.coffee
+++ b/lib/models/os.coffee
@@ -120,7 +120,14 @@ getOsModel = (deps, opts) ->
 		else
 			version
 
-	# utility method exported for testability
+	###*
+	# @summary Get the max OS version satisfying the given range.
+	# @description Utility method exported for testability.
+	# @name _getMaxSatisfyingVersion
+	# @private
+	# @function
+	# @memberof balena.models.os
+	###
 	exports._getMaxSatisfyingVersion = (versionOrRange, osVersions) ->
 		if versionOrRange in [ 'default', 'latest', 'recommended' ]
 			return osVersions[versionOrRange]

--- a/tests/integration/models/os.spec.coffee
+++ b/tests/integration/models/os.spec.coffee
@@ -121,11 +121,36 @@ describe 'OS model', ->
 				promise = balena.models.os.getSupportedVersions('raspberrypi')
 				m.chai.expect(promise).to.eventually.satisfy(areValidVersions)
 
+			it 'should cache the results', ->
+				balena.models.os.getSupportedVersions('raspberry-pi')
+				.then (result1) ->
+					balena.models.os.getSupportedVersions('raspberry-pi')
+					.then (result2) ->
+						m.chai.expect(result1).to.equal(result2)
+
+			it 'should cache the supported versions independently for each device type', ->
+				Promise.all [
+					balena.models.os.getSupportedVersions('raspberry-pi')
+					balena.models.os.getSupportedVersions('raspberrypi3')
+				]
+				.then ([ deviceType1Versions, deviceType2Versions ]) ->
+					m.chai.expect(deviceType1Versions).not.to.equal(deviceType2Versions)
+
 		describe 'given an invalid device slug', ->
 
 			it 'should be rejected with an error message', ->
 				promise = balena.models.os.getSupportedVersions('foo-bar-baz')
 				m.chai.expect(promise).to.be.rejectedWith('No such device type')
+
+	describe 'balena.models.os._getOsVersions()', ->
+
+		it 'should cache the results', ->
+			p1 = balena.models.os._getOsVersions('raspberry-pi')
+			p1.then (result1) ->
+				p2 = balena.models.os._getOsVersions('raspberry-pi')
+				p2.then (result2) ->
+					m.chai.expect(result1).to.equal(result2)
+					m.chai.expect(p1).to.equal(p2)
 
 	describe 'balena.models.os.getDownloadSize()', ->
 
@@ -149,6 +174,13 @@ describe 'OS model', ->
 				promise = balena.models.os.getDownloadSize('raspberry-pi', '2.0.6+rev3.prod')
 				m.chai.expect(promise).to.eventually.be.a('number')
 
+			it 'should cache the results', ->
+				balena.models.os.getDownloadSize('raspberry-pi', '1.26.1')
+				.then (result1) ->
+					balena.models.os.getDownloadSize('raspberry-pi', '1.26.1')
+					.then (result2) ->
+						m.chai.expect(result1).to.equal(result2)
+
 			it 'should cache download sizes independently for each version', ->
 				Promise.all [
 					balena.models.os.getDownloadSize('raspberry-pi', '1.26.1')
@@ -162,6 +194,36 @@ describe 'OS model', ->
 			it 'should be rejected with an error message', ->
 				promise = balena.models.os.getDownloadSize('foo-bar-baz')
 				m.chai.expect(promise).to.be.rejectedWith('No such device type')
+
+	describe 'balena.models.os._getDownloadSize()', ->
+
+		it 'should cache the results', ->
+			p1 = balena.models.os._getDownloadSize('raspberry-pi', '1.26.1')
+			p1.then (result1) ->
+				p2 = balena.models.os._getDownloadSize('raspberry-pi', '1.26.1')
+				p2.then (result2) ->
+					m.chai.expect(result1).to.equal(result2)
+					m.chai.expect(p1).to.equal(p2)
+
+	describe 'balena.models.os._clearDeviceTypesEndpointCaches()', ->
+
+		it 'should clear the result cache of balena.models.os._getOsVersions()', ->
+			p1 = balena.models.os._getOsVersions('raspberry-pi')
+			p1.then (result1) ->
+				balena.models.os._clearDeviceTypesEndpointCaches()
+				p2 = balena.models.os._getOsVersions('raspberry-pi')
+				p2.then (result2) ->
+					m.chai.expect(result1).to.deep.equal(result2)
+					m.chai.expect(p1).to.not.equal(p2)
+
+		it 'should clear the result cache of balena.models.os._getDownloadSize()', ->
+			p1 = balena.models.os._getDownloadSize('raspberry-pi', '1.26.1')
+			p1.then (result1) ->
+				balena.models.os._clearDeviceTypesEndpointCaches()
+				p2 = balena.models.os._getDownloadSize('raspberry-pi', '1.26.1')
+				p2.then (result2) ->
+					m.chai.expect(result1).to.deep.equal(result2)
+					m.chai.expect(p1).to.not.equal(p2)
 
 	describe 'balena.models.os.getLastModified()', ->
 


### PR DESCRIPTION
That's on top of https://github.com/balena-io/balena-sdk/pull/668, so the final PR will not require any changes in the tests.

Resolves: #664
Depends-on: balena-io/resin-api#1829
HQ: balena-io/balena#1744
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
