### PR TITLE
app.getWithDeviceServiceDetails: Add the release commit in the services

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1045,8 +1045,6 @@ This method does not map exactly to the underlying model: it runs a
 larger prebuilt query, and reformats it into an easy to use and
 understand format. If you want more control, or to see the raw model
 directly, use `application.get(uuidOrId, options)` instead.
-**NOTE:** In contrast with device.getWithServiceDetails() the service details
-in the result of this method do not include the associated commit.
 
 **Kind**: static method of [<code>application</code>](#balena.models.application)  
 **Summary**: Get a single application and its devices, along with each device's

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -250,8 +250,6 @@ getApplicationModel = (deps, opts) ->
 	# larger prebuilt query, and reformats it into an easy to use and
 	# understand format. If you want more control, or to see the raw model
 	# directly, use `application.get(uuidOrId, options)` instead.
-	# **NOTE:** In contrast with device.getWithServiceDetails() the service details
-	# in the result of this method do not include the associated commit.
 	#
 	# @param {String|Number} nameOrSlugOrId - application name (string), slug (string) or id (number)
 	# @param {Object} [options={}] - extra pine options to use
@@ -279,7 +277,7 @@ getApplicationModel = (deps, opts) ->
 
 		serviceOptions = mergePineOptions
 			$expand: [
-				owns__device: getCurrentServiceDetailsPineOptions(false)
+				owns__device: getCurrentServiceDetailsPineOptions(true)
 			]
 		, options
 

--- a/lib/util/device-service-details.ts
+++ b/lib/util/device-service-details.ts
@@ -34,7 +34,7 @@ export const getCurrentServiceDetailsPineOptions = (expandRelease: boolean) => {
 					},
 					...(expandRelease && {
 						is_provided_by__release: {
-							$select: ['id', 'commit'],
+							$select: ['commit'],
 						},
 					}),
 				},

--- a/tests/integration/models/application.spec.coffee
+++ b/tests/integration/models/application.spec.coffee
@@ -681,7 +681,7 @@ describe 'Application Model', ->
 			it 'should retrieve the application and it\'s devices along with service details', ->
 				balena.models.application.getWithDeviceServiceDetails(@application.id)
 				.then (applicationDetails) =>
-					itShouldBeAnApplicationWithDeviceServiceDetails.call(this, applicationDetails, false)
+					itShouldBeAnApplicationWithDeviceServiceDetails.call(this, applicationDetails, true)
 
 		describe 'balena.models.application.getAllWithDeviceServiceDetails()', ->
 

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -783,7 +783,9 @@ declare namespace BalenaSdk {
 					options?: PineOptionsFor<Application>,
 				): Promise<
 					Application & {
-						owns__device: Array<DeviceWithServiceDetails<CurrentService>>;
+						owns__device: Array<
+							DeviceWithServiceDetails<CurrentServiceWithCommit>
+						>;
 					}
 				>;
 				getAppByOwner(


### PR DESCRIPTION
Also removes an unused `id` expand fetched in device.getWithServiceDetails().

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [x] Includes updated documentation
- [x] Includes updated build output
