### PR TITLE
typings: Unify the PineParams & PineOptions to a single generic type w/o the For suffix

### DIFF
--- a/lib/models/api-key.ts
+++ b/lib/models/api-key.ts
@@ -112,7 +112,7 @@ const getApiKeysModel = function(
 	 * });
 	 */
 	exports.getAll = function(
-		options: BalenaSdk.PineOptionsFor<BalenaSdk.ApiKey> = {},
+		options: BalenaSdk.PineOptions<BalenaSdk.ApiKey> = {},
 		callback?: (error?: Error, apiKeys?: BalenaSdk.ApiKey[]) => void,
 	): Promise<BalenaSdk.ApiKey[]> {
 		callback = findCallback(arguments);

--- a/lib/util/device-service-details.ts
+++ b/lib/util/device-service-details.ts
@@ -7,14 +7,14 @@ import {
 	GatewayDownload,
 	Image,
 	ImageInstall,
-	PineOptionsFor,
+	PineOptions,
 	Release,
 	Service,
 } from '../../typings/balena-sdk';
 
 // Pine options necessary for getting raw service data for a device
 export const getCurrentServiceDetailsPineOptions = (expandRelease: boolean) => {
-	const pineOptions: PineOptionsFor<DeviceWithImageInstalls> = {
+	const pineOptions: PineOptions<DeviceWithImageInstalls> = {
 		$expand: {
 			image_install: {
 				$select: ['id', 'download_progress', 'status', 'install_date'],

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -124,9 +124,9 @@ export const isDevelopmentVersion = (version: string) =>
 //   * And $selects within expands override
 // * Any unknown 'extra' options throw an error. Unknown 'default' options are ignored.
 export const mergePineOptions = <R extends {}>(
-	defaults: Pine.PineOptions<R>,
-	extras: Pine.PineOptions<R>,
-): Pine.PineOptions<R> => {
+	defaults: Pine.ODataOptions<R>,
+	extras: Pine.ODataOptions<R>,
+): Pine.ODataOptions<R> => {
 	if (!extras) {
 		return defaults;
 	}

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -124,9 +124,9 @@ export const isDevelopmentVersion = (version: string) =>
 //   * And $selects within expands override
 // * Any unknown 'extra' options throw an error. Unknown 'default' options are ignored.
 export const mergePineOptions = <R extends {}>(
-	defaults: Pine.PineOptionsFor<R>,
-	extras: Pine.PineOptionsFor<R>,
-): Pine.PineOptionsFor<R> => {
+	defaults: Pine.PineOptions<R>,
+	extras: Pine.PineOptions<R>,
+): Pine.PineOptions<R> => {
 	if (!extras) {
 		return defaults;
 	}
@@ -228,13 +228,13 @@ const mergeExpandOptions = <T>(
 // containing (at most) $expand, $filter and $select keys
 const convertExpandToObject = <T extends {}>(
 	expandOption: Pine.Expand<T> | undefined,
-): Pine.ResourceExpandFor<T> => {
+): Pine.ResourceExpand<T> => {
 	if (expandOption == null) {
 		return {};
 	} else if (isString(expandOption)) {
 		return {
 			[expandOption]: {},
-		} as Pine.ResourceExpandFor<T>;
+		} as Pine.ResourceExpand<T>;
 	} else if (isArray(expandOption)) {
 		// Reduce the array into a single object
 		return expandOption.reduce(
@@ -245,7 +245,7 @@ const convertExpandToObject = <T extends {}>(
 	} else {
 		// Check the options in this object are the ones we know how to merge
 		for (const expandKey of Object.keys(expandOption) as Array<
-			keyof Pine.ResourceExpandFor<T>
+			keyof Pine.ResourceExpand<T>
 		>) {
 			const expandRelationshipOptions = expandOption[expandKey];
 

--- a/typing_tests/pine-options.ts
+++ b/typing_tests/pine-options.ts
@@ -6,15 +6,15 @@ import { AnyObject } from '../typings/utils';
 // This file is in .prettierignore, since otherwise
 // the $ExpectError commentswould move to the wrong place
 
-export const unkown$selectProps: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$selectProps: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$select: ['asdf', 'id', 'app_name', 'id'], // $ExpectError
 };
 
-export const unkown$selectPropsFixed: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$selectPropsFixed: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$select: ['id', 'app_name'],
 };
 
-export const unkown$selectPropsInside$expand: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$selectPropsInside$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: { // $ExpectError
 		owns__device: {
 			$select: ['asdf', 'note', 'device_name', 'uuid'],
@@ -22,7 +22,7 @@ export const unkown$selectPropsInside$expand: BalenaSdk.PineOptionsFor<BalenaSdk
 	},
 };
 
-export const unkown$expandProps: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$expandProps: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: {
 		asdf: {}, // $ExpectError
 		owns__device: {
@@ -31,7 +31,7 @@ export const unkown$expandProps: BalenaSdk.PineOptionsFor<BalenaSdk.Application>
 	},
 };
 
-export const unkownODataPropInside$expand: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkownODataPropInside$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: {
 		owns__device: {
 			asdf: {}, // $ExpectError
@@ -40,7 +40,7 @@ export const unkownODataPropInside$expand: BalenaSdk.PineOptionsFor<BalenaSdk.Ap
 	},
 };
 
-export const unkown$expandPropsFixed: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$expandPropsFixed: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: {
 		owns__device: {
 			$select: ['note', 'device_name', 'uuid'],
@@ -48,7 +48,7 @@ export const unkown$expandPropsFixed: BalenaSdk.PineOptionsFor<BalenaSdk.Applica
 	},
 };
 
-export const unkown$selectPropInsideNested$expandWith$select: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$selectPropInsideNested$expandWith$select: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: {
 		owns__device: {
 			$expand: {
@@ -63,7 +63,7 @@ export const unkown$selectPropInsideNested$expandWith$select: BalenaSdk.PineOpti
 	},
 };
 
-export const unkown$selectPropInsideNested$expandWith$select2: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$selectPropInsideNested$expandWith$select2: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: { // $ExpectError
 		owns__device: {
 			$select: ['note', 'device_name', 'uuid'],
@@ -76,7 +76,7 @@ export const unkown$selectPropInsideNested$expandWith$select2: BalenaSdk.PineOpt
 	},
 };
 
-export const unkown$selectPropInsideNested$expandWith$select2Fixed: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$selectPropInsideNested$expandWith$select2Fixed: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: {
 		owns__device: {
 			$select: ['note', 'device_name', 'uuid'],
@@ -89,7 +89,7 @@ export const unkown$selectPropInsideNested$expandWith$select2Fixed: BalenaSdk.Pi
 	},
 };
 
-export const unkown$expandPropInArray$expands: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$expandPropInArray$expands: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
@@ -106,7 +106,7 @@ export const unkown$expandPropInArray$expands: BalenaSdk.PineOptionsFor<BalenaSd
 	],
 };
 
-export const unkownODataPropInArray$expand: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkownODataPropInArray$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: [
 		{
 			owns__device: {
@@ -123,7 +123,7 @@ export const unkownODataPropInArray$expand: BalenaSdk.PineOptionsFor<BalenaSdk.A
 	],
 };
 
-export const unkown$selectPropInArray$expand: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$selectPropInArray$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
@@ -139,7 +139,7 @@ export const unkown$selectPropInArray$expand: BalenaSdk.PineOptionsFor<BalenaSdk
 	],
 };
 
-export const unkownNested$expandPropInsideArray$expand: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkownNested$expandPropInsideArray$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: [
 		{
 			owns__device: {
@@ -156,7 +156,7 @@ export const unkownNested$expandPropInsideArray$expand: BalenaSdk.PineOptionsFor
 	],
 };
 
-export const unkownNested$expandWith$selectPropInsideArray$expand: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkownNested$expandWith$selectPropInsideArray$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: [
 		{
 			owns__device: {
@@ -175,7 +175,7 @@ export const unkownNested$expandWith$selectPropInsideArray$expand: BalenaSdk.Pin
 	],
 };
 
-export const unkown$selectPropInsideNestedArray$expand: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const unkown$selectPropInsideNestedArray$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
@@ -191,7 +191,7 @@ export const unkown$selectPropInsideNestedArray$expand: BalenaSdk.PineOptionsFor
 	],
 };
 
-export const nestedArray$expandWithManyErrors1: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const nestedArray$expandWithManyErrors1: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
@@ -210,7 +210,7 @@ export const nestedArray$expandWithManyErrors1: BalenaSdk.PineOptionsFor<BalenaS
 	],
 };
 
-export const nestedArray$expandWithManyErrors2: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const nestedArray$expandWithManyErrors2: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
@@ -229,7 +229,7 @@ export const nestedArray$expandWithManyErrors2: BalenaSdk.PineOptionsFor<BalenaS
 	],
 };
 
-export const Nested$expandInArray$expandsFixed: BalenaSdk.PineOptionsFor<BalenaSdk.Application> = {
+export const Nested$expandInArray$expandsFixed: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: [
 		{
 			owns__device: {
@@ -253,7 +253,7 @@ export const Nested$expandInArray$expandsFixed: BalenaSdk.PineOptionsFor<BalenaS
 
 
 // invalid filters
-export const invalid$filterPropType: BalenaSdk.PineOptionsFor<
+export const invalid$filterPropType: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$filter: { // $ExpectError
@@ -261,7 +261,7 @@ export const invalid$filterPropType: BalenaSdk.PineOptionsFor<
 	},
 };
 
-export const invalid$filterPropType2: BalenaSdk.PineOptionsFor<
+export const invalid$filterPropType2: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$filter: { // $ExpectError
@@ -269,7 +269,7 @@ export const invalid$filterPropType2: BalenaSdk.PineOptionsFor<
 	},
 };
 
-export const invalid$filterOfReverseNavigationProp: BalenaSdk.PineOptionsFor<
+export const invalid$filterOfReverseNavigationProp: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$filter: {
@@ -280,7 +280,7 @@ export const invalid$filterOfReverseNavigationProp: BalenaSdk.PineOptionsFor<
 	},
 };
 
-export const unkownPropIn$filter: BalenaSdk.PineOptionsFor<
+export const unkownPropIn$filter: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$filter: {
@@ -292,7 +292,7 @@ export const unkownPropIn$filter: BalenaSdk.PineOptionsFor<
 	},
 };
 
-export const unkownPropIn$filterFixed: BalenaSdk.PineOptionsFor<
+export const unkownPropIn$filterFixed: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$filter: {
@@ -303,7 +303,7 @@ export const unkownPropIn$filterFixed: BalenaSdk.PineOptionsFor<
 	},
 };
 
-export const unknown$any$filterPropInsideArray$expand: BalenaSdk.PineOptionsFor<
+export const unknown$any$filterPropInsideArray$expand: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: [ // $ExpectError
@@ -329,7 +329,7 @@ export const unknown$any$filterPropInsideArray$expand: BalenaSdk.PineOptionsFor<
 	],
 };
 
-export const unknown$any$filterPropInsideArray$expandPlural: BalenaSdk.PineOptionsFor<
+export const unknown$any$filterPropInsideArray$expandPlural: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: [
@@ -358,7 +358,7 @@ export const unknown$any$filterPropInsideArray$expandPlural: BalenaSdk.PineOptio
 	],
 };
 
-export const unknown$any$filterPropInsideArray$expandFixed: BalenaSdk.PineOptionsFor<
+export const unknown$any$filterPropInsideArray$expandFixed: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: [
@@ -384,7 +384,7 @@ export const unknown$any$filterPropInsideArray$expandFixed: BalenaSdk.PineOption
 	],
 };
 
-export const unknown$filterPropInsideNested$expand: BalenaSdk.PineOptionsFor<
+export const unknown$filterPropInsideNested$expand: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: [
@@ -421,7 +421,7 @@ export const unknown$filterPropInsideNested$expand: BalenaSdk.PineOptionsFor<
 
 // this check that even though the unknown$any$filterPropInsideArray$expandPlural case doesn't work
 // it will at least not silence other errors
-export const unknown$filterPropInsideNested$expandWithUnknown$any$filterProp: BalenaSdk.PineOptionsFor<
+export const unknown$filterPropInsideNested$expandWithUnknown$any$filterProp: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: [
@@ -461,13 +461,13 @@ export const unknown$filterPropInsideNested$expandWithUnknown$any$filterProp: Ba
 
 // valid selects
 
-export const appOptionsEValid1: BalenaSdk.PineOptionsFor<
+export const appOptionsEValid1: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$select: ['app_name'],
 };
 
-export const deviceOptionsEValid2: BalenaSdk.PineOptionsFor<
+export const deviceOptionsEValid2: BalenaSdk.PineOptions<
 	BalenaSdk.Device
 > = {
 	$select: ['note', 'device_name', 'uuid'],
@@ -475,7 +475,7 @@ export const deviceOptionsEValid2: BalenaSdk.PineOptionsFor<
 
 // valid expands
 
-export const appOptionsEValid2: BalenaSdk.PineOptionsFor<
+export const appOptionsEValid2: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: {
@@ -485,7 +485,7 @@ export const appOptionsEValid2: BalenaSdk.PineOptionsFor<
 	},
 };
 
-export const appOptionsEValid4: BalenaSdk.PineOptionsFor<
+export const appOptionsEValid4: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: {
@@ -499,7 +499,7 @@ export const appOptionsEValid4: BalenaSdk.PineOptionsFor<
 	},
 };
 
-export const appOptionsEValid5: BalenaSdk.PineOptionsFor<
+export const appOptionsEValid5: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: {
@@ -514,7 +514,7 @@ export const appOptionsEValid5: BalenaSdk.PineOptionsFor<
 	},
 };
 
