### PR TITLE
Disable balenaCI auto rebase

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,2 @@
+type: 'node'
+autoRebase: false


### PR DESCRIPTION
Having autorebase enabled could lead to having
more then one instances of the sdk tests running in
parallel, which will result all of them failing, b/c they
will use the same test user, and will also add
unnecessary load to the API. Once we get #582 fixed
we can remove this.

Change-type: patch
See: https://github.com/balena-io/scripts/pull/80
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
