### PR TITLE
**BREAKING** Drop the commit from application ServiceDetail results

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -966,6 +966,8 @@ This method does not map exactly to the underlying model: it runs a
 larger prebuilt query, and reformats it into an easy to use and
 understand format. If you want more control, or to see the raw model
 directly, use `application.getAll(options)` instead.
+**NOTE:** In contrast with device.getWithServiceDetails() the service details
+in the result of this method do not include the associated commit.
 
 **Kind**: static method of [<code>application</code>](#balena.models.application)  
 **Summary**: Get applications and their devices, along with each device's
@@ -1029,6 +1031,8 @@ This method does not map exactly to the underlying model: it runs a
 larger prebuilt query, and reformats it into an easy to use and
 understand format. If you want more control, or to see the raw model
 directly, use `application.get(uuidOrId, options)` instead.
+**NOTE:** In contrast with device.getWithServiceDetails() the service details
+in the result of this method do not include the associated commit.
 
 **Kind**: static method of [<code>application</code>](#balena.models.application)  
 **Summary**: Get a single application and its devices, along with each device's
@@ -2512,7 +2516,8 @@ understand format. If you want more control, or to see the raw model
 directly, use `device.get(uuidOrId, options)` instead.
 
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
-**Summary**: Get a single device along with its associated services' essential details  
+**Summary**: Get a single device along with its associated services' details,
+including their associated commit  
 **Access**: public  
 **Fulfil**: <code>Object</code> - device with service details  
 

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -143,6 +143,8 @@ getApplicationModel = (deps, opts) ->
 	# larger prebuilt query, and reformats it into an easy to use and
 	# understand format. If you want more control, or to see the raw model
 	# directly, use `application.getAll(options)` instead.
+	# **NOTE:** In contrast with device.getWithServiceDetails() the service details
+	# in the result of this method do not include the associated commit.
 	#
 	# @param {Object} [options={}] - extra pine options to use
 	# @fulfil {Object[]} - applications
@@ -164,7 +166,7 @@ getApplicationModel = (deps, opts) ->
 
 		serviceOptions = mergePineOptions
 			$expand: [
-				owns__device: getCurrentServiceDetailsPineOptions()
+				owns__device: getCurrentServiceDetailsPineOptions(false)
 			]
 		, options
 
@@ -249,6 +251,8 @@ getApplicationModel = (deps, opts) ->
 	# larger prebuilt query, and reformats it into an easy to use and
 	# understand format. If you want more control, or to see the raw model
 	# directly, use `application.get(uuidOrId, options)` instead.
+	# **NOTE:** In contrast with device.getWithServiceDetails() the service details
+	# in the result of this method do not include the associated commit.
 	#
 	# @param {String|Number} nameOrId - application name (string) or id (number)
 	# @param {Object} [options={}] - extra pine options to use
@@ -276,7 +280,7 @@ getApplicationModel = (deps, opts) ->
 
 		serviceOptions = mergePineOptions
 			$expand: [
-				owns__device: getCurrentServiceDetailsPineOptions()
+				owns__device: getCurrentServiceDetailsPineOptions(false)
 			]
 		, options
 

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -346,7 +346,8 @@ getDeviceModel = (deps, opts) ->
 		.asCallback(callback)
 
 	###*
-	# @summary Get a single device along with its associated services' essential details
+	# @summary Get a single device along with its associated services' details,
+	# including their associated commit
 	# @name getWithServiceDetails
 	# @public
 	# @function
@@ -383,7 +384,7 @@ getDeviceModel = (deps, opts) ->
 		callback = findCallback(arguments)
 
 		exports.get uuidOrId,
-			mergePineOptions(getCurrentServiceDetailsPineOptions(), options)
+			mergePineOptions(getCurrentServiceDetailsPineOptions(true), options)
 		.then(generateCurrentServiceDetails)
 		.asCallback(callback)
 

--- a/lib/util/index.coffee
+++ b/lib/util/index.coffee
@@ -189,55 +189,66 @@ convertExpandToObject = (expandOption) ->
 		return cloneDeep(expandOption)
 
 # Pine options necessary for getting raw service data for a device
-exports.getCurrentServiceDetailsPineOptions = ->
-	$expand:
-		image_install:
-			$select: [
-				'id'
-				'download_progress'
-				'status'
-				'install_date'
-			]
-			$filter:
-				# We filter out deleted images entirely
-				status: $ne: 'deleted'
-			$expand:
-				image:
-					$select: ['id']
-					$expand:
-						is_a_build_of__service:
-							$select: ['id', 'service_name']
-				is_provided_by__release:
-					$select: ['id', 'commit']
-		gateway_download:
-			$select: [
-				'id'
-				'download_progress'
-				'status'
-			]
-			$filter:
-				# We filter out deleted gateway downloads entirely
-				status: $ne: 'deleted'
-			$expand:
-				image:
-					$select: ['id']
-					$expand:
-						is_a_build_of__service:
-							$select: ['id', 'service_name']
+exports.getCurrentServiceDetailsPineOptions = (expandRelease) ->
+	pineOptions =
+		$expand:
+			image_install:
+				$select: [
+					'id'
+					'download_progress'
+					'status'
+					'install_date'
+				]
+				$filter:
+					# We filter out deleted images entirely
+					status: $ne: 'deleted'
+				$expand:
+					image:
+						$select: ['id']
+						$expand:
+							is_a_build_of__service:
+								$select: ['id', 'service_name']
+			gateway_download:
+				$select: [
+					'id'
+					'download_progress'
+					'status'
+				]
+				$filter:
+					# We filter out deleted gateway downloads entirely
+					status: $ne: 'deleted'
+				$expand:
+					image:
+						$select: ['id']
+						$expand:
+							is_a_build_of__service:
+								$select: ['id', 'service_name']
+
+	if expandRelease
+		pineOptions.$expand.image_install.$expand.is_provided_by__release =
+			$select: ['id', 'commit']
+
+	return pineOptions
 
 # Builds summary data for an image install or gateway download
 getSingleInstallSummary = (rawData) ->
 	image = rawData.image[0]
 	service = image.is_a_build_of__service[0]
 
-	# ? because gateway downloads don't have releases
-	release = rawData.is_provided_by__release?[0]
+	releaseInfo = {}
+	# for the case that the release wasn't expanded or
+	# this is about gateway downloads which don't have releases
+	if rawData.is_provided_by__release?
+		release = rawData.is_provided_by__release[0]
+		releaseInfo =
+			commit: release?.commit
 
-	return Object.assign {}, omit(rawData, ['image', 'is_provided_by__release']),
+	return Object.assign omit(rawData, ['image', 'is_provided_by__release']),
 		service_name: service.service_name
 		image_id: image.id
 		service_id: service.id
-		commit: release?.commit
+	,
+		releaseInfo
 
 # Converts raw service data into a more usable structure and attaches it to the
 # device object under the `current_services` key

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -66,10 +66,13 @@ declare namespace BalenaSdk {
 		id: number;
 		image_id: number;
 		service_id: number;
-		commit: string;
 		download_progress: number;
-		install_date: string;
 		status: string;
+		install_date: string;
+	}
+
+	interface CurrentServiceWithCommit extends CurrentService {
+		commit: string;
 	}
 
 	interface CurrentGatewayDownload {
@@ -80,9 +83,11 @@ declare namespace BalenaSdk {
 		status: string;
 	}
 
-	interface DeviceWithServiceDetails extends Device {
+	interface DeviceWithServiceDetails<
+		TCurrentService extends CurrentService = CurrentService
+	> extends Device {
 		current_services: {
-			[serviceName: string]: CurrentService[];
+			[serviceName: string]: TCurrentService[];
 		};
 
 		current_gateway_downloads: CurrentGatewayDownload[];
@@ -717,7 +722,7 @@ declare namespace BalenaSdk {
 					options?: PineOptionsFor<Application>,
 				): Promise<
 					Application & {
-						owns__device: DeviceWithServiceDetails[];
+						owns__device: Array<DeviceWithServiceDetails<CurrentService>>;
 					}
 				>;
 				getAppByOwner(
@@ -731,7 +736,7 @@ declare namespace BalenaSdk {
 				): Promise<
 					Array<
 						Application & {
-							owns__device: DeviceWithServiceDetails[];
+							owns__device: Array<DeviceWithServiceDetails<CurrentService>>;
 						}
 					>
 				>;
@@ -879,7 +884,7 @@ declare namespace BalenaSdk {
 				getWithServiceDetails(
 					nameOrId: string | number,
 					options?: PineOptionsFor<Device>,
-				): Promise<DeviceWithServiceDetails>;
+				): Promise<DeviceWithServiceDetails<CurrentServiceWithCommit>>;
 				getAll(options?: PineOptionsFor<Device>): Promise<Device[]>;
 				getAllByApplication(
 					nameOrId: string | number,


### PR DESCRIPTION
 This removed the commit field from the results of
application.getWithDeviceServiceDetails() &
application.getAllWithDeviceServiceDetails(), which
allows to drop the release $expand, in order to make
those requests lighter for the API.
We still keep the abstract object creation logic
though, so that consumers depending on that field
can just add the removed $expand on their provided
pine options argument.

Resolves: #694
Change-type: major
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [x] Includes updated documentation
- [ ] Includes updated build output
