### PR TITLE
Fix downstream typing errors due to `Dictionary` helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
   "scripts": {
     "clean": "rimraf build",
     "test": "npm run build && npm run test:all",
-    "test:all": "npm run test:node && npm run test:browser",
+    "test:all": "npm run test:ts-compatibility && npm run test:node && npm run test:browser",
     "test:node": "gulp test",
     "test:browser": "karma start",
+    "test:ts-compatibility": "npx typescript@~3.4.0 --noEmit --project ./tsconfig.dist.json",
     "build": "npm run lint && npm run clean && tsc && gulp build && npm run docs",
     "docs": "jsdoc2md \"build/**/!(balena-browser*.js)\" > DOCUMENTATION.md",
     "ci": "npm test && catch-uncommitted",

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"typings/**/*.d.ts"
+	]
+}

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -7,6 +7,7 @@ import { Readable } from 'stream';
 import * as BalenaPine from './balena-pine';
 import { BalenaRequest } from './balena-request';
 import * as Pine from './pinejs-client-core';
+import { Dictionary } from './utils';
 
 declare namespace BalenaSdk {
 	type WithId = Pine.WithId;

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -10,3 +10,7 @@ export type PropsOfType<T, P> = {
 export type StringKeyof<T> = keyof T & string;
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+export interface Dictionary<T> {
+	[key: string]: T;
+}


### PR DESCRIPTION
Also add a test for the typings, using the minimum TS version that we support, so that this doesn't happen again. Moreover this protects us from the case that we start using newer TS version features and break the compatibility with the min supported TS version of each major SDK release.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
