### PR TITLE
Improve typings for Device, Image, ServiceInstall & Release

### DIFF
--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -458,6 +458,7 @@ declare namespace BalenaSdk {
 		device_environment_variable: ReverseNavigationResource<DeviceVariable>;
 		device_tag: ReverseNavigationResource<DeviceTag>;
 		manages__device: ReverseNavigationResource<Device>;
+		service_install: ReverseNavigationResource<ServiceInstall>;
 	}
 
 	interface SupervisorRelease {
@@ -504,6 +505,7 @@ declare namespace BalenaSdk {
 		project_type?: string | null;
 		status: string;
 		created_at: string;
+		is_stored_at__image_location: string;
 		is_a_build_of__service: NavigationResource<Service>;
 		start_timestamp?: string | null;
 		end_timestamp?: string | null;
@@ -568,6 +570,10 @@ declare namespace BalenaSdk {
 		installs__service: NavigationResource<Service>;
 		service: Service[];
 		application: NavigationResource<Application>;
+
+		device_service_environment_variable: ReverseNavigationResource<
+			DeviceServiceEnvironmentVariable
+		>;
 	}
 
 	interface EnvironmentVariableBase {

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -295,13 +295,13 @@ declare namespace BalenaSdk {
 		status: ReleaseStatus;
 		update_timestamp: string | null;
 
-		contains__image: null | Array<{
-			id: number;
-			image: NavigationResource<Image>;
-		}>;
 		is_created_by__user: NavigationResource<User>;
 		belongs_to__application: NavigationResource<Application>;
 
+		contains__image: ReverseNavigationResource<{
+			id: number;
+			image: NavigationResource<Image>;
+		}>;
 		release_tag: ReverseNavigationResource<ReleaseTag>;
 	}
 

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -40,7 +40,7 @@ type OrderByValues = 'asc' | 'desc';
 type OrderBy = string | string[] | { [index: string]: OrderByValues };
 
 type ResourceObjFilter<T> = {
-	[k in keyof T]?: object | number | string | boolean
+	[k in keyof T]?: object | number | string | boolean;
 };
 
 type Filter<T> = FilterObj<T>;
@@ -154,7 +154,7 @@ export interface PineParams extends PineParamsBase {
 }
 
 export type SubmitBody<T> = {
-	[k in keyof T]?: T[k] extends AssociatedResource ? number | null : T[k]
+	[k in keyof T]?: T[k] extends AssociatedResource ? number | null : T[k];
 };
 
 export interface PineParamsFor<T> extends PineParamsBase {

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -3,7 +3,7 @@ export type AnyObject = {
 };
 
 export type PropsOfType<T, P> = {
-	[K in keyof T]: T[K] extends P ? K : never
+	[K in keyof T]: T[K] extends P ? K : never;
 }[keyof T];
 
 // backwards compatible alternative for: Extract<keyof T, string>


### PR DESCRIPTION
Adds missing model typings for Device Image & ServiceInstall.
Normalizes Release.contains__image typings.

Chagen-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
