### PR TITLE
Drop the imageMakerUrl & apiKey constructor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ var balena = require('balena-sdk')({
 Where the factory method accepts the following options:
 * `apiUrl`, string, *optional*, is the balena API url. Defaults to `https://api.balena-cloud.com/`,
 * `builderUrl`, string, *optional* , is the balena builder url. Defaults to `https://builder.balena-cloud.com/`,
-* `imageMakerUrl`, string, *optional* *deprecated* , is the balena image maker url. Defaults to `https://img.balena-cloud.com/`,
 * `deviceUrlsBase`, string, *optional*, is the base balena device API url. Defaults to `balena-devices.com`,
 * `dataDirectory`, string, *optional*, *ignored in the browser*, is the directory where the user settings are stored, normally retrieved like `require('balena-settings-client').get('dataDirectory')`. Defaults to `$HOME/.balena`,
 * `isBrowser`, boolean, *optional*, is the flag to tell if the module works in the browser. If not set will be computed based on the presence of the global `window` value,

--- a/lib/balena.coffee
+++ b/lib/balena.coffee
@@ -72,8 +72,6 @@ getSdk = (opts = {}) ->
 	defaults opts,
 		apiUrl: 'https://api.balena-cloud.com/'
 		builderUrl: 'https://builder.balena-cloud.com/'
-		# deprecated
-		imageMakerUrl: 'https://img.balena-cloud.com/'
 		isBrowser: window?
 		# API version is configurable but only do so if you know what you're doing,
 		# as the SDK is directly tied to a specific version.

--- a/lib/balena.coffee
+++ b/lib/balena.coffee
@@ -86,6 +86,11 @@ getSdk = (opts = {}) ->
 		defaults opts,
 			dataDirectory: settings.get('dataDirectory')
 
+	if 'apiKey' of opts
+		# to prevent exposing it to balena-request directly
+		# which would add it as a query sting option
+		opts.apiKey = null
+
 	auth = new BalenaAuth(opts)
 	request = getRequest(assign({}, opts, { auth }))
 	pine = getPine(assign({}, opts, { auth, request }))

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "clean": "rimraf build",
+    "test:fast": "gulp build-node && npm run test:node",
     "test": "npm run build && npm run test:all",
     "test:all": "npm run test:ts-compatibility && npm run test:typings && npm run test:node && npm run test:browser",
     "test:node": "gulp test",

--- a/tests/integration/balena.spec.coffee
+++ b/tests/integration/balena.spec.coffee
@@ -1,3 +1,4 @@
+_ = require('lodash')
 m = require('mochainon')
 
 { balena, getSdk, sdkOpts, credentials, givenLoggedInUser } = require('./setup')
@@ -119,3 +120,22 @@ describe 'Balena SDK', ->
 			mockBalena = getSdk.fromSharedOptions()
 			m.chai.expect(mockBalena).to.include.keys(validKeys)
 
+	describe 'constructor options', ->
+
+		describe 'Given an apiKey', ->
+
+			givenLoggedInUser(before)
+
+			before ->
+				balena.models.apiKey.create('apiKey', 'apiKeyDescription')
+				.then (@testApiKey) =>
+					m.chai.expect(@testApiKey).to.be.a('string')
+					balena.auth.logout()
+
+			it 'should not be used in API requests', ->
+				m.chai.expect(@testApiKey).to.be.a('string')
+				testSdkOpts = _.assign({}, sdkOpts, { apiKey: @testApiKey })
+				testSdk = getSdk(testSdkOpts)
+				promise = testSdk.models.apiKey.getAll()
+				m.chai.expect(promise).to.be.rejected
+					.and.eventually.have.property('code', 'BalenaNotLoggedIn')

--- a/tests/integration/setup.coffee
+++ b/tests/integration/setup.coffee
@@ -28,7 +28,6 @@ else
 		dataDirectory: settings.get('dataDirectory')
 
 _.assign opts,
-	apiKey: null
 	isBrowser: IS_BROWSER,
 	retries: 3
 

--- a/tests/integration/setup.d.ts
+++ b/tests/integration/setup.d.ts
@@ -8,7 +8,6 @@ export const getSdk: BalenaSdk.SdkConstructor;
 export const sdkOpts: {
 	apiUrl: string;
 	dataDirectory: string;
-	apiKey: string | null;
 	isBrowser: boolean;
 	retries: number;
 };

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -1346,10 +1346,6 @@ declare namespace BalenaSdk {
 		 * @deprecated Use balena.auth.loginWithToken(apiKey) instead
 		 */
 		apiKey?: string;
-		/**
-		 * @deprecated Not used
-		 */
-		imageMakerUrl?: string;
 		builderUrl?: string;
 		dataDirectory?: string;
 		isBrowser?: boolean;

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -1342,10 +1342,6 @@ declare namespace BalenaSdk {
 
 	interface SdkOptions {
 		apiUrl?: string;
-		/**
-		 * @deprecated Use balena.auth.loginWithToken(apiKey) instead
-		 */
-		apiKey?: string;
 		builderUrl?: string;
 		dataDirectory?: string;
 		isBrowser?: boolean;


### PR DESCRIPTION
* The `imageMakerUrl` was deprecated and no longer used since v12.12.0, so it's just removing it from the docs.
* For the `apiKey`, event though it was deprecated, it seems that balena-request was still picking this up from the constructor options, in case a use was still providing it. So we are now actively preventing that to be passed down. (The equivalent suggested method is `sdk.auth.loginWithToken()`.)

Change-type: major
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