-export const appOptionsEValid20: BalenaSdk.PineOptionsFor<
+export const appOptionsEValid20: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: [
@@ -539,7 +539,7 @@ export type ReleaseExpandableProps = BalenaSdk.PineExpandableProps<BalenaSdk.Rel
 // $ExpectType Release
 export type DeviceIsRunningReleaseAssociatedResourceType = InferAssociatedResourceType<BalenaSdk.Device['is_running__release']>;
 
-export const appOptionsEValid30: BalenaSdk.PineOptionsFor<
+export const appOptionsEValid30: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: [
@@ -557,7 +557,7 @@ export const appOptionsEValid30: BalenaSdk.PineOptionsFor<
 	],
 };
 
-export const appOptionsEValid31: BalenaSdk.PineOptionsFor<
+export const appOptionsEValid31: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: [
@@ -581,7 +581,7 @@ export const appOptionsEValid31: BalenaSdk.PineOptionsFor<
 
 // valid filters
 
-export const appOptionsEValidf1: BalenaSdk.PineOptionsFor<
+export const appOptionsEValidf1: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$filter: {
@@ -591,7 +591,7 @@ export const appOptionsEValidf1: BalenaSdk.PineOptionsFor<
 	},
 };
 
-export const appOptionsEValidf2: BalenaSdk.PineOptionsFor<
+export const appOptionsEValidf2: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$filter: {
@@ -638,7 +638,7 @@ export const appOptionsEValidf2: BalenaSdk.PineOptionsFor<
 	},
 };
 
