### PR TITLE
typings: Fix return type of device.getDisplayName(), device.getDeviceSlug() & os.getMaxSatisfyingVersion()

### DIFF
--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -1143,7 +1143,7 @@ declare namespace BalenaSdk {
 				getMaxSatisfyingVersion(
 					deviceType: string,
 					versionOrRange: string,
-				): string;
+				): Promise<string>;
 				getLastModified(deviceType: string, version?: string): Promise<Date>;
 				download(deviceType: string, version?: string): Promise<Readable>;
 				isSupportedOsUpdate(

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -977,8 +977,8 @@ declare namespace BalenaSdk {
 				getSupervisorTargetState(
 					uuidOrId: string | number,
 				): Promise<DeviceState.DeviceState>;
-				getDisplayName(deviceTypeName: string): string;
-				getDeviceSlug(deviceTypeName: string): string;
+				getDisplayName(deviceTypeName: string): Promise<string>;
+				getDeviceSlug(deviceTypeName: string): Promise<string>;
 				generateUniqueKey(): string;
 				register(
 					applicationNameOrId: string | number,


### PR DESCRIPTION
I've tracked this back to the original commit that the
typings for these methods were added and I can only
hypothesize that they got in wrong by accident.

Change-type: patch
See: https://github.com/balena-io/balena-sdk/commit/1f74411f8e8939c2782298c4b110a61fcec5505a
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
