### PR TITLE
Rename "currently online" to "online" for device lastOnline status

### DIFF
--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -2096,7 +2096,7 @@ getDeviceModel = (deps, opts) ->
 			return 'Connecting...'
 
 		if device.is_online
-			return "Currently online (for #{timeSince(lce, false)})"
+			return "Online (for #{timeSince(lce, false)})"
 
 		return timeSince(lce)
 

--- a/tests/integration/models/device.spec.coffee
+++ b/tests/integration/models/device.spec.coffee
@@ -1597,7 +1597,7 @@ describe 'Device Model', ->
 
 				m.chai.expect(
 					balena.models.device.lastOnline(mockDevice)
-				).to.equal('Currently online (for 5 minutes)')
+				).to.equal('Online (for 5 minutes)')
 
 			it 'should return the correct time string if the device is offline', ->
 				mockDevice =


### PR DESCRIPTION
This is done so it takes less space in the dashboard table. I guess this can be considered a breaking change, in that case I would be happy if we include this in https://github.com/balena-io/balena-sdk/pull/621.

Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