-export const appOptionsEFValid1: BalenaSdk.PineOptionsFor<
+export const appOptionsEFValid1: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
 	$expand: [
@@ -672,7 +672,7 @@ export const appOptionsEFValid1: BalenaSdk.PineOptionsFor<
 	],
 };
 
-export const anyObjectOptionsValid1: BalenaSdk.PineOptionsFor<
+export const anyObjectOptionsValid1: BalenaSdk.PineOptions<
 	AnyObject
 > = {
 	$select: ['id', 'app_name'],

--- a/typing_tests/pine-options.ts
+++ b/typing_tests/pine-options.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 import * as BalenaSdk from '../typings/balena-sdk';
 import { InferAssociatedResourceType } from '../typings/pinejs-client-core';
+import { AnyObject } from '../typings/utils';
 
 // This file is in .prettierignore, since otherwise
 // the $ExpectError commentswould move to the wrong place
@@ -669,4 +670,59 @@ export const appOptionsEFValid1: BalenaSdk.PineOptionsFor<
 		},
 		'depends_on__application',
 	],
+};
+
+export const anyObjectOptionsValid1: BalenaSdk.PineOptionsFor<
+	AnyObject
+> = {
+	$select: ['id', 'app_name'],
+	$expand: {
+		owns__device: {
+			$filter: {
+				device_name: null,
+				note: 'note',
+				device_environment_variable: {
+					$any: {
+						$alias: 'dev',
+						$expr: {
+							dev: {
+								name: 'name',
+							},
+						},
+					},
+				},
+			},
+			$expand: {
+				device_environment_variable: {
+					$filter: {
+						name: 'name',
+						value: null,
+					},
+				},
+			},
+		},
+	},
+	$filter: {
+		app_name: 'test',
+		application_type: {
+			$any: {
+				$alias: 'o',
+				$expr: {
+					o: {
+						name: 'test',
+					},
+				},
+			},
+		},
+		owns__device: {
+			$any: {
+				$alias: 'd',
+				$expr: {
+					d: {
+						device_name: 'test',
+					},
+				},
+			},
+		},
+	},
 };

