### PR TITLE
typings: Add a PineOptionsWithSelect variant

### DIFF
--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -35,7 +35,7 @@ errors = require('balena-errors')
 } = require('../util')
 { normalizeDeviceOsVersion } = require('../util/device-os-version')
 {
-	getCurrentServiceDetailsPineOptions,
+	getCurrentServiceDetailsPineExpand,
 	generateCurrentServiceDetails,
 } = require('../util/device-service-details')
 
@@ -163,7 +163,8 @@ getApplicationModel = (deps, opts) ->
 
 		serviceOptions = mergePineOptions
 			$expand: [
-				owns__device: getCurrentServiceDetailsPineOptions(false)
+				owns__device:
+					$expand: getCurrentServiceDetailsPineExpand(false)
 			]
 		, options
 
@@ -277,7 +278,8 @@ getApplicationModel = (deps, opts) ->
 
 		serviceOptions = mergePineOptions
 			$expand: [
-				owns__device: getCurrentServiceDetailsPineOptions(false)
+				owns__device:
+					$expand: getCurrentServiceDetailsPineExpand(false)
 			]
 		, options
 

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -48,7 +48,7 @@ deviceStatus = require('balena-device-status')
 	normalizeDeviceOsVersion
 } = require('../util/device-os-version')
 {
-	getCurrentServiceDetailsPineOptions,
+	getCurrentServiceDetailsPineExpand,
 	generateCurrentServiceDetails,
 } = require('../util/device-service-details')
 {
@@ -391,7 +391,7 @@ getDeviceModel = (deps, opts) ->
 		callback = findCallback(arguments)
 
 		exports.get uuidOrId,
-			mergePineOptions(getCurrentServiceDetailsPineOptions(true), options)
+			mergePineOptions($expand: getCurrentServiceDetailsPineExpand(true), options)
 		.then(generateCurrentServiceDetails)
 		.asCallback(callback)
 

--- a/lib/util/device-service-details.ts
+++ b/lib/util/device-service-details.ts
@@ -7,52 +7,50 @@ import {
 	GatewayDownload,
 	Image,
 	ImageInstall,
-	PineOptions,
+	PineExpand,
 	Release,
 	Service,
 } from '../../typings/balena-sdk';
 
-// Pine options necessary for getting raw service data for a device
-export const getCurrentServiceDetailsPineOptions = (expandRelease: boolean) => {
-	const pineOptions: PineOptions<DeviceWithImageInstalls> = {
-		$expand: {
-			image_install: {
-				$select: ['id', 'download_progress', 'status', 'install_date'],
-				$filter: {
-					status: {
-						$ne: 'deleted',
-					},
-				},
-				$expand: {
-					image: {
-						$select: ['id'],
-						$expand: {
-							is_a_build_of__service: {
-								$select: ['id', 'service_name'],
-							},
-						},
-					},
-					...(expandRelease && {
-						is_provided_by__release: {
-							$select: ['id', 'commit'],
-						},
-					}),
+// Pine expand options necessary for getting raw service data for a device
+export const getCurrentServiceDetailsPineExpand = (expandRelease: boolean) => {
+	const pineExpand: PineExpand<DeviceWithImageInstalls> = {
+		image_install: {
+			$select: ['id', 'download_progress', 'status', 'install_date'],
+			$filter: {
+				status: {
+					$ne: 'deleted',
 				},
 			},
-			gateway_download: {
-				$select: ['id', 'download_progress', 'status'],
-				$filter: {
-					status: {
-						$ne: 'deleted',
+			$expand: {
+				image: {
+					$select: ['id'],
+					$expand: {
+						is_a_build_of__service: {
+							$select: ['id', 'service_name'],
+						},
 					},
 				},
-				$expand: {
-					image: {
-						$select: ['id'],
-						$expand: {
-							is_a_build_of__service: {
-								$select: ['id', 'service_name'],
-							},
+				...(expandRelease && {
+					is_provided_by__release: {
+						$select: ['id', 'commit'],
+					},
+				}),
+			},
+		},
+		gateway_download: {
+			$select: ['id', 'download_progress', 'status'],
+			$filter: {
+				status: {
+					$ne: 'deleted',
+				},
+			},
+			$expand: {
+				image: {
+					$select: ['id'],
+					$expand: {
+						is_a_build_of__service: {
+							$select: ['id', 'service_name'],
 						},
 					},
 				},
@@ -60,7 +58,7 @@ export const getCurrentServiceDetailsPineOptions = (expandRelease: boolean) => {
 		},
 	};
 
-	return pineOptions;
+	return pineExpand;
 };
 
 interface WithServiceName {

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -123,10 +123,18 @@ export const isDevelopmentVersion = (version: string) =>
 //   * That means $expands within expands are combined
 //   * And $selects within expands override
 // * Any unknown 'extra' options throw an error. Unknown 'default' options are ignored.
-export const mergePineOptions = <R extends {}>(
+export function mergePineOptions<R extends {}>(
+	defaults: Pine.ODataOptionsWithSelect<R>,
+	extras: Pine.ODataOptions<R>,
+): Pine.ODataOptionsWithSelect<R>;
+export function mergePineOptions<R extends {}>(
 	defaults: Pine.ODataOptions<R>,
 	extras: Pine.ODataOptions<R>,
-): Pine.ODataOptions<R> => {
+): Pine.ODataOptions<R>;
+export function mergePineOptions<R extends {}>(
+	defaults: Pine.ODataOptions<R>,
+	extras: Pine.ODataOptions<R>,
+): Pine.ODataOptions<R> {
 	if (!extras) {
 		return defaults;
 	}
@@ -179,7 +187,7 @@ export const mergePineOptions = <R extends {}>(
 	}
 
 	return result;
-};
+}
 
 const mergeExpandOptions = <T>(
 	defaultExpand: Pine.Expand<T> | undefined,

--- a/tests/integration/models/device.spec.coffee
+++ b/tests/integration/models/device.spec.coffee
@@ -518,7 +518,10 @@ describe 'Device Model', ->
 					latitude: 41.383333
 					longitude: 2.183333
 				.then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: [
+						'custom_latitude'
+						'custom_longitude'
+					])
 				.then (device) ->
 					m.chai.expect(device.custom_latitude).to.equal('41.383333')
 					m.chai.expect(device.custom_longitude).to.equal('2.183333')
@@ -528,7 +531,10 @@ describe 'Device Model', ->
 					latitude: 42.383333
 					longitude: 2.283333
 				.then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: [
+						'custom_latitude'
+						'custom_longitude'
+					])
 				.then (device) ->
 					m.chai.expect(device.custom_latitude).to.equal('42.383333')
 					m.chai.expect(device.custom_longitude).to.equal('2.283333')
@@ -556,14 +562,20 @@ describe 'Device Model', ->
 
 			it 'should be able to unset the location of a device by uuid', ->
 				balena.models.device.unsetCustomLocation(@device.uuid).then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: [
+						'custom_latitude'
+						'custom_longitude'
+					])
 				.then (device) ->
 					m.chai.expect(device.custom_latitude).to.equal('')
 					m.chai.expect(device.custom_longitude).to.equal('')
 
 			it 'should be able to unset the location of a device by id', ->
 				balena.models.device.unsetCustomLocation(@device.id).then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: [
+						'custom_latitude'
+						'custom_longitude'
+					])
 				.then (device) ->
 					m.chai.expect(device.custom_latitude).to.equal('')
 					m.chai.expect(device.custom_longitude).to.equal('')
@@ -803,7 +815,7 @@ describe 'Device Model', ->
 				expiryTimestamp = Date.now() + 3600 * 1000
 				promise = balena.models.device.grantSupportAccess(@device.id, expiryTimestamp)
 				.then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: 'is_accessible_by_support_until__date')
 				.then ({ is_accessible_by_support_until__date }) ->
 					Date.parse(is_accessible_by_support_until__date)
 
@@ -819,7 +831,7 @@ describe 'Device Model', ->
 			it 'should revoke support access', ->
 				balena.models.device.revokeSupportAccess(@device.id)
 				.then =>
-					balena.models.device.get(@device.id)
+					balena.models.device.get(@device.id, $select: 'is_accessible_by_support_until__date')
 				.then ({ is_accessible_by_support_until__date }) ->
 					m.chai.expect(is_accessible_by_support_until__date).to.be.null
 

--- a/tests/integration/setup.coffee
+++ b/tests/integration/setup.coffee
@@ -150,6 +150,8 @@ exports.givenAnApplication = (beforeFn) ->
 			balena.pine.get
 				resource: 'device_type'
 				id: @application.is_for__device_type.__id
+				options:
+					$select: 'slug'
 		.then (@applicationDeviceType) =>
 			chai.expect(@applicationDeviceType).to.be.an('object')
 			.that.has.property('slug').that.is.a('string')

--- a/typing_tests/pine-options-with-select.ts
+++ b/typing_tests/pine-options-with-select.ts
@@ -1,0 +1,128 @@
+/// <reference types="node" />
+import * as BalenaSdk from '../typings/balena-sdk';
+import { InferAssociatedResourceType } from '../typings/pinejs-client-core';
+import { AnyObject } from '../typings/utils';
+
+// This file is in .prettierignore, since otherwise
+// the $ExpectError comments would move to the wrong place
+
+export const noTopSelect: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = { // $ExpectError
+	$expand: {
+		owns__device: {
+			$select: 'id',
+		},
+	},
+	$filter: {
+		id: 5,
+	},
+};
+
+export const noTopSelect2: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = { // $ExpectError
+	$filter: {
+		id: 5,
+	},
+};
+
+export const noTopSelectFixed: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$filter: {
+		id: 5,
+	},
+};
+
+export const propExpand: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: 'owns__device',  // $ExpectError
+	$filter: {
+		id: 5,
+	},
+};
+
+export const propExpandArray: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: ['owns__device'],  // $ExpectError
+	$filter: {
+		id: 5,
+	},
+};
+
+export const expandWithNoSelect: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: { // $ExpectError
+		owns__device: {},
+	},
+	$filter: {
+		id: 5,
+	},
+};
+
+export const expandWithNoSelect2: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: { // $ExpectError
+		owns__device: {
+			$filter: {
+				id: 5,
+			},
+		},
+	},
+	$filter: {
+		id: 5,
+	},
+};
+
+export const expandWithNoSelectFixed: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: {
+		owns__device: {
+			$select: 'id',
+		},
+	},
+	$filter: {
+		id: 5,
+	},
+};
+
+export const nestedExpandWithNoSelect3: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: { // $ExpectError
+		owns__device: {
+			$expand: {
+				device_environment_variable: {
+					$select: ['name', 'value'],
+				},
+			},
+		},
+	},
+};
+
+export const nestedExpandWithNoSelect4: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: { // $ExpectError
+		owns__device: {
+			$select: 'id',
+			$expand: {
+				device_environment_variable: {},
+			},
+		},
+	},
+};
+
+export const nestedExpandWithNoSelectFixed: BalenaSdk.PineOptionsWithSelect<BalenaSdk.Application> = {
+	$select: 'id',
+	$expand: {
+		owns__device: {
+			$select: 'id',
+			$expand: {
+				device_environment_variable: {
+					$select: ['name', 'value'],
+				},
+			},
+			$filter: {
+				id: 5,
+			},
+		},
+	},
+	$filter: {
+		id: 5,
+	},
+};

--- a/typing_tests/pine-options.ts
+++ b/typing_tests/pine-options.ts
@@ -4,7 +4,7 @@ import { InferAssociatedResourceType } from '../typings/pinejs-client-core';
 import { AnyObject } from '../typings/utils';
 
 // This file is in .prettierignore, since otherwise
-// the $ExpectError commentswould move to the wrong place
+// the $ExpectError comments would move to the wrong place
 
 export const unkown$selectProps: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$select: ['asdf', 'id', 'app_name', 'id'], // $ExpectError

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -31,6 +31,7 @@ declare namespace BalenaSdk {
 	type PineFilter<T> = Pine.Filter<T>;
 	type PineExpand<T> = Pine.Expand<T>;
 	type PineOptions<T> = Pine.ODataOptions<T>;
+	type PineOptionsWithSelect<T> = Pine.ODataOptionsWithSelect<T>;
 	type PineOptionsWithFilter<T> = Pine.ODataOptionsWithFilter<T>;
 	type PineSubmitBody<T> = Pine.SubmitBody<T>;
 	type PineParams<T> = Pine.ParamsObj<T>;

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -282,6 +282,8 @@ declare namespace BalenaSdk {
 		created_at: string;
 		name: string;
 		description: string | null;
+
+		is_of__actor: PineDeferred;
 	}
 
 	interface Application {
@@ -366,16 +368,16 @@ declare namespace BalenaSdk {
 		| null;
 
 	interface Release {
-		commit: string;
-		created_at: string;
 		id: number;
+		created_at: string;
+		commit: string;
 		composition: string | null;
+		status: ReleaseStatus;
 		source: string;
 		build_log: string | null;
-		end_timestamp: string;
 		start_timestamp: string;
-		status: ReleaseStatus;
 		update_timestamp: string | null;
+		end_timestamp: string;
 
 		is_created_by__user: OptionalNavigationResource<User>;
 		belongs_to__application: NavigationResource<Application>;
@@ -604,8 +606,8 @@ declare namespace BalenaSdk {
 	}
 
 	interface ServiceInstance {
-		created_at: string;
 		id: number;
+		created_at: string;
 		service_type: string;
 		ip_address: string;
 		last_heartbeat: string;
@@ -613,6 +615,7 @@ declare namespace BalenaSdk {
 
 	interface Service {
 		id: number;
+		created_at: string;
 		service_name: string;
 		application: NavigationResource<Application>;
 	}

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -214,9 +214,19 @@ export type ResourceExpand<T> = {
 	[k in ExpandableProps<T>]?: ODataOptions<InferAssociatedResourceType<T[k]>>;
 };
 
+type ResourceExpandWithSelect<T> = {
+	[k in ExpandableProps<T>]?: ODataOptionsWithSelect<
+		InferAssociatedResourceType<T[k]>
+	>;
+};
+
 type BaseExpand<T> = ResourceExpand<T> | ExpandableProps<T>;
 
 export type Expand<T> = BaseExpand<T> | Array<BaseExpand<T>>;
+
+type ExpandWithSelect<T> =
+	| ResourceExpandWithSelect<T>
+	| Array<ResourceExpandWithSelect<T>>;
 
 export type ODataMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
@@ -228,6 +238,11 @@ export interface ODataOptions<T> {
 	$top?: number;
 	$skip?: number;
 }
+
+export type ODataOptionsWithSelect<T> = Omit<ODataOptions<T>, '$expand'> &
+	Required<Pick<ODataOptions<T>, '$select'>> & {
+		$expand?: ExpandWithSelect<T>;
+	};
 
 export type ODataOptionsWithFilter<T> = ODataOptions<T> &
 	Required<Pick<ODataOptions<T>, '$filter'>>;


### PR DESCRIPTION
Since `$select`s are not going to be mandatory on `/v6`, but still is great to require using them per project (eg: in the Dashboard):
* I've removed the merged $select related commits from #621
* extracted the useful parts of (the previously merged) #777 from branch `539-orgs` into this separate PR

The tests atm pass only against the `/v6` api branch, since `/resin` now requires `$select`s.

See: https://github.com/balena-io/balena-sdk/pull/777
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
