### PR TITLE
Fix device.getStatus() return type typings

### DIFF
--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -961,7 +961,7 @@ declare namespace BalenaSdk {
 				enableTcpPing(uuidOrId: string | number): Promise<void>;
 				disableTcpPing(uuidOrId: string | number): Promise<void>;
 				ping(uuidOrId: string | number): Promise<void>;
-				getStatus(device: object): string;
+				getStatus(device: object): Promise<string>;
 				lastOnline(device: Device): string;
 				getOsVersion(device: Device): string;
 				isTrackingApplicationRelease(


### PR DESCRIPTION
See: https://github.com/balena-io/balena-sdk/blob/cac50add85367b853ec759242d887eef2e746d39/lib/models/device.coffee#L2006-L2009
Resolves: #699
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