--- a/typings/balena-pine.d.ts
+++ b/typings/balena-pine.d.ts
@@ -5,16 +5,16 @@ import * as PineClient from './pinejs-client-core';
 declare namespace BalenaPine {
 	interface Pine {
 		delete<T>(
-			params: PineClient.PineParamsWithIdFor<T> | PineClient.PineParamsFor<T>,
+			params: PineClient.PineParamsWithId<T> | PineClient.PineParams<T>,
 		): Promise<'OK'>;
-		get<T>(params: PineClient.PineParamsWithIdFor<T>): Promise<T>;
-		get<T>(params: PineClient.PineParamsFor<T>): Promise<T[]>;
-		get<T, Result>(params: PineClient.PineParamsFor<T>): Promise<Result>;
-		post<T>(params: PineClient.PineParamsFor<T>): Promise<T>;
+		get<T>(params: PineClient.PineParamsWithId<T>): Promise<T>;
+		get<T>(params: PineClient.PineParams<T>): Promise<T[]>;
+		get<T, Result>(params: PineClient.PineParams<T>): Promise<Result>;
+		post<T>(params: PineClient.PineParams<T>): Promise<T>;
 		patch<T>(
-			params: PineClient.PineParamsWithIdFor<T> | PineClient.PineParamsFor<T>,
+			params: PineClient.PineParamsWithId<T> | PineClient.PineParams<T>,
 		): Promise<'OK'>;
-		upsert<T>(params: PineClient.UpsertPineParamsFor<T>): Promise<T | 'OK'>;
+		upsert<T>(params: PineClient.UpsertPineParams<T>): Promise<T | 'OK'>;
 	}
 }
 

