### PR TITLE
Update balena-hup-action-utils to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "balena-auth": "^3.0.0",
     "balena-device-status": "^3.1.0",
     "balena-errors": "^4.0.0",
-    "balena-hup-action-utils": "~3.0.0",
+    "balena-hup-action-utils": "~4.0.0-allow-dev-updates-599603c2c6b0007f7a458e3a3cb1c54f3f188598",
     "balena-pine": "^9.0.0",
     "balena-register-device": "^6.0.0",
     "balena-request": "^10.0.0",

--- a/tests/integration/models/device.spec.coffee
+++ b/tests/integration/models/device.spec.coffee
@@ -1753,7 +1753,7 @@ describe 'Device Model', ->
 						target_os_version
 					)).to.throw('The device is offline')
 
-			it 'should throw when the device is running a dev version', ->
+			it 'should not throw when the device is running a dev version', ->
 				[
 					['Resin OS 2.0.0+rev3 (dev)', 'dev']
 					['Resin OS 2.0.0+rev3 (dev)', '']
@@ -1787,7 +1787,63 @@ describe 'Device Model', ->
 					m.chai.expect(-> balena.models.device._checkOsUpdateTarget(
 						mockDevice
 						'2.29.2+rev1.prod'
-					)).to.throw('Updates cannot be performed on development balenaOS variants')
+					)).to.not.throw()
+
+			it 'should not throw when the update target is a dev version', ->
+				[
+					['Resin OS 2.0.0+rev3 (dev)', 'dev']
+					['Resin OS 2.0.0+rev3 (dev)', '']
+					['Resin OS 2.0.0+rev5 (dev)', '']
+					['Resin OS 2.0.2+rev2', 'dev']
+					['Resin OS 2.0.3+rev1', 'dev']
+					['Resin OS 2.0.4+rev1', 'dev']
+					['Resin OS 2.0.5', 'dev']
+					['Resin OS 2.0.5+rev1', 'dev']
+					['Resin OS 2.0.6+rev1', 'dev']
+					['Resin OS 2.0.6+rev2', 'dev']
+					['Resin OS 2.1.0+rev1', 'dev']
+					['Resin OS 2.2.0+rev1', 'dev']
+					['Resin OS 2.9.7+rev1', 'dev']
+					['Resin OS 2.12.0+rev1', 'dev']
+					['Resin OS 2.12.1+rev1', 'dev']
+					['Resin OS 2.12.3', 'dev']
+					['Resin OS 2.12.3+rev1', 'dev']
+					['balenaOS 2.26.0', 'dev']
+					['balenaOS 2.26.0+rev1', 'dev']
+					['balenaOS 2.28.0+rev1', 'dev']
+					['Resin OS 2.0.0+rev3 (prod)', 'prod']
+					['Resin OS 2.0.0+rev3 (prod)', '']
+					['Resin OS 2.0.0+rev5 (prod)', '']
+					['Resin OS 2.0.2+rev2', 'prod']
+					['Resin OS 2.0.3+rev1', 'prod']
+					['Resin OS 2.0.4+rev1', 'prod']
+					['Resin OS 2.0.5', 'prod']
+					['Resin OS 2.0.5+rev1', 'prod']
+					['Resin OS 2.0.6+rev1', 'prod']
+					['Resin OS 2.0.6+rev2', 'prod']
+					['Resin OS 2.1.0+rev1', 'prod']
+					['Resin OS 2.2.0+rev1', 'prod']
+					['Resin OS 2.9.7+rev1', 'prod']
+					['Resin OS 2.12.0+rev1', 'prod']
+					['Resin OS 2.12.1+rev1', 'prod']
+					['Resin OS 2.12.3', 'prod']
+					['Resin OS 2.12.3+rev1', 'prod']
+					['balenaOS 2.26.0', 'prod']
+					['balenaOS 2.26.0+rev1', 'prod']
+					['balenaOS 2.28.0+rev1', 'prod']
+				].forEach ([os_version, os_variant]) ->
+					mockDevice = {
+						uuid
+						device_type: 'raspberrypi3'
+						is_online: true
+						os_version
+						os_variant
+					}
+
+					m.chai.expect(-> balena.models.device._checkOsUpdateTarget(
+						mockDevice
+						'2.29.2+rev1.dev'
+					)).to.not.throw()
 
 			it 'should throw when the device is running a pre-release version', ->
 				[


### PR DESCRIPTION
Update balena-hup-action-utils from 3.0.0 to 4.0.0

Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>
HQ: https://github.com/balena-io/balena/issues/1322

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
