### PR TITLE
getCurrentServiceDetailsPineOptions: Drop $tolower to make it faster

### DIFF
--- a/lib/util/index.coffee
+++ b/lib/util/index.coffee
@@ -200,11 +200,7 @@ exports.getCurrentServiceDetailsPineOptions = ->
 			]
 			$filter:
 				# We filter out deleted images entirely
-				$ne:
-					[
-						$tolower: $: 'status'
-						'deleted'
-					]
+				status: $ne: 'deleted'
 			$expand:
 				image:
 					$select: ['id']
@@ -221,11 +217,7 @@ exports.getCurrentServiceDetailsPineOptions = ->
 			]
 			$filter:
 				# We filter out deleted gateway downloads entirely
-				$ne:
-					[
-						$tolower: $: 'status'
-						'deleted'
-					]
+				status: $ne: 'deleted'
 			$expand:
 				image:
 					$select: ['id']

--- a/tests/integration/setup.coffee
+++ b/tests/integration/setup.coffee
@@ -203,7 +203,7 @@ exports.givenADevice = (beforeFn) ->
 						is_provided_by__release: @oldRelease.id
 						device: device.id
 						download_progress: 100,
-						status: 'Deleted',
+						status: 'deleted',
 						install_date: '2017-09-30'
 			,
 				balena.pine.post


### PR DESCRIPTION
After checking the API code, it seems that it should be just lower case `'deleted'`.
It seems that's only the JS & Python SDK tests that have even created records with `'Deteled'` status.

Resolves: #693
Change-type: pacth
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
