### PR TITLE
util/device-os-version: Make compatible w/ newer typings

### DIFF
--- a/lib/util/device-os-version.ts
+++ b/lib/util/device-os-version.ts
@@ -31,7 +31,7 @@ export const getDeviceOsSemverWithVariant = ({
 	const build = versionInfo.build.slice();
 	if (
 		os_variant &&
-		!includes(build.concat(versionInfo.prerelease), os_variant)
+		!includes([...build, ...versionInfo.prerelease], os_variant)
 	) {
 		build.push(os_variant);
 	}


### PR DESCRIPTION
TypeScript will emit the same code, but imo this was
was a nice way to avoid the Array<string | number>
cast (that's what the new typings say for the
`prerelease` prop).

Change-type: patch
See: https://www.typescriptlang.org/play/#src=%5B...build%2C%20...versionInfo.prerelease%5D
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
