### PR TITLE
Temporarily skip the auth.register() tests

### DIFF
--- a/tests/integration/auth.spec.coffee
+++ b/tests/integration/auth.spec.coffee
@@ -83,7 +83,7 @@ describe 'SDK authentication', ->
 				m.chai.expect(promise).to.be.rejected
 					.and.eventually.have.property('code', 'BalenaNotLoggedIn')
 
-		describe 'balena.auth.register()', ->
+		describe.skip 'balena.auth.register()', ->
 
 			beforeEach ->
 				balena.auth.login


### PR DESCRIPTION
This temporarily disables the user registration tests,
given the current rate limiting and the upcoming
changes, so that we can have properly passing SDK
PRs until we find a way to implement the tests.

Also opened an SDK issue so that we don't forget to undo this and continue with the proper implementation.

See: https://github.com/balena-io/balena-sdk/issues/704
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
