### PR TITLE
Make $select required in pine GET requests and $filter or ID required in PATCH & DELETE

### DIFF
--- a/lib/logs.coffee
+++ b/lib/logs.coffee
@@ -31,7 +31,7 @@ AbortController = globalEnv?.AbortController || AbortControllerPonyfill
 getLogs = (deps, opts) ->
 	{ request } = deps
 
-	deviceModel = require('./models/device')(deps, opts)
+	deviceModel = require('./models/device').default(deps, opts)
 
 	exports = {}
 

--- a/lib/models/api-key.ts
+++ b/lib/models/api-key.ts
@@ -23,6 +23,14 @@ import * as BalenaSdk from '../../typings/balena-sdk';
 import { InjectedDependenciesParam, InjectedOptionsParam } from '../balena';
 import { findCallback, mergePineOptions } from '../util';
 
+const ApiKeyFields: Array<keyof BalenaSdk.ApiKey> = [
+	'id',
+	'created_at',
+	'name',
+	'description',
+	'is_of__actor',
+];
+
 const getApiKeysModel = function(
 	deps: InjectedDependenciesParam,
 	opts: InjectedOptionsParam,
@@ -121,6 +129,7 @@ const getApiKeysModel = function(
 				resource: 'api_key',
 				options: mergePineOptions(
 					{
+						$select: ApiKeyFields,
 						// the only way to reason whether
 						// it's a named user api key is whether
 						// it has a name

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -43,8 +43,8 @@ getApplicationModel = (deps, opts) ->
 	{ request, pine } = deps
 	{ apiUrl } = opts
 
-	deviceModel = once -> require('./device')(deps, opts)
-	releaseModel = once -> require('./release')(deps, opts)
+	deviceModel = once -> require('./device').default(deps, opts)
+	releaseModel = once -> require('./release').default(deps, opts)
 
 	{ buildDependentResource } = require('../util/dependent-resource')
 
@@ -1463,4 +1463,6 @@ getApplicationModel = (deps, opts) ->
 
 	return exports
 
-module.exports = getApplicationModel
+module.exports =
+	default: getApplicationModel
+	ApplicationFields: ApplicationFields

--- a/lib/models/billing.coffee
+++ b/lib/models/billing.coffee
@@ -208,4 +208,5 @@ getBillingModel = (deps, opts) ->
 
 	return exports
 
-module.exports = getBillingModel
+module.exports =
+	default: getBillingModel

--- a/lib/models/config.coffee
+++ b/lib/models/config.coffee
@@ -22,7 +22,7 @@ getConfigModel = (deps, opts) ->
 	{ request } = deps
 	{ apiUrl } = opts
 
-	deviceModel = once -> require('./device')(deps, opts)
+	deviceModel = once -> require('./device').default(deps, opts)
 
 	exports = {}
 
@@ -138,4 +138,5 @@ getConfigModel = (deps, opts) ->
 
 	return exports
 
-module.exports = getConfigModel
+module.exports =
+	default: getConfigModel

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -77,9 +77,9 @@ getDeviceModel = (deps, opts) ->
 	{ apiUrl, dashboardUrl, deviceUrlsBase } = opts
 
 	registerDevice = require('balena-register-device')({ request })
-	configModel = once -> require('./config')(deps, opts)
-	applicationModel = once -> require('./application')(deps, opts)
-	osModel = once -> require('./os')(deps, opts)
+	configModel = once -> require('./config').default(deps, opts)
+	applicationModel = once -> require('./application').default(deps, opts)
+	osModel = once -> require('./os').default(deps, opts)
 
 	{ buildDependentResource } = require('../util/dependent-resource')
 
@@ -3309,4 +3309,9 @@ getDeviceModel = (deps, opts) ->
 
 	return exports
 
-module.exports = getDeviceModel
+module.exports =
+	default: getDeviceModel
+	DeviceFields: DeviceFields
+	DeviceServiceEnvironmentVariableFields: DeviceServiceEnvironmentVariableFields
+	ServiceInstallFields: ServiceInstallFields
+

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -48,7 +48,7 @@ deviceStatus = require('balena-device-status')
 	normalizeDeviceOsVersion
 } = require('../util/device-os-version')
 {
-	getCurrentServiceDetailsPineOptions,
+	getCurrentServiceDetailsPineExpand,
 	generateCurrentServiceDetails,
 } = require('../util/device-service-details')
 {
@@ -71,6 +71,54 @@ MIN_SUPERVISOR_MC_API = '7.0.0'
 # noticed during tests and the endpoints that resulted in container management actions were
 # affected in particular.
 CONTAINER_ACTION_ENDPOINT_TIMEOUT = 50000
+
+DeviceFields = [
+	'id'
+	'created_at'
+	'actor'
+	'device_name'
+	'uuid'
+	'note'
+	'local_id'
+	'status'
+	'is_online'
+	'last_connectivity_event'
+	'is_connected_to_vpn'
+	'last_vpn_event'
+	'ip_address'
+	'vpn_address'
+	'public_address'
+	'os_version'
+	'os_variant'
+	'supervisor_version'
+	'provisioning_progress'
+	'provisioning_state'
+	'download_progress'
+	'logs_channel'
+	'is_locked_until__date'
+	'api_heartbeat_state'
+	'is_of__device_type'
+	'belongs_to__application'
+	'is_managed_by__device'
+	'should_be_running__release'
+	'is_running__release'
+	'is_managed_by__service_instance'
+]
+
+DeviceServiceEnvironmentVariableFields = [
+	'id'
+	'created_at'
+	'value'
+	'name'
+	'service_install'
+]
+
+ServiceInstallFields = [
+	'id'
+	'created_at'
+	'device'
+	'installs__service'
+]
 
 getDeviceModel = (deps, opts) ->
 	{ pine, request, sdkInstance: { auth } } = deps
@@ -211,6 +259,7 @@ getDeviceModel = (deps, opts) ->
 			resource: 'device'
 			options:
 				mergePineOptions
+					$select: DeviceFields
 					$orderby: 'device_name asc'
 				, options
 
@@ -330,7 +379,10 @@ getDeviceModel = (deps, opts) ->
 				pine.get
 					resource: 'device'
 					id: uuidOrId
-					options: options
+					options:
+						mergePineOptions
+							$select: DeviceFields
+						, options
 				.tap (device) ->
 					if not device?
 						throw new errors.BalenaDeviceNotFound(uuidOrId)
@@ -339,6 +391,7 @@ getDeviceModel = (deps, opts) ->
 					resource: 'device'
 					options:
 						mergePineOptions
+							$select: DeviceFields
 							$filter:
 								uuid: $startswith: uuidOrId
 						, options
@@ -391,7 +444,7 @@ getDeviceModel = (deps, opts) ->
 		callback = findCallback(arguments)
 
 		exports.get uuidOrId,
-			mergePineOptions(getCurrentServiceDetailsPineOptions(true), options)
+			mergePineOptions($expand: getCurrentServiceDetailsPineExpand(true), options)
 		.then(generateCurrentServiceDetails)
 		.asCallback(callback)
 
@@ -3088,6 +3141,7 @@ getDeviceModel = (deps, opts) ->
 				pine.get
 					resource: 'device_service_environment_variable'
 					options: mergePineOptions
+						$select: DeviceServiceEnvironmentVariableFields
 						$filter:
 							service_install:
 								$any:
@@ -3134,6 +3188,7 @@ getDeviceModel = (deps, opts) ->
 					resource: 'device_service_environment_variable'
 					options:
 						mergePineOptions
+							$select: DeviceServiceEnvironmentVariableFields
 							$filter:
 								service_install:
 									$any:
@@ -3185,6 +3240,7 @@ getDeviceModel = (deps, opts) ->
 				pine.get
 					resource: 'device_service_environment_variable'
 					options:
+						$select: DeviceServiceEnvironmentVariableFields
 						$filter:
 							service_install:
 								$any:
@@ -3242,6 +3298,7 @@ getDeviceModel = (deps, opts) ->
 				pine.get
 					resource: 'service_install'
 					options:
+						$select: ServiceInstallFields
 						$filter:
 							device: deviceFilter
 							service: serviceId

--- a/lib/models/image.coffee
+++ b/lib/models/image.coffee
@@ -21,7 +21,7 @@ errors = require('balena-errors')
 
 getImageModel = (deps, opts) ->
 	{ pine } = deps
-	applicationModel = once -> require('./application')(deps, opts)
+	applicationModel = once -> require('./application').default(deps, opts)
 
 	exports = {}
 
@@ -105,4 +105,5 @@ getImageModel = (deps, opts) ->
 
 	return exports
 
-module.exports = getImageModel
+module.exports =
+	default: getImageModel

--- a/lib/models/index.coffee
+++ b/lib/models/index.coffee
@@ -22,13 +22,13 @@ modelsTemplate =
 	# @namespace application
 	# @memberof balena.models
 	###
-	application: require('./application')
+	application: require('./application').default
 
 	###*
 	# @namespace device
 	# @memberof balena.models
 	###
-	device: require('./device')
+	device: require('./device').default
 
 	###*
 	# @namespace apiKey
@@ -40,44 +40,44 @@ modelsTemplate =
 	# @namespace key
 	# @memberof balena.models
 	###
-	key: require('./key')
+	key: require('./key').default
 
 	###*
 	# @namespace os
 	# @memberof balena.models
 	###
-	os: require('./os')
+	os: require('./os').default
 
 	###*
 	# @namespace config
 	# @memberof balena.models
 	###
-	config: require('./config')
+	config: require('./config').default
 
 	###*
 	# @namespace release
 	# @memberof balena.models
 	###
-	release: require('./release')
+	release: require('./release').default
 
 	###*
 	# @namespace service
 	# @memberof balena.models
 	###
-	service: require('./service')
+	service: require('./service').default
 
 	###*
 	# @namespace image
 	# @memberof balena.models
 	###
-	image: require('./image')
+	image: require('./image').default
 
 	###*
 	# @namespace billing
 	# @memberof balena.models
 	# @description **Note!** The billing methods are available on Balena.io exclusively.
 	###
-	billing: require('./billing')
+	billing: require('./billing').default
 
 module.exports = (deps, opts) ->
 	mapValues(modelsTemplate, (v) -> v(deps, opts))

--- a/lib/models/key.coffee
+++ b/lib/models/key.coffee
@@ -149,4 +149,7 @@ getKeyModel = (deps, opts) ->
 
 	return exports
 
-module.exports = getKeyModel
+module.exports =
+	default: getKeyModel
+	UserPublicKeyFields: UserPublicKeyFields
+

--- a/lib/models/key.coffee
+++ b/lib/models/key.coffee
@@ -20,6 +20,14 @@ errors = require('balena-errors')
 
 { findCallback, mergePineOptions } = require('../util')
 
+UserPublicKeyFields = [
+	'id'
+	'user'
+	'title'
+	'public_key'
+	'created_at'
+]
+
 getKeyModel = (deps, opts) ->
 	{ pine, sdkInstance: { auth } } = deps
 
@@ -51,7 +59,9 @@ getKeyModel = (deps, opts) ->
 		callback = findCallback(arguments)
 		return pine.get
 			resource: 'user__has__public_key'
-			options: mergePineOptions({}, options)
+			options: mergePineOptions
+				$select: UserPublicKeyFields
+			, options
 		.asCallback(callback)
 
 	###*
@@ -80,6 +90,8 @@ getKeyModel = (deps, opts) ->
 		return pine.get
 			resource: 'user__has__public_key'
 			id: id
+			options:
+				$select: UserPublicKeyFields
 		.tap (key) ->
 			if isEmpty(key)
 				throw new errors.BalenaKeyNotFound(id)

--- a/lib/models/os.coffee
+++ b/lib/models/os.coffee
@@ -46,8 +46,8 @@ getOsModel = (deps, opts) ->
 	{ request, pubsub } = deps
 	{ apiUrl, isBrowser } = opts
 
-	configModel = once -> require('./config')(deps, opts)
-	applicationModel = once -> require('./application')(deps, opts)
+	configModel = once -> require('./config').default(deps, opts)
+	applicationModel = once -> require('./application').default(deps, opts)
 
 	withDeviceTypesEndpointCaching = (fn) ->
 		memoizedFn = memoizee(fn, {
@@ -561,4 +561,5 @@ getOsModel = (deps, opts) ->
 
 	return exports
 
-module.exports = getOsModel
+module.exports =
+	default: getOsModel

--- a/lib/models/release.coffee
+++ b/lib/models/release.coffee
@@ -22,6 +22,27 @@ Promise = require('bluebird')
 
 { isId, findCallback, mergePineOptions } = require('../util')
 
+ReleaseFields = [
+	'id'
+	'created_at'
+	'commit'
+	'composition'
+	'status'
+	'source'
+	'build_log'
+	'start_timestamp'
+	'update_timestamp'
+	'end_timestamp'
+	'belongs_to__application'
+]
+
+ReleaseTagFields = [
+	'id'
+	'tag_key'
+	'value'
+	'release'
+]
+
 getReleaseModel = (deps, opts) ->
 	{ pine } = deps
 	applicationModel = once -> require('./application').default(deps, opts)
@@ -79,7 +100,10 @@ getReleaseModel = (deps, opts) ->
 				pine.get
 					resource: 'release'
 					id: commitOrId
-					options: mergePineOptions({}, options)
+					options:
+						mergePineOptions
+							$select: ReleaseFields
+						, options
 				.tap (release) ->
 					if not release?
 						throw new errors.BalenaReleaseNotFound(commitOrId)
@@ -88,6 +112,7 @@ getReleaseModel = (deps, opts) ->
 					resource: 'release'
 					options:
 						mergePineOptions
+							$select: ReleaseFields
 							$filter:
 								commit: $startswith: commitOrId
 						, options
@@ -148,6 +173,7 @@ getReleaseModel = (deps, opts) ->
 		return exports.get commitOrId, mergePineOptions
 			$expand:
 				contains__image:
+					$select: 'image'
 					$expand:
 						image:
 							mergePineOptions
@@ -218,6 +244,7 @@ getReleaseModel = (deps, opts) ->
 				resource: 'release'
 				options:
 					mergePineOptions
+						$select: ReleaseFields
 						$filter:
 							belongs_to__application: id
 						$orderby: 'created_at desc'
@@ -389,6 +416,7 @@ getReleaseModel = (deps, opts) ->
 			$expand:
 				release_tag:
 					mergePineOptions
+						$select: ReleaseTagFields
 						$orderby: 'tag_key asc'
 					, options
 		)
@@ -474,4 +502,3 @@ getReleaseModel = (deps, opts) ->
 module.exports =
 	default: getReleaseModel
 	ReleaseFields: ReleaseFields
-

--- a/lib/models/release.coffee
+++ b/lib/models/release.coffee
@@ -24,7 +24,7 @@ Promise = require('bluebird')
 
 getReleaseModel = (deps, opts) ->
 	{ pine } = deps
-	applicationModel = once -> require('./application')(deps, opts)
+	applicationModel = once -> require('./application').default(deps, opts)
 
 	{ buildDependentResource } = require('../util/dependent-resource')
 	{ BuilderHelper } = require('../util/builder')
@@ -471,4 +471,7 @@ getReleaseModel = (deps, opts) ->
 
 	return exports
 
-module.exports = getReleaseModel
+module.exports =
+	default: getReleaseModel
+	ReleaseFields: ReleaseFields
+

--- a/lib/models/service.coffee
+++ b/lib/models/service.coffee
@@ -19,6 +19,13 @@ errors = require('balena-errors')
 
 { findCallback, mergePineOptions } = require('../util')
 
+ServiceFields = [
+	'id'
+	'created_at'
+	'service_name'
+	'application'
+]
+
 getServiceModel = (deps, opts) ->
 	{ pine } = deps
 	applicationModel = once -> require('./application').default(deps, opts)
@@ -41,7 +48,9 @@ getServiceModel = (deps, opts) ->
 		pine.get
 			resource: 'service'
 			id: id
-			options: options
+			options: mergePineOptions
+				$select: ServiceFields
+			, options
 		.tap (service) ->
 			if not service?
 				throw new errors.BalenaServiceNotFound(id)
@@ -83,6 +92,7 @@ getServiceModel = (deps, opts) ->
 				resource: 'service'
 				options:
 					mergePineOptions
+						$select: ServiceFields
 						$filter: application: id
 					, options
 		.asCallback(callback)

--- a/lib/models/service.coffee
+++ b/lib/models/service.coffee
@@ -21,7 +21,7 @@ errors = require('balena-errors')
 
 getServiceModel = (deps, opts) ->
 	{ pine } = deps
-	applicationModel = once -> require('./application')(deps, opts)
+	applicationModel = once -> require('./application').default(deps, opts)
 
 	{ buildDependentResource } = require('../util/dependent-resource')
 
@@ -241,4 +241,6 @@ getServiceModel = (deps, opts) ->
 
 	return exports
 
-module.exports = getServiceModel
+module.exports =
+	default: getServiceModel
+	ServiceFields: ServiceFields

--- a/lib/util/dependent-resource.coffee
+++ b/lib/util/dependent-resource.coffee
@@ -38,8 +38,15 @@ exports.buildDependentResource = (
 		parentResourceName # e.g. device
 		getResourceId # e.g. getId(uuidOrId)
 		ResourceNotFoundError # e.g. DeviceNotFoundError
+		ExtraFields = ['id', 'value']
 	}
 ) ->
+	Fields = [
+		ExtraFields...
+		resourceKeyField
+		parentResourceName
+	]
+
 	exports = {
 		getAll: (options = {}, callback) ->
 			callback = findCallback(arguments)
@@ -48,6 +55,7 @@ exports.buildDependentResource = (
 				resource: resourceName
 				options:
 					mergePineOptions
+						$select: Fields
 						$orderby: "#{resourceKeyField} asc"
 					, options
 			.asCallback(callback)
@@ -71,6 +79,7 @@ exports.buildDependentResource = (
 				pine.get
 					resource: resourceName
 					options:
+						$select: Fields
 						$filter:
 							"#{parentResourceName}": id
 							"#{resourceKeyField}": key

--- a/lib/util/device-service-details.ts
+++ b/lib/util/device-service-details.ts
@@ -7,52 +7,50 @@ import {
 	GatewayDownload,
 	Image,
 	ImageInstall,
-	PineOptions,
+	PineExpand,
 	Release,
 	Service,
 } from '../../typings/balena-sdk';
 
-// Pine options necessary for getting raw service data for a device
-export const getCurrentServiceDetailsPineOptions = (expandRelease: boolean) => {
-	const pineOptions: PineOptions<DeviceWithImageInstalls> = {
-		$expand: {
-			image_install: {
-				$select: ['id', 'download_progress', 'status', 'install_date'],
-				$filter: {
-					status: {
-						$ne: 'deleted',
-					},
-				},
-				$expand: {
-					image: {
-						$select: ['id'],
-						$expand: {
-							is_a_build_of__service: {
-								$select: ['id', 'service_name'],
-							},
-						},
-					},
-					...(expandRelease && {
-						is_provided_by__release: {
-							$select: ['id', 'commit'],
-						},
-					}),
+// Pine expand options necessary for getting raw service data for a device
+export const getCurrentServiceDetailsPineExpand = (expandRelease: boolean) => {
+	const pineExpand: PineExpand<DeviceWithImageInstalls> = {
+		image_install: {
+			$select: ['id', 'download_progress', 'status', 'install_date'],
+			$filter: {
+				status: {
+					$ne: 'deleted',
 				},
 			},
-			gateway_download: {
-				$select: ['id', 'download_progress', 'status'],
-				$filter: {
-					status: {
-						$ne: 'deleted',
+			$expand: {
+				image: {
+					$select: ['id'],
+					$expand: {
+						is_a_build_of__service: {
+							$select: ['id', 'service_name'],
+						},
 					},
 				},
-				$expand: {
-					image: {
-						$select: ['id'],
-						$expand: {
-							is_a_build_of__service: {
-								$select: ['id', 'service_name'],
-							},
+				...(expandRelease && {
+					is_provided_by__release: {
+						$select: ['id', 'commit'],
+					},
+				}),
+			},
+		},
+		gateway_download: {
+			$select: ['id', 'download_progress', 'status'],
+			$filter: {
+				status: {
+					$ne: 'deleted',
+				},
+			},
+			$expand: {
+				image: {
+					$select: ['id'],
+					$expand: {
+						is_a_build_of__service: {
+							$select: ['id', 'service_name'],
 						},
 					},
 				},
@@ -60,7 +58,7 @@ export const getCurrentServiceDetailsPineOptions = (expandRelease: boolean) => {
 		},
 	};
 
-	return pineOptions;
+	return pineExpand;
 };
 
 interface WithServiceName {

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -123,10 +123,18 @@ export const isDevelopmentVersion = (version: string) =>
 //   * That means $expands within expands are combined
 //   * And $selects within expands override
 // * Any unknown 'extra' options throw an error. Unknown 'default' options are ignored.
-export const mergePineOptions = <R extends {}>(
+export function mergePineOptions<R extends {}>(
+	defaults: Pine.ODataOptionsWithSelect<R>,
+	extras: Pine.ODataOptions<R>,
+): Pine.ODataOptionsWithSelect<R>;
+export function mergePineOptions<R extends {}>(
 	defaults: Pine.ODataOptions<R>,
 	extras: Pine.ODataOptions<R>,
-): Pine.ODataOptions<R> => {
+): Pine.ODataOptions<R>;
+export function mergePineOptions<R extends {}>(
+	defaults: Pine.ODataOptions<R>,
+	extras: Pine.ODataOptions<R>,
+): Pine.ODataOptions<R> {
 	if (!extras) {
 		return defaults;
 	}
@@ -179,7 +187,7 @@ export const mergePineOptions = <R extends {}>(
 	}
 
 	return result;
-};
+}
 
 const mergeExpandOptions = <T>(
 	defaultExpand: Pine.Expand<T> | undefined,

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -204,7 +204,9 @@ const mergeExpandOptions = <T>(
 		keyof typeof extraExpand
 	>) {
 		const extraExpandOptions = extraExpand[expandKey]! || {};
-		defaultExpand[expandKey] = defaultExpand[expandKey] || {};
+		defaultExpand[expandKey] =
+			defaultExpand[expandKey] ||
+			({} as typeof defaultExpand[typeof expandKey]);
 		const expandOptions = defaultExpand[expandKey]!;
 
 		if (extraExpandOptions.$select) {

--- a/tests/integration/logs.spec.coffee
+++ b/tests/integration/logs.spec.coffee
@@ -34,6 +34,8 @@ describe 'Logs', ->
 		afterEach ->
 			balena.pine.delete
 				resource: 'device'
+				options:
+					$filter: uuid: @uuid
 
 		describe 'balena.logs.history()', ->
 

--- a/tests/integration/models/application.spec.coffee
+++ b/tests/integration/models/application.spec.coffee
@@ -104,6 +104,8 @@ describe 'Application Model', ->
 				afterEach ->
 					balena.pine.delete
 						resource: 'application'
+						options:
+							$filter: 1: 1
 
 				it 'should be able to create an application w/o providing an application type', ->
 					balena.models.application.create

--- a/tests/integration/models/application.spec.coffee
+++ b/tests/integration/models/application.spec.coffee
@@ -3,6 +3,13 @@ Promise = require('bluebird')
 m = require('mochainon')
 
 {
+	ApplicationFields
+} = require('../../../lib/models/application')
+{
+	DeviceFields
+} = require('../../../lib/models/device')
+
+{
 	balena
 	credentials
 	givenADevice
@@ -117,7 +124,7 @@ describe 'Application Model', ->
 						.that.has.property('__id').that.is.a('number')
 
 						balena.models.application.getAll
-							$expand: 'is_for__device_type'
+							$expand: is_for__device_type: $select: 'slug'
 						.then (apps) ->
 							m.chai.expect(apps).to.have.length(1)
 							m.chai.expect(apps[0]).to.have.property('id', app.id)
@@ -143,6 +150,10 @@ describe 'Application Model', ->
 							balena.pine.get
 								resource: 'application'
 								options:
+									$select: [
+										'id'
+										'depends_on__application'
+									]
 									$filter: id: $in: [parentApplication.id, childApplication.id]
 									$orderby: id: 'asc'
 					.then ([ parentApplication, childApplication ]) ->
@@ -167,12 +178,14 @@ describe 'Application Model', ->
 							organization: orgId
 					.then ->
 						Promise.all([
-							balena.models.application.getAll()
+							balena.models.application.getAll(
+								$expand: organization: $select: 'id'
+							)
 							balena.auth.getPersonalOrganizationId()
 						])
 					.then ([apps, orgId]) ->
 						m.chai.expect(apps).to.have.length(1)
-						m.chai.expect(apps[0]).to.have.nested.property('organization.__id', orgId)
+						m.chai.expect(apps[0]).to.have.nested.property('organization[0].id', orgId)
 
 				it "should be able to create an application using the user's personal org name", ->
 					balena.auth.whoami()
@@ -183,12 +196,14 @@ describe 'Application Model', ->
 							organization: orgName
 					.then ->
 						Promise.all([
-							balena.models.application.getAll()
+							balena.models.application.getAll(
+								$expand: organization: $select: 'id'
+							)
 							balena.auth.getPersonalOrganizationId()
 						])
 					.then ([apps, orgId]) ->
 						m.chai.expect(apps).to.have.length(1)
-						m.chai.expect(apps[0]).to.have.nested.property('organization.__id', orgId)
+						m.chai.expect(apps[0]).to.have.nested.property('organization[0].id', orgId)
 
 	describe 'given a single application', ->
 
@@ -238,19 +253,21 @@ describe 'Application Model', ->
 						m.chai.expect(applications[0].id).to.equal(@application.id)
 
 				it 'should support arbitrary pinejs options', ->
-					balena.models.application.getAll($expand: 'organization')
+					balena.models.application.getAll($expand: organization: $select: 'name')
 					.then (applications) ->
 						m.chai.expect(applications[0].organization[0].name).to.equal(credentials.username)
 
 			describe 'balena.models.application.get()', ->
 
 				it 'should be able to get an application by name', ->
-					promise = balena.models.application.get(@application.app_name)
-					m.chai.expect(promise).to.become(@application)
+					balena.models.application.get(@application.app_name)
+					.then (app) =>
+						m.chai.expect(app).to.deep.match(_.pick(@application, ApplicationFields))
 
 				it 'should be able to get an application by id', ->
-					promise = balena.models.application.get(@application.id)
-					m.chai.expect(promise).to.become(@application)
+					balena.models.application.get(@application.id)
+					.then (app) =>
+						m.chai.expect(app).to.deep.match(_.pick(@application, ApplicationFields))
 
 				it 'should be rejected if the application name does not exist', ->
 					promise = balena.models.application.get('HelloWorldApp')
@@ -261,7 +278,7 @@ describe 'Application Model', ->
 					m.chai.expect(promise).to.be.rejectedWith('Application not found: 999999')
 
 				it 'should support arbitrary pinejs options', ->
-					balena.models.application.get(@application.id, $expand: 'organization')
+					balena.models.application.get(@application.id, $expand: organization: $select: 'name')
 					.then (application) ->
 						m.chai.expect(application.organization[0].name).to.equal(credentials.username)
 
@@ -366,7 +383,7 @@ describe 'Application Model', ->
 					expiryTime = Date.now() + 3600 * 1000
 					promise = balena.models.application.grantSupportAccess(@application.id, expiryTime)
 					.then =>
-						balena.models.application.get(@application.id)
+						balena.models.application.get(@application.id, $select: 'is_accessible_by_support_until__date')
 					.then (app) ->
 						Date.parse(app.is_accessible_by_support_until__date)
 
@@ -379,7 +396,7 @@ describe 'Application Model', ->
 					.then =>
 						balena.models.application.revokeSupportAccess(@application.id)
 					.then =>
-						balena.models.application.get(@application.id)
+						balena.models.application.get(@application.id, $select: 'is_accessible_by_support_until__date')
 					.then (app) ->
 						app.is_accessible_by_support_until__date
 
@@ -678,13 +695,14 @@ describe 'Application Model', ->
 		givenMulticontainerApplicationWithADevice(before)
 
 		itShouldBeAnApplicationWithDeviceServiceDetails = (application, expectCommit = false) ->
-			# Commit is empty on newly created application, so ignoring it
-			omittedFields = [
-				'owns__device'
+			# we will check the omitted fields right after
+			firstSetOfCheckedFields = _.difference(ApplicationFields, [
 				'should_be_running__release'
-				'__metadata'
-			]
-			m.chai.expect(_.omit(application, omittedFields)).to.deep.equal(_.omit(@application, omittedFields))
+				'owns__device'
+			])
+
+			m.chai.expect(_.pick(application, firstSetOfCheckedFields))
+			.to.deep.equal(_.pick(@application, firstSetOfCheckedFields))
 
 			# Check the app's target release after the release got created
 			m.chai.expect(application.should_be_running__release.__id).to.equal(@currentRelease.id)
@@ -753,6 +771,7 @@ describe 'Application Model', ->
 			extraServiceDetailOptions =
 				$expand:
 					owns__device:
+						$select: DeviceFields
 						$expand:
 							image_install:
 								$expand:

--- a/tests/integration/models/device.spec.coffee
+++ b/tests/integration/models/device.spec.coffee
@@ -518,7 +518,10 @@ describe 'Device Model', ->
 					latitude: 41.383333
 					longitude: 2.183333
 				.then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: [
+						'custom_latitude'
+						'custom_longitude'
+					])
 				.then (device) ->
 					m.chai.expect(device.custom_latitude).to.equal('41.383333')
 					m.chai.expect(device.custom_longitude).to.equal('2.183333')
@@ -528,7 +531,10 @@ describe 'Device Model', ->
 					latitude: 42.383333
 					longitude: 2.283333
 				.then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: [
+						'custom_latitude'
+						'custom_longitude'
+					])
 				.then (device) ->
 					m.chai.expect(device.custom_latitude).to.equal('42.383333')
 					m.chai.expect(device.custom_longitude).to.equal('2.283333')
@@ -556,14 +562,20 @@ describe 'Device Model', ->
 
 			it 'should be able to unset the location of a device by uuid', ->
 				balena.models.device.unsetCustomLocation(@device.uuid).then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: [
+						'custom_latitude'
+						'custom_longitude'
+					])
 				.then (device) ->
 					m.chai.expect(device.custom_latitude).to.equal('')
 					m.chai.expect(device.custom_longitude).to.equal('')
 
 			it 'should be able to unset the location of a device by id', ->
 				balena.models.device.unsetCustomLocation(@device.id).then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: [
+						'custom_latitude'
+						'custom_longitude'
+					])
 				.then (device) ->
 					m.chai.expect(device.custom_latitude).to.equal('')
 					m.chai.expect(device.custom_longitude).to.equal('')
@@ -803,7 +815,7 @@ describe 'Device Model', ->
 				expiryTimestamp = Date.now() + 3600 * 1000
 				promise = balena.models.device.grantSupportAccess(@device.id, expiryTimestamp)
 				.then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: 'is_accessible_by_support_until__date')
 				.then ({ is_accessible_by_support_until__date }) ->
 					Date.parse(is_accessible_by_support_until__date)
 
@@ -819,7 +831,7 @@ describe 'Device Model', ->
 			it 'should revoke support access', ->
 				balena.models.device.revokeSupportAccess(@device.id)
 				.then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: 'is_accessible_by_support_until__date')
 				.then ({ is_accessible_by_support_until__date }) ->
 					m.chai.expect(is_accessible_by_support_until__date).to.be.null
 

--- a/tests/integration/setup.coffee
+++ b/tests/integration/setup.coffee
@@ -72,9 +72,13 @@ exports.resetUser = ->
 		Promise.all [
 			balena.pine.delete
 				resource: 'application'
+				options:
+					$filter: 1: 1
 
 			balena.pine.delete
 				resource: 'user__has__public_key'
+				options:
+					$filter: 1: 1
 
 			balena.pine.delete
 				resource: 'api_key'
@@ -126,6 +130,8 @@ exports.loginPaidUser = ->
 resetApplications = ->
 	balena.pine.delete
 		resource: 'application'
+		options:
+			$filter: 1: 1
 
 exports.givenAnApplication = (beforeFn) ->
 	beforeFn ->
@@ -155,6 +161,8 @@ exports.givenAnApplication = (beforeFn) ->
 resetDevices = ->
 	balena.pine.delete
 		resource: 'device'
+		options:
+			$filter: 1: 1
 
 exports.givenADevice = (beforeFn, extraDeviceProps) ->
 	beforeFn ->

--- a/typing_tests/pine-options.ts
+++ b/typing_tests/pine-options.ts
@@ -14,7 +14,79 @@ export const unkown$selectPropsFixed: BalenaSdk.PineOptions<BalenaSdk.Applicatio
 	$select: ['id', 'app_name'],
 };
 
+export const noTopSelect: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = { // $ExpectError
+	$expand: {
+		owns__device: {
+			$select: 'id',
+		},
+	},
+	$filter: {
+		id: 5,
+	},
+};
+
+export const noTopSelect2: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = { // $ExpectError
+	$filter: {
+		id: 5,
+	},
+};
+
+export const noTopSelectFixed: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$filter: {
+		id: 5,
+	},
+};
+
+export const noNestedSelect: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: { // $ExpectError
+		owns__device: {
+			$filter: {
+				id: 5,
+			},
+		},
+	},
+	$filter: {
+		id: 5,
+	},
+};
+
+export const noNestedSelect2: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: { // $ExpectError
+		owns__device: {
+			$expand: {
+				device_environment_variable: {
+					$select: ['name', 'value'],
+				},
+			},
+		},
+	},
+};
+
+export const noNestedSelectFixed: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: {
+		owns__device: {
+			$select: 'id',
+			$expand: {
+				device_environment_variable: {
+					$select: ['name', 'value'],
+				},
+			},
+			$filter: {
+				id: 5,
+			},
+		},
+	},
+	$filter: {
+		id: 5,
+	},
+};
+
 export const unkown$selectPropsInside$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: { // $ExpectError
 		owns__device: {
 			$select: ['asdf', 'note', 'device_name', 'uuid'],
@@ -23,6 +95,17 @@ export const unkown$selectPropsInside$expand: BalenaSdk.PineOptions<BalenaSdk.Ap
 };
 
 export const unkown$expandProps: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: {
+		asdf: { $select: ['id'] }, // $ExpectError
+		owns__device: {
+			$select: ['note', 'device_name', 'uuid'],
+		},
+	},
+};
+
+export const unkown$expandPropsNoSelect: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: {
 		asdf: {}, // $ExpectError
 		owns__device: {
@@ -32,6 +115,7 @@ export const unkown$expandProps: BalenaSdk.PineOptions<BalenaSdk.Application> = 
 };
 
 export const unkownODataPropInside$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: {
 		owns__device: {
 			asdf: {}, // $ExpectError
@@ -41,6 +125,7 @@ export const unkownODataPropInside$expand: BalenaSdk.PineOptions<BalenaSdk.Appli
 };
 
 export const unkown$expandPropsFixed: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: {
 		owns__device: {
 			$select: ['note', 'device_name', 'uuid'],
@@ -49,8 +134,10 @@ export const unkown$expandPropsFixed: BalenaSdk.PineOptions<BalenaSdk.Applicatio
 };
 
 export const unkown$selectPropInsideNested$expandWith$select: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: {
 		owns__device: {
+			$select: 'id',
 			$expand: {
 				asdf: { // $ExpectError
 					$select: ['asdf'],
@@ -64,6 +151,7 @@ export const unkown$selectPropInsideNested$expandWith$select: BalenaSdk.PineOpti
 };
 
 export const unkown$selectPropInsideNested$expandWith$select2: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: { // $ExpectError
 		owns__device: {
 			$select: ['note', 'device_name', 'uuid'],
@@ -77,6 +165,7 @@ export const unkown$selectPropInsideNested$expandWith$select2: BalenaSdk.PineOpt
 };
 
 export const unkown$selectPropInsideNested$expandWith$select2Fixed: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: {
 		owns__device: {
 			$select: ['note', 'device_name', 'uuid'],
@@ -89,7 +178,8 @@ export const unkown$selectPropInsideNested$expandWith$select2Fixed: BalenaSdk.Pi
 	},
 };
 
-export const unkown$expandPropInArray$expands: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+export const arrayString$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
@@ -102,11 +192,47 @@ export const unkown$expandPropInArray$expands: BalenaSdk.PineOptions<BalenaSdk.A
 			},
 		},
 		'depends_on__application',
-		'asdf',
+	],
+};
+
+export const array$expandFixed: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: [
+		{
+			owns__device: {
+				$select: ['note', 'device_name', 'uuid'],
+				$expand: {
+					device_environment_variable: {
+						$select: ['name', 'value'],
+					},
+				},
+			},
+		},
+		{ depends_on__application: { $select: 'id' } },
+	],
+};
+
+
+export const unkown$expandPropInArray$expands: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: [
+		{
+			owns__device: {
+				$select: ['note', 'device_name', 'uuid'],
+				$expand: {
+					device_environment_variable: {
+						$select: ['name', 'value'],
+					},
+				},
+			},
+		},
+		{ depends_on__application: { $select: 'id' } },
+		{ asdf: { $select: 'id' } }, // $ExpectError
 	],
 };
 
 export const unkownODataPropInArray$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
@@ -119,11 +245,12 @@ export const unkownODataPropInArray$expand: BalenaSdk.PineOptions<BalenaSdk.Appl
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const unkown$selectPropInArray$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
@@ -135,11 +262,12 @@ export const unkown$selectPropInArray$expand: BalenaSdk.PineOptions<BalenaSdk.Ap
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const unkownNested$expandPropInsideArray$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
@@ -152,11 +280,12 @@ export const unkownNested$expandPropInsideArray$expand: BalenaSdk.PineOptions<Ba
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const unkownNested$expandWith$selectPropInsideArray$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
@@ -171,11 +300,12 @@ export const unkownNested$expandWith$selectPropInsideArray$expand: BalenaSdk.Pin
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const unkown$selectPropInsideNestedArray$expand: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
@@ -187,11 +317,12 @@ export const unkown$selectPropInsideNestedArray$expand: BalenaSdk.PineOptions<Ba
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const nestedArray$expandWithManyErrors1: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
@@ -206,11 +337,12 @@ export const nestedArray$expandWithManyErrors1: BalenaSdk.PineOptions<BalenaSdk.
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const nestedArray$expandWithManyErrors2: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
@@ -225,11 +357,12 @@ export const nestedArray$expandWithManyErrors2: BalenaSdk.PineOptions<BalenaSdk.
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const Nested$expandInArray$expandsFixed: BalenaSdk.PineOptions<BalenaSdk.Application> = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
@@ -247,7 +380,7 @@ export const Nested$expandInArray$expandsFixed: BalenaSdk.PineOptions<BalenaSdk.
 				$select: 'id',
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
@@ -306,9 +439,11 @@ export const unkownPropIn$filterFixed: BalenaSdk.PineOptions<
 export const unknown$any$filterPropInsideArray$expand: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: [ // $ExpectError
 		{
 			owns__device: {
+				$select: 'id',
 				$filter: {
 					device_name: null,
 					note: 'note',
@@ -325,16 +460,18 @@ export const unknown$any$filterPropInsideArray$expand: BalenaSdk.PineOptions<
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const unknown$any$filterPropInsideArray$expandPlural: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
+				$select: 'id',
 				$filter: {
 					device_name: null,
 					note: 'note',
@@ -354,16 +491,18 @@ export const unknown$any$filterPropInsideArray$expandPlural: BalenaSdk.PineOptio
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const unknown$any$filterPropInsideArray$expandFixed: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
+				$select: 'id',
 				$filter: {
 					device_name: null,
 					note: 'note',
@@ -380,16 +519,18 @@ export const unknown$any$filterPropInsideArray$expandFixed: BalenaSdk.PineOption
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const unknown$filterPropInsideNested$expand: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
+				$select: 'id',
 				$filter: {
 					device_name: null,
 					note: 'note',
@@ -406,6 +547,7 @@ export const unknown$filterPropInsideNested$expand: BalenaSdk.PineOptions<
 				},
 				$expand: {
 					device_environment_variable: {
+						$select: ['name', 'value'],
 						$filter: {
 							name: 'name',
 							value: null,
@@ -415,7 +557,7 @@ export const unknown$filterPropInsideNested$expand: BalenaSdk.PineOptions<
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
@@ -424,9 +566,11 @@ export const unknown$filterPropInsideNested$expand: BalenaSdk.PineOptions<
 export const unknown$filterPropInsideNested$expandWithUnknown$any$filterProp: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
+				$select: 'id',
 				$filter: {
 					device_name: null,
 					note: 'note',
@@ -446,6 +590,7 @@ export const unknown$filterPropInsideNested$expandWithUnknown$any$filterProp: Ba
 				},
 				$expand: {
 					device_environment_variable: {
+						$select: ['name', 'value'],
 						$filter: {
 							name: 'name',
 							value: null,
@@ -455,7 +600,7 @@ export const unknown$filterPropInsideNested$expandWithUnknown$any$filterProp: Ba
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
@@ -478,6 +623,7 @@ export const deviceOptionsEValid2: BalenaSdk.PineOptions<
 export const appOptionsEValid2: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: {
 		owns__device: {
 			$select: ['note', 'device_name', 'uuid'],
@@ -485,23 +631,10 @@ export const appOptionsEValid2: BalenaSdk.PineOptions<
 	},
 };
 
-export const appOptionsEValid4: BalenaSdk.PineOptions<
-	BalenaSdk.Application
-> = {
-	$expand: {
-		owns__device: {
-			$expand: {
-				device_environment_variable: {
-					$select: ['name', 'value'],
-				},
-			},
-		},
-	},
-};
-
 export const appOptionsEValid5: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: {
 		owns__device: {
 			$select: ['note', 'device_name', 'uuid'],
@@ -517,6 +650,7 @@ export const appOptionsEValid5: BalenaSdk.PineOptions<
 export const appOptionsEValid20: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
@@ -528,7 +662,7 @@ export const appOptionsEValid20: BalenaSdk.PineOptions<
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
@@ -542,6 +676,7 @@ export type DeviceIsRunningReleaseAssociatedResourceType = InferAssociatedResour
 export const appOptionsEValid30: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
@@ -553,13 +688,14 @@ export const appOptionsEValid30: BalenaSdk.PineOptions<
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
 export const appOptionsEValid31: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
@@ -574,7 +710,7 @@ export const appOptionsEValid31: BalenaSdk.PineOptions<
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
@@ -641,9 +777,11 @@ export const appOptionsEValidf2: BalenaSdk.PineOptions<
 export const appOptionsEFValid1: BalenaSdk.PineOptions<
 	BalenaSdk.Application
 > = {
+	$select: 'id',
 	$expand: [
 		{
 			owns__device: {
+				$select: 'id',
 				$filter: {
 					device_name: null,
 					note: 'note',
@@ -660,6 +798,7 @@ export const appOptionsEFValid1: BalenaSdk.PineOptions<
 				},
 				$expand: {
 					device_environment_variable: {
+						$select: ['name', 'value'],
 						$filter: {
 							name: 'name',
 							value: null,
@@ -668,7 +807,7 @@ export const appOptionsEFValid1: BalenaSdk.PineOptions<
 				},
 			},
 		},
-		'depends_on__application',
+		{ depends_on__application: { $select: 'id' } },
 	],
 };
 
@@ -678,6 +817,7 @@ export const anyObjectOptionsValid1: BalenaSdk.PineOptions<
 	$select: ['id', 'app_name'],
 	$expand: {
 		owns__device: {
+			$select: ['note', 'device_name', 'uuid'],
 			$filter: {
 				device_name: null,
 				note: 'note',
@@ -694,6 +834,7 @@ export const anyObjectOptionsValid1: BalenaSdk.PineOptions<
 			},
 			$expand: {
 				device_environment_variable: {
+					$select: ['name', 'value'],
 					$filter: {
 						name: 'name',
 						value: null,

--- a/typings/balena-pine.d.ts
+++ b/typings/balena-pine.d.ts
@@ -7,9 +7,15 @@ declare namespace BalenaPine {
 		delete<T>(
 			params: PineClient.ParamsObjWithId<T> | PineClient.ParamsObj<T>,
 		): Promise<'OK'>;
-		get<T>(params: PineClient.ParamsObjWithId<T>): Promise<T>;
-		get<T>(params: PineClient.ParamsObj<T>): Promise<T[]>;
-		get<T, Result>(params: PineClient.ParamsObj<T>): Promise<Result>;
+		get<T>(
+			params: PineClient.ParamsObjWithSelect<T> & PineClient.WithId,
+		): Promise<T>;
+		get<T>(params: PineClient.ParamsObjWithSelect<T>): Promise<T[]>;
+		get<T, Result>(
+			params: Result extends number
+				? PineClient.ParamsObj<T>
+				: PineClient.ParamsObjWithSelect<T>,
+		): Promise<Result>;
 		post<T>(params: PineClient.ParamsObj<T>): Promise<T>;
 		patch<T>(
 			params: PineClient.ParamsObjWithId<T> | PineClient.ParamsObj<T>,

--- a/typings/balena-pine.d.ts
+++ b/typings/balena-pine.d.ts
@@ -5,7 +5,7 @@ import * as PineClient from './pinejs-client-core';
 declare namespace BalenaPine {
 	interface Pine {
 		delete<T>(
-			params: PineClient.ParamsObjWithId<T> | PineClient.ParamsObj<T>,
+			params: PineClient.ParamsObjWithId<T> | PineClient.ParamsObjWithFilter<T>,
 		): Promise<'OK'>;
 		get<T>(
 			params: PineClient.ParamsObjWithSelect<T> & PineClient.WithId,
@@ -18,7 +18,7 @@ declare namespace BalenaPine {
 		): Promise<Result>;
 		post<T>(params: PineClient.ParamsObj<T>): Promise<T>;
 		patch<T>(
-			params: PineClient.ParamsObjWithId<T> | PineClient.ParamsObj<T>,
+			params: PineClient.ParamsObjWithId<T> | PineClient.ParamsObjWithFilter<T>,
 		): Promise<'OK'>;
 		upsert<T>(params: PineClient.UpsertParams<T>): Promise<T | 'OK'>;
 	}

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -281,6 +281,8 @@ declare namespace BalenaSdk {
 		created_at: string;
 		name: string;
 		description: string | null;
+
+		is_of__actor: PineDeferred;
 	}
 
 	interface Application {
@@ -365,16 +367,16 @@ declare namespace BalenaSdk {
 		| null;
 
 	interface Release {
-		commit: string;
-		created_at: string;
 		id: number;
+		created_at: string;
+		commit: string;
 		composition: string | null;
+		status: ReleaseStatus;
 		source: string;
 		build_log: string | null;
-		end_timestamp: string;
 		start_timestamp: string;
-		status: ReleaseStatus;
 		update_timestamp: string | null;
+		end_timestamp: string;
 
 		is_created_by__user: OptionalNavigationResource<User>;
 		belongs_to__application: NavigationResource<Application>;
@@ -603,8 +605,8 @@ declare namespace BalenaSdk {
 	}
 
 	interface ServiceInstance {
-		created_at: string;
 		id: number;
+		created_at: string;
 		service_type: string;
 		ip_address: string;
 		last_heartbeat: string;
@@ -612,6 +614,7 @@ declare namespace BalenaSdk {
 
 	interface Service {
 		id: number;
+		created_at: string;
 		service_name: string;
 		application: NavigationResource<Application>;
 	}

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -31,6 +31,8 @@ declare namespace BalenaSdk {
 	type PineFilter<T> = Pine.Filter<T>;
 	type PineExpand<T> = Pine.Expand<T>;
 	type PineOptions<T> = Pine.ODataOptions<T>;
+	type PineOptionsWithSelect<T> = Pine.ODataOptionsWithSelect<T>;
+	type PineOptionsWithFilter<T> = Pine.ODataOptionsWithFilter<T>;
 	type PineSubmitBody<T> = Pine.SubmitBody<T>;
 	type PineParams<T> = Pine.ParamsObj<T>;
 	type PineParamsWithId<T> = Pine.ParamsObjWithId<T>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -232,6 +232,9 @@ export interface ODataOptions<T> {
 export type ODataOptionsWithSelect<T> = ODataOptions<T> &
 	Required<Pick<ODataOptions<T>, '$select'>>;
 
+export type ODataOptionsWithFilter<T> = ODataOptions<T> &
+	Required<Pick<ODataOptions<T>, '$filter'>>;
+
 export type SubmitBody<T> = {
 	[k in keyof T]?: T[k] extends AssociatedResource ? number | null : T[k];
 };
@@ -259,7 +262,7 @@ export interface ParamsObjWithSelect<T> extends ParamsObj<T> {
 }
 
 export interface ParamsObjWithFilter<T> extends ParamsObj<T> {
-	options: ODataOptions<T> & Required<Pick<ODataOptions<T>, '$filter'>>;
+	options: ODataOptionsWithFilter<T>;
 }
 
 export interface UpsertParams<T>

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -254,6 +254,10 @@ export interface ParamsObjWithId<T> extends ParamsObj<T> {
 	id: number;
 }
 
+export interface ParamsObjWithSelect<T> extends ParamsObj<T> {
+	options: ODataOptionsWithSelect<T>;
+}
+
 export interface UpsertParams<T>
 	extends Omit<ParamsObj<T>, 'id' | 'method' | 'options'> {
 	id: SubmitBody<T>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -221,7 +221,7 @@ export type Expand<T> = BaseExpand<T> | Array<BaseExpand<T>>;
 export type ODataMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
 export interface ODataOptions<T> {
-	$select?: Array<SelectableProps<T>> | SelectableProps<T> | '*';
+	$select?: Array<SelectableProps<T>> | SelectableProps<T>;
 	$filter?: Filter<T>;
 	$expand?: Expand<T>;
 	$orderby?: OrderBy;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -214,9 +214,7 @@ export type ResourceExpand<T> = {
 	[k in ExpandableProps<T>]?: ODataOptions<InferAssociatedResourceType<T[k]>>;
 };
 
-type BaseExpand<T> = ResourceExpand<T> | ExpandableProps<T>;
-
-export type Expand<T> = BaseExpand<T> | Array<BaseExpand<T>>;
+export type Expand<T> = ResourceExpand<T> | Array<ResourceExpand<T>>;
 
 export type ODataMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -258,6 +258,10 @@ export interface ParamsObjWithSelect<T> extends ParamsObj<T> {
 	options: ODataOptionsWithSelect<T>;
 }
 
+export interface ParamsObjWithFilter<T> extends ParamsObj<T> {
+	options: ODataOptions<T> & Required<Pick<ODataOptions<T>, '$filter'>>;
+}
+
 export interface UpsertParams<T>
 	extends Omit<ParamsObj<T>, 'id' | 'method' | 'options'> {
 	id: SubmitBody<T>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -211,7 +211,9 @@ type FilterExpressions<T> = {
 };
 
 export type ResourceExpand<T> = {
-	[k in ExpandableProps<T>]?: ODataOptions<InferAssociatedResourceType<T[k]>>;
+	[k in ExpandableProps<T>]?: ODataOptionsWithSelect<
+		InferAssociatedResourceType<T[k]>
+	>;
 };
 
 export type Expand<T> = ResourceExpand<T> | Array<ResourceExpand<T>>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -229,6 +229,9 @@ export interface ODataOptions<T> {
 	$skip?: number;
 }
 
+export type ODataOptionsWithSelect<T> = ODataOptions<T> &
+	Required<Pick<ODataOptions<T>, '$select'>>;
+
 export type SubmitBody<T> = {
 	[k in keyof T]?: T[k] extends AssociatedResource ? number | null : T[k];
 };


### PR DESCRIPTION
That's on top of https://github.com/balena-io/balena-sdk/pull/772, so let's get that in first.

In v6 $select will be required in all GET requests, so we now have to hard-code $select all fields available in open-balena, to all the GET requests found in the available methods.
If we also added non-open-balena fields, then requests to an open-balena instance would fail with 400.

Resolves: #764
Change-type: major
See: balena-io/balena-api#2226
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
