### PR TITLE
Allow moving aarch64 devices to armv7hf applications

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -159,6 +159,7 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.getConfig(nameOrId, options)](#balena.models.os.getConfig) ⇒ <code>Promise</code>
             * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
             * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
+            * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
         * [.config](#balena.models.config) : <code>object</code>
             * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
             * [.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>
@@ -463,6 +464,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.getConfig(nameOrId, options)](#balena.models.os.getConfig) ⇒ <code>Promise</code>
         * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
         * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
+        * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
     * [.config](#balena.models.config) : <code>object</code>
         * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
         * [.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>
@@ -4273,6 +4275,7 @@ balena.models.key.create('Main', 'ssh-rsa AAAAB....', function(error, key) {
     * [.getConfig(nameOrId, options)](#balena.models.os.getConfig) ⇒ <code>Promise</code>
     * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
     * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
+    * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
 
 <a name="balena.models.os.getDownloadSize"></a>
 
@@ -4500,6 +4503,28 @@ balena.models.os.getSupportedOsUpdateVersions('raspberry-pi', '2.9.6+rev2.prod',
 	if (error) throw error;
 	console.log(isSupported);
 });
+```
+<a name="balena.models.os.isArchitectureCompatibleWith"></a>
+
+##### os.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture) ⇒ <code>Boolean</code>
+**Kind**: static method of [<code>os</code>](#balena.models.os)  
+**Summary**: Returns whether the specified OS architecture is compatible with the target architecture  
+**Returns**: <code>Boolean</code> - - Whether the specified OS architecture is capable of running
+applications build for the target architecture  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| osArchitecture | <code>String</code> | The OS's architecture as specified in its device type |
+| applicationArchitecture | <code>String</code> | The application's architecture as specified in its device type |
+
+**Example**  
+```js
+const result1 = balena.models.os.isArchitectureCompatibleWith('aarch64', 'armv7hf');
+console.log(result1);
+
+const result2 = balena.models.os.isArchitectureCompatibleWith('armv7hf', 'amd64');
+console.log(result2);
 ```
 <a name="balena.models.config"></a>
 

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -36,6 +36,7 @@ deviceStatus = require('balena-device-status')
 	getCurrentServiceDetailsPineOptions
 	getOsUpdateHelper: _getOsUpdateHelper
 	generateCurrentServiceDetails
+	deviceTypes: deviceTypesUtil
 	mergePineOptions
 	notFoundResponse
 	noDeviceForKeyResponse
@@ -873,10 +874,9 @@ getDeviceModel = (deps, opts) ->
 			deviceTypes: configModel().getDeviceTypes()
 			application: applicationModel().get(applicationNameOrId, $select: [ 'id', 'device_type' ])
 		.then ({ application, device, deviceTypes }) ->
-			deviceDeviceType = find(deviceTypes, { slug: device.device_type })
-			appDeviceType = find(deviceTypes, { slug: application.device_type })
-			isCompatibleMove = deviceDeviceType.arch is appDeviceType.arch and
-				(!!deviceDeviceType.isDependent is !!appDeviceType.isDependent)
+			osDeviceType = deviceTypesUtil.getBySlug(deviceTypes, device.device_type)
+			targetAppDeviceType = deviceTypesUtil.getBySlug(deviceTypes, application.device_type)
+			isCompatibleMove = deviceTypesUtil.isDeviceTypeCompatibleWith(osDeviceType, targetAppDeviceType)
 			if not isCompatibleMove
 				throw new errors.BalenaInvalidDeviceType("Incompatible application: #{applicationNameOrId}")
 

--- a/lib/typings/common-types.d.ts
+++ b/lib/typings/common-types.d.ts
@@ -37,6 +37,7 @@ interface DeviceTypeOptions {
 type DeviceType = {
 	slug: string;
 	name: string;
+	arch: string;
 	aliases: string[];
 
 	isDependent?: boolean;

--- a/tests/integration/models/device.spec.coffee
+++ b/tests/integration/models/device.spec.coffee
@@ -1565,6 +1565,48 @@ describe 'Device Model', ->
 				promise = balena.models.device.move(@deviceInfo.uuid, @application2.app_name)
 				m.chai.expect(promise).to.be.rejectedWith("Incompatible application: #{@application2.app_name}")
 
+	describe 'given an armv7hf and an aarch64 application with a device on each', ->
+
+		before ->
+			Promise.props
+				application1: balena.models.application.create
+					name: 'FooBar32'
+					applicationType: 'microservices-starter'
+					deviceType: 'raspberrypi3'
+				application2: balena.models.application.create
+					name: 'BarBaz64'
+					applicationType: 'microservices-starter'
+					deviceType: 'raspberrypi3-64'
+			.then (apps) =>
+				@application1 = apps.application1
+				@application2 = apps.application2
+
+				Promise.all([
+					balena.models.device.register(@application1.id, balena.models.device.generateUniqueKey())
+					balena.models.device.register(@application2.id, balena.models.device.generateUniqueKey())
+				])
+			.then ([device1Info, device2Info]) =>
+				@device1Info = device1Info
+				@device2Info = device2Info
+
+		after ->
+			Promise.map [
+				@application1.id
+				@application2.id
+			], balena.models.application.remove
+
+		describe 'balena.models.device.move()', ->
+
+			it 'should be rejected with an incompatibility error when trying to move an armv7hf device to an aarch64 application', ->
+				promise = balena.models.device.move(@device1Info.uuid, @application2.app_name)
+				m.chai.expect(promise).to.be.rejectedWith("Incompatible application: #{@application2.app_name}")
+
+			it 'should be able to move an aarch64 device to an armv7hf application', ->
+				balena.models.device.move(@device2Info.id, @application1.id).then =>
+					balena.models.device.getApplicationName(@device2Info.id)
+				.then (applicationName) =>
+					m.chai.expect(applicationName).to.equal(@application1.app_name)
+
 	describe 'helpers', ->
 
 		describe 'balena.models.device.getDashboardUrl()', ->

--- a/tests/integration/models/os.spec.coffee
+++ b/tests/integration/models/os.spec.coffee
@@ -438,3 +438,44 @@ describe 'OS model', ->
 			it 'should be rejected if the application name does not exist', ->
 				promise = balena.models.os.getConfig('foobarbaz', { version: DEFAULT_OS_VERSION })
 				m.chai.expect(promise).to.be.rejectedWith('Application not found: foobarbaz')
+
+	describe 'helpers', ->
+
+		describe 'balena.models.os.isArchitectureCompatibleWith()', ->
+
+			it 'should return false when comparing arm and i386 architectures', ->
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('armv7hf', 'i386')).to.equal(false)
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('aarch64', 'i386')).to.equal(false)
+
+			it 'should return false when comparing i386 and arm architectures', ->
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('i386', 'armv7hf')).to.equal(false)
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('i386', 'aarch64')).to.equal(false)
+
+			it 'should return false when comparing arm and amd64 architectures', ->
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('armv7hf', 'amd64')).to.equal(false)
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('aarch64', 'amd64')).to.equal(false)
+
+			it 'should return false when comparing amd64 and arm architectures', ->
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('amd64', 'armv7hf')).to.equal(false)
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('amd64', 'aarch64')).to.equal(false)
+
+			it 'should return true when comparing the same architecture slugs', ->
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('rpi', 'rpi')).to.equal(true)
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('armv5e', 'armv5e')).to.equal(true)
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('armv7hf', 'armv7hf')).to.equal(true)
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('aarch64', 'aarch64')).to.equal(true)
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('i386', 'i386')).to.equal(true)
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('i386-nlp', 'i386-nlp')).to.equal(true)
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('amd64', 'amd64')).to.equal(true)
+
+			it 'should return true when comparing aarch64 and armv7hf architectures', ->
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('aarch64', 'armv7hf')).to.equal(true)
+
+			it 'should return false when comparing armv7hf and aarch64 architectures', ->
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('armv7hf', 'aarch64')).to.equal(false)
+
+			it 'should return false when comparing amd64 and i386 architectures', ->
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('amd64', 'i386')).to.equal(false)
+
+			it 'should return false when comparing i386 and amd64 architectures', ->
+				m.chai.expect(balena.models.os.isArchitectureCompatibleWith('i386', 'amd64')).to.equal(false)

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -1155,6 +1155,10 @@ declare namespace BalenaSdk {
 					deviceType: string,
 					currentVersion: string,
 				): Promise<OsUpdateVersions>;
+				isArchitectureCompatibleWith(
+					osArchitecture: string,
+					applicationArchitecture: string,
+				): boolean;
 			};
 		};
 


### PR DESCRIPTION
Also adds an `os.isArchitectureCompatibleWith()` method so that consumers can rely on the SDK instead of repeating this logic.

Resolves: #727
See: https://www.flowdock.com/app/rulemotion/r-beginners/threads/A4a3CALEDol4WIUXZZIlv-ZD3v0
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [x] Includes updated documentation
- [ ] Includes updated build output
