### PR TITLE
Properly type optional navigation resources

### DIFF
--- a/lib/util/local-mode.ts
+++ b/lib/util/local-mode.ts
@@ -15,10 +15,7 @@ export const LOCAL_MODE_SUPPORT_PROPERTIES = [
 ] as const;
 
 export const checkLocalModeSupported = (
-	device: Pick<
-		BalenaSdk.Device,
-		(typeof LOCAL_MODE_SUPPORT_PROPERTIES)[number]
-	>,
+	device: Pick<BalenaSdk.Device, typeof LOCAL_MODE_SUPPORT_PROPERTIES[number]>,
 ): void => {
 	if (!isProvisioned(device)) {
 		throw new Error('Device is not yet fully provisioned');

--- a/typing_tests/pine-options.ts
+++ b/typing_tests/pine-options.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 import * as BalenaSdk from '../typings/balena-sdk';
+import { InferAssociatedResourceType } from '../typings/pinejs-client-core';
 
 // This file is in .prettierignore, since otherwise
 // the $ExpectError commentswould move to the wrong place
@@ -529,6 +530,53 @@ export const appOptionsEValid20: BalenaSdk.PineOptionsFor<
 		'depends_on__application',
 	],
 };
+
+// valid OptionalNavigationResource $selects & $expands
+
+// $ExpectType "is_created_by__user" | "belongs_to__application" | "contains__image" | "should_be_running_on__application" | "is_running_on__device" | "should_be_running_on__device" | "release_tag"
+export type ReleaseExpandableProps = BalenaSdk.PineExpandableProps<BalenaSdk.Release>;
+// $ExpectType Release
+export type DeviceIsRunningReleaseAssociatedResourceType = InferAssociatedResourceType<BalenaSdk.Device['is_running__release']>;
+
+export const appOptionsEValid30: BalenaSdk.PineOptionsFor<
+	BalenaSdk.Application
+> = {
+	$expand: [
+		{
+			owns__device: {
+				$select: ['note', 'device_name', 'uuid', 'is_running__release'],
+				$expand: {
+					device_environment_variable: {
+						$select: ['name', 'value'],
+					},
+				},
+			},
+		},
+		'depends_on__application',
+	],
+};
+
+export const appOptionsEValid31: BalenaSdk.PineOptionsFor<
+	BalenaSdk.Application
+> = {
+	$expand: [
+		{
+			owns__device: {
+				$select: ['note', 'device_name', 'uuid'],
+				$expand: {
+					is_running__release: {
+						$select: ['id', 'commit'],
+					},
+					device_environment_variable: {
+						$select: ['name', 'value'],
+					},
+				},
+			},
+		},
+		'depends_on__application',
+	],
+};
+
 
 // valid filters
 

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -17,6 +17,9 @@ declare namespace BalenaSdk {
 	 * When expanded hold an array with a single element.
 	 */
 	type NavigationResource<T = WithId> = Pine.NavigationResource<T>;
+	type OptionalNavigationResource<T = WithId> = Pine.OptionalNavigationResource<
+		T
+	>;
 	/**
 	 * When expanded holds an array, otherwise the property is not present.
 	 * Selecting is not suggested,
@@ -292,9 +295,9 @@ declare namespace BalenaSdk {
 
 		application_type: NavigationResource<ApplicationType>;
 		is_for__device_type: NavigationResource<DeviceType>;
-		depends_on__application: NavigationResource<Application>;
+		depends_on__application: OptionalNavigationResource<Application>;
 		organization: NavigationResource<Organization>;
-		should_be_running__release: NavigationResource<Release>;
+		should_be_running__release: OptionalNavigationResource<Release>;
 
 		application_config_variable: ReverseNavigationResource<ApplicationVariable>;
 		application_environment_variable: ReverseNavigationResource<
@@ -375,7 +378,7 @@ declare namespace BalenaSdk {
 		status: ReleaseStatus;
 		update_timestamp: string | null;
 
-		is_created_by__user: NavigationResource<User>;
+		is_created_by__user: OptionalNavigationResource<User>;
 		belongs_to__application: NavigationResource<Application>;
 
 		contains__image: ReverseNavigationResource<{
@@ -528,17 +531,22 @@ declare namespace BalenaSdk {
 		supervisor_version: string;
 		uuid: string;
 		vpn_address: string | null;
-		should_be_managed_by__supervisor_release: number;
 		api_heartbeat_state: 'online' | 'offline' | 'timeout' | 'unknown';
 
 		is_of__device_type: NavigationResource<DeviceType>;
+		// the schema has this as a nullable, but for simplicity we have it as non-optional
 		belongs_to__application: NavigationResource<Application>;
 		belongs_to__organization: NavigationResource<Organization>;
-		belongs_to__user: NavigationResource<User>;
-		is_running__release: NavigationResource<Release>;
-		should_be_running__release: NavigationResource<Release>;
-		is_managed_by__service__instance: NavigationResource<ServiceInstance>;
-		is_managed_by__device: NavigationResource<Device>;
+		belongs_to__user: OptionalNavigationResource<User>;
+		is_running__release: OptionalNavigationResource<Release>;
+		should_be_running__release: OptionalNavigationResource<Release>;
+		is_managed_by__service_instance: OptionalNavigationResource<
+			ServiceInstance
+		>;
+		is_managed_by__device: OptionalNavigationResource<Device>;
+		should_be_managed_by__supervisor_release: OptionalNavigationResource<
+			SupervisorRelease
+		>;
 
 		device_config_variable: ReverseNavigationResource<DeviceVariable>;
 		device_environment_variable: ReverseNavigationResource<DeviceVariable>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -12,7 +12,7 @@ export interface PineDeferred {
  * When not selected-out holds a deferred.
  * When expanded hold an array with a single element.
  */
-export type NavigationResource<T = WithId> = T[] | PineDeferred;
+export type NavigationResource<T = WithId> = [T] | PineDeferred;
 
 /**
  * When expanded holds an array, otherwise the property is not present.

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -13,6 +13,11 @@ export interface PineDeferred {
  * When expanded hold an array with a single element.
  */
 export type NavigationResource<T = WithId> = [T] | PineDeferred;
+export type OptionalNavigationResource<T = WithId> =
+	| []
+	| [T]
+	| PineDeferred
+	| null;
 
 /**
  * When expanded holds an array, otherwise the property is not present.
@@ -23,9 +28,11 @@ export type ReverseNavigationResource<T = WithId> = T[] | undefined;
 
 export type AssociatedResource<T = WithId> =
 	| NavigationResource<T>
+	| OptionalNavigationResource<T>
 	| ReverseNavigationResource<T>;
 
-type InferAssociatedResourceType<T> = T extends AssociatedResource & any[]
+export type InferAssociatedResourceType<T> = T extends AssociatedResource &
+	any[]
 	? T[number]
 	: never;
 

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -25,7 +25,7 @@ export type AssociatedResource<T = WithId> =
 	| NavigationResource<T>
 	| ReverseNavigationResource<T>;
 
-type InferAssociatedResourceType<T> = T extends (AssociatedResource & any[])
+type InferAssociatedResourceType<T> = T extends AssociatedResource & any[]
 	? T[number]
 	: never;
 
@@ -68,14 +68,14 @@ type AssociatedResourceFilter<T> = T extends NonNullable<
 	ReverseNavigationResource
 >
 	? FilterObj<InferAssociatedResourceType<T>>
-	: (FilterObj<InferAssociatedResourceType<T>> | number | null);
+	: FilterObj<InferAssociatedResourceType<T>> | number | null;
 
 type ResourceObjFilterPropValue<
 	T,
 	k extends keyof T
 > = T[k] extends AssociatedResource
 	? AssociatedResourceFilter<T[k]>
-	: (T[k] | FilterExpressions<T[k]> | null);
+	: T[k] | FilterExpressions<T[k]> | null;
 
 type ResourceObjFilter<T> = {
 	[k in keyof T]?: ResourceObjFilterPropValue<T, k>;


### PR DESCRIPTION
Also improves the NavigationResource typings to use an one item tuple, instead of an array.

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
