### PR TITLE
Drop promise-memoize in favor of memoizee

### DIFF
--- a/lib/models/os.coffee
+++ b/lib/models/os.coffee
@@ -26,7 +26,7 @@ partition = require('lodash/partition')
 reject = require('lodash/reject')
 bSemver = require('balena-semver')
 semver = require('semver')
-promiseMemoize = require('promise-memoize')
+memoizee = require('memoizee')
 
 {
 	onlyIf
@@ -50,7 +50,12 @@ getOsModel = (deps, opts) ->
 	applicationModel = once -> require('./application')(deps, opts)
 
 	withDeviceTypesEndpointCaching = (fn) ->
-		memoizedFn = promiseMemoize(fn, { maxAge: DEVICE_TYPES_ENDPOINT_CACHING_INTERVAL })
+		memoizedFn = memoizee(fn, {
+			maxAge: DEVICE_TYPES_ENDPOINT_CACHING_INTERVAL
+			primitive: true
+			promise: true
+		})
+
 		pubsub.subscribe 'auth.keyChange', ->
 			memoizedFn.clear()
 

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "memoizee": "^0.4.9",
     "moment": "^2.18.1",
     "ndjson": "^1.5.0",
-    "promise-memoize": "^1.2.0",
     "semver": "^5.3.0"
   }
 }


### PR DESCRIPTION
- [ ] That's on top of #752, so let's get that in first.

We already use memoizee in some `util` functions, and we also prefer it in several other balena components. Since memoizee also supports promises,  we can drop promise-memoize to both reduce dist size and have more uniform code, both within the SDK and across all other balena modules as well.

Resolves: #751
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
