### PR TITLE
tests: Use RPi2 for the device.getDisplayName() tests

### DIFF
--- a/tests/integration/models/device.spec.coffee
+++ b/tests/integration/models/device.spec.coffee
@@ -38,12 +38,12 @@ describe 'Device Model', ->
 		describe 'balena.models.device.getDisplayName()', ->
 
 			it 'should get the display name for a known slug', ->
-				promise = balena.models.device.getDisplayName('raspberry-pi')
-				m.chai.expect(promise).to.eventually.equal('Raspberry Pi (v1 / Zero / Zero W)')
+				promise = balena.models.device.getDisplayName('raspberry-pi2')
+				m.chai.expect(promise).to.eventually.equal('Raspberry Pi 2')
 
 			it 'should get the display name given a device type alias', ->
-				promise = balena.models.device.getDisplayName('raspberrypi')
-				m.chai.expect(promise).to.eventually.equal('Raspberry Pi (v1 / Zero / Zero W)')
+				promise = balena.models.device.getDisplayName('raspberrypi2')
+				m.chai.expect(promise).to.eventually.equal('Raspberry Pi 2')
 
 			it 'should eventually be undefined if the slug is invalid', ->
 				promise = balena.models.device.getDisplayName('asdf')
@@ -52,20 +52,20 @@ describe 'Device Model', ->
 		describe 'balena.models.device.getDeviceSlug()', ->
 
 			it 'should eventually be the slug from a display name', ->
-				promise = balena.models.device.getDeviceSlug('Raspberry Pi (v1 / Zero / Zero W)')
-				m.chai.expect(promise).to.eventually.equal('raspberry-pi')
+				promise = balena.models.device.getDeviceSlug('Raspberry Pi 2')
+				m.chai.expect(promise).to.eventually.equal('raspberry-pi2')
 
 			it 'should eventually be the slug if passing already a slug', ->
-				promise = balena.models.device.getDeviceSlug('raspberry-pi')
-				m.chai.expect(promise).to.eventually.equal('raspberry-pi')
+				promise = balena.models.device.getDeviceSlug('raspberry-pi2')
+				m.chai.expect(promise).to.eventually.equal('raspberry-pi2')
 
 			it 'should eventually be undefined if the display name is invalid', ->
 				promise = balena.models.device.getDeviceSlug('asdf')
 				m.chai.expect(promise).to.eventually.be.undefined
 
 			it 'should eventually be the slug if passing an alias', ->
-				promise = balena.models.device.getDeviceSlug('raspberrypi')
-				m.chai.expect(promise).to.eventually.equal('raspberry-pi')
+				promise = balena.models.device.getDeviceSlug('raspberrypi2')
+				m.chai.expect(promise).to.eventually.equal('raspberry-pi2')
 
 		describe 'balena.models.device.getSupportedDeviceTypes()', ->
 


### PR DESCRIPTION
At some point we changed the name field of RPI1 and
had to update these tests to use the new one. We
also recently reverted some OS releases, which as a
result bought back the old name and broke the tests
again. So, I decided to just use RPi2 for this tests
since we don't expect its name to change soon but
also its one of the few devices that also has an alias.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
