### PR TITLE
Revert "tests/logs.spec: Increase the delay of logs.subscribe()"

### DIFF
--- a/tests/integration/logs.spec.coffee
+++ b/tests/integration/logs.spec.coffee
@@ -89,7 +89,7 @@ describe 'Logs', ->
 						logs.on('line', (line) -> lines.push(line))
 						logs.on('error', reject)
 
-						Promise.delay(10000)
+						Promise.delay(2000)
 						.then ->
 							resolve(lines)
 					.finally(logs.unsubscribe)
@@ -112,7 +112,7 @@ describe 'Logs', ->
 						logs.on('line', (line) -> lines.push(line))
 						logs.on('error', reject)
 
-						Promise.delay(10000)
+						Promise.delay(2000)
 						.then ->
 							resolve(lines)
 					.finally(logs.unsubscribe)
@@ -140,7 +140,7 @@ describe 'Logs', ->
 						logs.on('line', (line) -> lines.push(line))
 						logs.on('error', reject)
 
-						Promise.delay(10000)
+						Promise.delay(2000)
 						.then ->
 							resolve(lines)
 					.finally(logs.unsubscribe)
@@ -169,7 +169,7 @@ describe 'Logs', ->
 								message: 'New message',
 								timestamp: Date.now()
 							}]
-							.delay(10000)
+							.delay(2000)
 							.then ->
 								resolve(lines)
 							.catch(reject)


### PR DESCRIPTION
This reverts commit 8b6b8be9fa49c9bfae032549617dd0d302ec734e which was added in attempt to make the log related tests more stable. It doesn't look like it's needed any more.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
