### PR TITLE
pinejs-client-code.d.ts: Restrict the selectable & expandable properties

### DIFF
--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -33,6 +33,8 @@ declare namespace BalenaSdk {
 	type PineParams = Pine.PineParams;
 	type PineParamsFor<T> = Pine.PineParamsFor<T>;
 	type PineParamsWithIdFor<T> = Pine.PineParamsWithIdFor<T>;
+	type PineSelectableProps<T> = Pine.SelectableProps<T>;
+	type PineExpandableProps<T> = Pine.ExpandableProps<T>;
 
 	interface Interceptor {
 		request?(response: any): Promise<any>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -29,6 +29,13 @@ type InferAssociatedResourceType<T> = T extends (AssociatedResource & any[])
 	? T[number]
 	: never;
 
+export type SelectableProps<T> = Exclude<
+	StringKeyof<T>,
+	PropsOfType<T, ReverseNavigationResource>
+>;
+
+export type ExpandableProps<T> = PropsOfType<T, AssociatedResource>;
+
 // based on https://github.com/balena-io/pinejs-client-js/blob/master/core.d.ts
 
 type RawFilter =
@@ -195,13 +202,11 @@ type FilterExpressions<T> = {
 	$cast?: FilterFunctionValue<T>;
 };
 
-type BaseExpandFor<T> =
-	| {
-			[k in PropsOfType<T, AssociatedResource>]?: PineOptionsFor<
-				InferAssociatedResourceType<T[k]>
-			>;
-	  }
-	| StringKeyof<T>;
+type ResourceExpandFor<T> = {
+	[k in ExpandableProps<T>]?: PineOptionsFor<InferAssociatedResourceType<T[k]>>;
+};
+
+type BaseExpandFor<T> = ResourceExpandFor<T> | ExpandableProps<T>;
 
 export type Expand<T> = BaseExpandFor<T> | Array<BaseExpandFor<T>>;
 
@@ -220,7 +225,7 @@ export interface PineOptions extends ODataOptionsBase {
 }
 
 export interface PineOptionsFor<T> extends ODataOptionsBase {
-	$select?: Array<StringKeyof<T>> | StringKeyof<T> | '*';
+	$select?: Array<SelectableProps<T>> | SelectableProps<T> | '*';
 	$filter?: Filter<T>;
 	$expand?: Expand<T>;
 }


### PR DESCRIPTION
In case consumers are passing `string[]` `const`s in the `$select`, then this could break their build, (it does so in the UI).
As a result, I'm thinking that this might better be merged in the orgs branch (but don't have a super strong opinion on this). What do you think?

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