--- a/typings/balena-pine.d.ts
+++ b/typings/balena-pine.d.ts
@@ -5,16 +5,16 @@ import * as PineClient from './pinejs-client-core';
 declare namespace BalenaPine {
 	interface Pine {
 		delete<T>(
-			params: PineClient.PineParamsWithId<T> | PineClient.PineParams<T>,
+			params: PineClient.ParamsObjWithId<T> | PineClient.ParamsObj<T>,
 		): Promise<'OK'>;
-		get<T>(params: PineClient.PineParamsWithId<T>): Promise<T>;
-		get<T>(params: PineClient.PineParams<T>): Promise<T[]>;
-		get<T, Result>(params: PineClient.PineParams<T>): Promise<Result>;
-		post<T>(params: PineClient.PineParams<T>): Promise<T>;
+		get<T>(params: PineClient.ParamsObjWithId<T>): Promise<T>;
+		get<T>(params: PineClient.ParamsObj<T>): Promise<T[]>;
+		get<T, Result>(params: PineClient.ParamsObj<T>): Promise<Result>;
+		post<T>(params: PineClient.ParamsObj<T>): Promise<T>;
 		patch<T>(
-			params: PineClient.PineParamsWithId<T> | PineClient.PineParams<T>,
+			params: PineClient.ParamsObjWithId<T> | PineClient.ParamsObj<T>,
 		): Promise<'OK'>;
-		upsert<T>(params: PineClient.UpsertPineParams<T>): Promise<T | 'OK'>;
+		upsert<T>(params: PineClient.UpsertParams<T>): Promise<T | 'OK'>;
 	}
 }
 

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -30,10 +30,10 @@ declare namespace BalenaSdk {
 	>;
 	type PineFilterFor<T> = Pine.Filter<T>;
 	type PineExpandFor<T> = Pine.Expand<T>;
-	type PineOptions = Pine.PineOptions;
+	type PineOptions<T> = Pine.PineOptionsFor<T>;
 	type PineOptionsFor<T> = Pine.PineOptionsFor<T>;
 	type PineSubmitBody<T> = Pine.SubmitBody<T>;
-	type PineParams = Pine.PineParams;
+	type PineParams<T> = Pine.PineParamsFor<T>;
 	type PineParamsFor<T> = Pine.PineParamsFor<T>;
 	type PineParamsWithIdFor<T> = Pine.PineParamsWithIdFor<T>;
 	type PineSelectableProps<T> = Pine.SelectableProps<T>;

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -30,10 +30,10 @@ declare namespace BalenaSdk {
 	>;
 	type PineFilter<T> = Pine.Filter<T>;
 	type PineExpand<T> = Pine.Expand<T>;
-	type PineOptions<T> = Pine.PineOptions<T>;
+	type PineOptions<T> = Pine.ODataOptions<T>;
 	type PineSubmitBody<T> = Pine.SubmitBody<T>;
-	type PineParams<T> = Pine.PineParams<T>;
-	type PineParamsWithId<T> = Pine.PineParamsWithId<T>;
+	type PineParams<T> = Pine.ParamsObj<T>;
+	type PineParamsWithId<T> = Pine.ParamsObjWithId<T>;
 	type PineSelectableProps<T> = Pine.SelectableProps<T>;
 	type PineExpandableProps<T> = Pine.ExpandableProps<T>;
 

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -28,14 +28,12 @@ declare namespace BalenaSdk {
 	type ReverseNavigationResource<T = WithId> = Pine.ReverseNavigationResource<
 		T
 	>;
-	type PineFilterFor<T> = Pine.Filter<T>;
-	type PineExpandFor<T> = Pine.Expand<T>;
-	type PineOptions<T> = Pine.PineOptionsFor<T>;
-	type PineOptionsFor<T> = Pine.PineOptionsFor<T>;
+	type PineFilter<T> = Pine.Filter<T>;
+	type PineExpand<T> = Pine.Expand<T>;
+	type PineOptions<T> = Pine.PineOptions<T>;
 	type PineSubmitBody<T> = Pine.SubmitBody<T>;
-	type PineParams<T> = Pine.PineParamsFor<T>;
-	type PineParamsFor<T> = Pine.PineParamsFor<T>;
-	type PineParamsWithIdFor<T> = Pine.PineParamsWithIdFor<T>;
+	type PineParams<T> = Pine.PineParams<T>;
+	type PineParamsWithId<T> = Pine.PineParamsWithId<T>;
 	type PineSelectableProps<T> = Pine.SelectableProps<T>;
 	type PineExpandableProps<T> = Pine.ExpandableProps<T>;
 
@@ -870,11 +868,11 @@ declare namespace BalenaSdk {
 				}): Promise<Application>;
 				get(
 					nameOrId: string | number,
-					options?: PineOptionsFor<Application>,
+					options?: PineOptions<Application>,
 				): Promise<Application>;
 				getWithDeviceServiceDetails(
 					nameOrId: string | number,
-					options?: PineOptionsFor<Application>,
+					options?: PineOptions<Application>,
 				): Promise<
 					Application & {
 						owns__device: Array<DeviceWithServiceDetails<CurrentService>>;
@@ -883,11 +881,11 @@ declare namespace BalenaSdk {
 				getAppByOwner(
 					appName: string,
 					owner: string,
-					options?: PineOptionsFor<Application>,
+					options?: PineOptions<Application>,
 				): Promise<Application>;
-				getAll(options?: PineOptionsFor<Application>): Promise<Application[]>;
+				getAll(options?: PineOptions<Application>): Promise<Application[]>;
 				getAllWithDeviceServiceDetails(
-					options?: PineOptionsFor<Application>,
+					options?: PineOptions<Application>,
 				): Promise<
 					Array<
 						Application & {
@@ -922,10 +920,10 @@ declare namespace BalenaSdk {
 				tags: {
 					getAllByApplication(
 						nameOrId: string | number,
-						options?: PineOptionsFor<ApplicationTag>,
+						options?: PineOptions<ApplicationTag>,
 					): Promise<ApplicationTag[]>;
 					getAll(
-						options?: PineOptionsFor<ApplicationTag>,
+						options?: PineOptions<ApplicationTag>,
 					): Promise<ApplicationTag[]>;
 					set(
 						nameOrId: string | number,
@@ -937,7 +935,7 @@ declare namespace BalenaSdk {
 				configVar: {
 					getAllByApplication(
 						nameOrId: string | number,
-						options?: PineOptionsFor<ApplicationVariable>,
+						options?: PineOptions<ApplicationVariable>,
 					): Promise<ApplicationVariable[]>;
 					set(
 						nameOrId: string | number,
@@ -953,7 +951,7 @@ declare namespace BalenaSdk {
 				envVar: {
 					getAllByApplication(
 						nameOrId: string | number,
-						options?: PineOptionsFor<ApplicationVariable>,
+						options?: PineOptions<ApplicationVariable>,
 					): Promise<ApplicationVariable[]>;
 					set(
 						nameOrId: string | number,
@@ -969,7 +967,7 @@ declare namespace BalenaSdk {
 			};
 			apiKey: {
 				create: (name: string, description?: string | null) => Promise<string>;
-				getAll: (options?: PineOptionsFor<ApiKey>) => Promise<ApiKey[]>;
+				getAll: (options?: PineOptions<ApiKey>) => Promise<ApiKey[]>;
 				update: (
 					id: number,
 					apiKeyInfo: { name?: string; description?: string | null },
@@ -979,21 +977,21 @@ declare namespace BalenaSdk {
 			release: {
 				get(
 					commitOrId: string | number,
-					options?: PineOptionsFor<Release>,
+					options?: PineOptions<Release>,
 				): Promise<Release>;
 				getAllByApplication(
 					nameOrId: string | number,
-					options?: PineOptionsFor<Release>,
+					options?: PineOptions<Release>,
 				): Promise<Release[]>;
 				getLatestByApplication(
 					nameOrId: string | number,
-					options?: PineOptionsFor<Release>,
+					options?: PineOptions<Release>,
 				): Promise<Release>;
 				getWithImageDetails(
 					commitOrId: string | number,
 					options?: {
-						release?: PineOptionsFor<Release>;
-						image?: PineOptionsFor<Image>;
+						release?: PineOptions<Release>;
+						image?: PineOptions<Image>;
 					},
 				): Promise<
 					Array<
@@ -1013,13 +1011,13 @@ declare namespace BalenaSdk {
 				tags: {
 					getAllByApplication(
 						nameOrId: string | number,
-						options?: PineOptionsFor<ReleaseTag>,
+						options?: PineOptions<ReleaseTag>,
 					): Promise<ReleaseTag[]>;
 					getAllByRelease(
 						commitOrId: string | number,
-						options?: PineOptionsFor<ReleaseTag>,
+						options?: PineOptions<ReleaseTag>,
 					): Promise<ReleaseTag[]>;
-					getAll(options?: PineOptionsFor<ReleaseTag>): Promise<ReleaseTag[]>;
+					getAll(options?: PineOptions<ReleaseTag>): Promise<ReleaseTag[]>;
 					set(
 						commitOrReleaseId: string | number,
 						tagKey: string,
@@ -1044,24 +1042,24 @@ declare namespace BalenaSdk {
 			device: {
 				get(
 					uuidOrId: string | number,
-					options?: PineOptionsFor<Device>,
+					options?: PineOptions<Device>,
 				): Promise<Device>;
 				getByName(
 					nameOrId: string | number,
-					options?: PineOptionsFor<Device>,
+					options?: PineOptions<Device>,
 				): Promise<Device[]>;
 				getWithServiceDetails(
 					nameOrId: string | number,
-					options?: PineOptionsFor<Device>,
+					options?: PineOptions<Device>,
 				): Promise<DeviceWithServiceDetails<CurrentServiceWithCommit>>;
-				getAll(options?: PineOptionsFor<Device>): Promise<Device[]>;
+				getAll(options?: PineOptions<Device>): Promise<Device[]>;
 				getAllByApplication(
 					nameOrId: string | number,
-					options?: PineOptionsFor<Device>,
+					options?: PineOptions<Device>,
 				): Promise<Device[]>;
 				getAllByParentDevice(
 					parentUuidOrId: string | number,
-					options?: PineOptionsFor<Device>,
+					options?: PineOptions<Device>,
 				): Promise<Device[]>;
 				getName(uuidOrId: string | number): Promise<string>;
 				getApplicationName(uuidOrId: string | number): Promise<string>;
@@ -1176,13 +1174,13 @@ declare namespace BalenaSdk {
 				tags: {
 					getAllByApplication(
 						nameOrId: string | number,
-						options?: PineOptionsFor<DeviceTag>,
+						options?: PineOptions<DeviceTag>,
 					): Promise<DeviceTag[]>;
 					getAllByDevice(
 						uuidOrId: string | number,
-						options?: PineOptionsFor<DeviceTag>,
+						options?: PineOptions<DeviceTag>,
 					): Promise<DeviceTag[]>;
-					getAll(options?: PineOptionsFor<DeviceTag>): Promise<DeviceTag[]>;
+					getAll(options?: PineOptions<DeviceTag>): Promise<DeviceTag[]>;
 					set(
 						uuidOrId: string | number,
 						tagKey: string,
@@ -1193,11 +1191,11 @@ declare namespace BalenaSdk {
 				configVar: {
 					getAllByDevice(
 						uuidOrId: string | number,
-						options?: PineOptionsFor<DeviceVariable>,
+						options?: PineOptions<DeviceVariable>,
 					): Promise<DeviceVariable[]>;
 					getAllByApplication(
 						nameOrId: string | number,
-						options?: PineOptionsFor<DeviceVariable>,
+						options?: PineOptions<DeviceVariable>,
 					): Promise<DeviceVariable[]>;
 					set(
 						uuidOrId: string | number,
@@ -1213,11 +1211,11 @@ declare namespace BalenaSdk {
 				envVar: {
 					getAllByDevice(
 						uuidOrId: string | number,
-						options?: PineOptionsFor<DeviceVariable>,
+						options?: PineOptions<DeviceVariable>,
 					): Promise<DeviceVariable[]>;
 					getAllByApplication(
 						nameOrId: string | number,
-						options?: PineOptionsFor<DeviceVariable>,
+						options?: PineOptions<DeviceVariable>,
 					): Promise<DeviceVariable[]>;
 					set(
 						uuidOrId: string | number,
@@ -1233,11 +1231,11 @@ declare namespace BalenaSdk {
 				serviceVar: {
 					getAllByDevice(
 						uuidOrId: string | number,
-						options?: PineOptionsFor<DeviceServiceEnvironmentVariable>,
+						options?: PineOptions<DeviceServiceEnvironmentVariable>,
 					): Promise<DeviceServiceEnvironmentVariable[]>;
 					getAllByApplication(
 						nameOrId: string | number,
-						options?: PineOptionsFor<DeviceServiceEnvironmentVariable>,
+						options?: PineOptions<DeviceServiceEnvironmentVariable>,
 					): Promise<DeviceServiceEnvironmentVariable[]>;
 					set(
 						uuidOrId: string | number,
@@ -1260,16 +1258,16 @@ declare namespace BalenaSdk {
 			service: {
 				getAllByApplication(
 					nameOrId: string | number,
-					options?: PineOptionsFor<Service>,
+					options?: PineOptions<Service>,
 				): Promise<Service[]>;
 				var: {
 					getAllByService(
 						id: number,
-						options?: PineOptionsFor<ServiceEnvironmentVariable>,
+						options?: PineOptions<ServiceEnvironmentVariable>,
 					): Promise<ServiceEnvironmentVariable[]>;
 					getAllByApplication(
 						nameOrId: string | number,
-						options?: PineOptionsFor<ServiceEnvironmentVariable>,
+						options?: PineOptions<ServiceEnvironmentVariable>,
 					): Promise<ServiceEnvironmentVariable[]>;
 					set(id: number, key: string, value: string): Promise<void>;
 					get(id: number, key: string): Promise<string | undefined>;
@@ -1289,11 +1287,11 @@ declare namespace BalenaSdk {
 				>;
 			};
 			image: {
-				get(id: number, options?: PineOptionsFor<Image>): Promise<Image>;
+				get(id: number, options?: PineOptions<Image>): Promise<Image>;
 				getLogs(id: number): Promise<string>;
 			};
 			key: {
-				getAll(options?: PineOptionsFor<SSHKey>): Promise<SSHKey[]>;
+				getAll(options?: PineOptions<SSHKey>): Promise<SSHKey[]>;
 				get(id: string | number): Promise<SSHKey>;
 				remove(id: string | number): Promise<void>;
 				create(title: string, key: string): Promise<SSHKey>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -36,10 +36,11 @@ export type InferAssociatedResourceType<T> = T extends AssociatedResource &
 	? T[number]
 	: never;
 
-export type SelectableProps<T> = Exclude<
-	StringKeyof<T>,
-	PropsOfType<T, ReverseNavigationResource>
->;
+export type SelectableProps<T> =
+	// This allows us to get proper results when T is any/AnyObject, otherwise this returned never
+	PropsOfType<T, ReverseNavigationResource> extends StringKeyof<T>
+		? StringKeyof<T>
+		: Exclude<StringKeyof<T>, PropsOfType<T, ReverseNavigationResource>>; // This is the normal typed case
 
 export type ExpandableProps<T> = PropsOfType<T, AssociatedResource> & string;
 

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -227,16 +227,15 @@ interface ODataOptionsBase {
 	$select?: string | string[] | '*';
 }
 
-export interface PineOptions extends ODataOptionsBase {
-	$filter?: object;
-	$expand?: object | string;
-}
-
 export interface PineOptionsFor<T> extends ODataOptionsBase {
 	$select?: Array<SelectableProps<T>> | SelectableProps<T> | '*';
 	$filter?: Filter<T>;
 	$expand?: Expand<T>;
 }
+
+export type SubmitBody<T> = {
+	[k in keyof T]?: T[k] extends AssociatedResource ? number | null : T[k];
+};
 
 interface PineParamsBase {
 	apiPrefix?: string;
@@ -248,15 +247,6 @@ interface PineParamsBase {
 	passthroughByMethod?: { [method in ODataMethod]: AnyObject };
 	customOptions?: AnyObject;
 }
-
-export interface PineParams extends PineParamsBase {
-	body?: AnyObject;
-	options?: PineOptions;
-}
-
-export type SubmitBody<T> = {
-	[k in keyof T]?: T[k] extends AssociatedResource ? number | null : T[k];
-};
 
 export interface PineParamsFor<T> extends PineParamsBase {
 	body?: SubmitBody<T>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -211,7 +211,7 @@ type FilterExpressions<T> = {
 };
 
 export type ResourceExpand<T> = {
-	[k in ExpandableProps<T>]?: PineOptions<InferAssociatedResourceType<T[k]>>;
+	[k in ExpandableProps<T>]?: ODataOptions<InferAssociatedResourceType<T[k]>>;
 };
 
 type BaseExpand<T> = ResourceExpand<T> | ExpandableProps<T>;
@@ -220,45 +220,39 @@ export type Expand<T> = BaseExpand<T> | Array<BaseExpand<T>>;
 
 export type ODataMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
-interface ODataOptionsBase {
-	$orderby?: OrderBy;
-	$top?: number;
-	$skip?: number;
-	$select?: string | string[] | '*';
-}
-
-export interface PineOptions<T> extends ODataOptionsBase {
+export interface ODataOptions<T> {
 	$select?: Array<SelectableProps<T>> | SelectableProps<T> | '*';
 	$filter?: Filter<T>;
 	$expand?: Expand<T>;
+	$orderby?: OrderBy;
+	$top?: number;
+	$skip?: number;
 }
 
 export type SubmitBody<T> = {
 	[k in keyof T]?: T[k] extends AssociatedResource ? number | null : T[k];
 };
 
-interface PineParamsBase {
+export interface ParamsObj<T> {
+	resource?: string;
+	body?: SubmitBody<T>;
+	id?: number;
+	options?: ODataOptions<T>;
+
 	apiPrefix?: string;
 	method?: ODataMethod;
-	resource?: string;
-	id?: number;
 	url?: string;
 	passthrough?: AnyObject;
 	passthroughByMethod?: { [method in ODataMethod]: AnyObject };
 	customOptions?: AnyObject;
 }
 
-export interface PineParams<T> extends PineParamsBase {
-	body?: SubmitBody<T>;
-	options?: PineOptions<T>;
-}
-
-export interface PineParamsWithId<T> extends PineParams<T> {
+export interface ParamsObjWithId<T> extends ParamsObj<T> {
 	id: number;
 }
 
-export interface UpsertPineParams<T>
-	extends Omit<PineParams<T>, 'id' | 'method' | 'options'> {
+export interface UpsertParams<T>
+	extends Omit<ParamsObj<T>, 'id' | 'method' | 'options'> {
 	id: SubmitBody<T>;
 	resource: string;
 	body: SubmitBody<T>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -210,13 +210,13 @@ type FilterExpressions<T> = {
 	$cast?: FilterFunctionValue<T>;
 };
 
-export type ResourceExpandFor<T> = {
-	[k in ExpandableProps<T>]?: PineOptionsFor<InferAssociatedResourceType<T[k]>>;
+export type ResourceExpand<T> = {
+	[k in ExpandableProps<T>]?: PineOptions<InferAssociatedResourceType<T[k]>>;
 };
 
-type BaseExpandFor<T> = ResourceExpandFor<T> | ExpandableProps<T>;
+type BaseExpand<T> = ResourceExpand<T> | ExpandableProps<T>;
 
-export type Expand<T> = BaseExpandFor<T> | Array<BaseExpandFor<T>>;
+export type Expand<T> = BaseExpand<T> | Array<BaseExpand<T>>;
 
 export type ODataMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
@@ -227,7 +227,7 @@ interface ODataOptionsBase {
 	$select?: string | string[] | '*';
 }
 
-export interface PineOptionsFor<T> extends ODataOptionsBase {
+export interface PineOptions<T> extends ODataOptionsBase {
 	$select?: Array<SelectableProps<T>> | SelectableProps<T> | '*';
 	$filter?: Filter<T>;
 	$expand?: Expand<T>;
@@ -248,17 +248,17 @@ interface PineParamsBase {
 	customOptions?: AnyObject;
 }
 
-export interface PineParamsFor<T> extends PineParamsBase {
+export interface PineParams<T> extends PineParamsBase {
 	body?: SubmitBody<T>;
-	options?: PineOptionsFor<T>;
+	options?: PineOptions<T>;
 }
 
-export interface PineParamsWithIdFor<T> extends PineParamsFor<T> {
+export interface PineParamsWithId<T> extends PineParams<T> {
 	id: number;
 }
 
-export interface UpsertPineParamsFor<T>
-	extends Omit<PineParamsFor<T>, 'id' | 'method' | 'options'> {
+export interface UpsertPineParams<T>
+	extends Omit<PineParams<T>, 'id' | 'method' | 'options'> {
 	id: SubmitBody<T>;
 	resource: string;
 	body: SubmitBody<T>;


### PR DESCRIPTION
This allows using AnyObject/Dictionary<any> as the generic parameter of PineOptionsFor<T>.
As a result we no longer need two separate PineOptions & PineOptionsFor<T> variants (the same is true for PineParams).
So we now
* combine them to a single PineOptions<T> & PineParams<T> type
* dropping the now unnecessary `For` suffix (was there to help distinct the generic types)

Lastly, this also changes the names of some internal typings to make them match with the ones in pinejs-client-core.

Change-type: major
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
