### PR TITLE
Added `getDashboardUrl(id)` to application model

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -969,7 +969,10 @@ balena.models.application.envVar.remove('MyApp', 'VAR', function(error) {
 
 **Example**  
 ```js
-dashboardApplicationUrl = balena.models.application.getDashboardUrl(1)
+balena.models.application.get('MyApp').then(function(application) {
+	const dashboardApplicationUrl = balena.models.application.getDashboardUrl(application.id);
+	console.log(dashboardApplicationUrl);
+});
 ```
 <a name="balena.models.application.getAll"></a>
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -33,6 +33,7 @@ If you feel something is missing, not clear or could be improved, please don't h
                 * [.get(nameOrSlugOrId, key)](#balena.models.application.envVar.get) ⇒ <code>Promise</code>
                 * [.set(nameOrSlugOrId, key, value)](#balena.models.application.envVar.set) ⇒ <code>Promise</code>
                 * [.remove(nameOrSlugOrId, key)](#balena.models.application.envVar.remove) ⇒ <code>Promise</code>
+            * [.getDashboardUrl(id)](#balena.models.application.getDashboardUrl) ⇒ <code>String</code>
             * [.getAll([options])](#balena.models.application.getAll) ⇒ <code>Promise</code>
             * [.getAllWithDeviceServiceDetails([options])](#balena.models.application.getAllWithDeviceServiceDetails) ⇒ <code>Promise</code>
             * [.get(nameOrSlugOrId, [options])](#balena.models.application.get) ⇒ <code>Promise</code>
@@ -343,6 +344,7 @@ balena.models.device.get(123).catch(function (error) {
             * [.get(nameOrSlugOrId, key)](#balena.models.application.envVar.get) ⇒ <code>Promise</code>
             * [.set(nameOrSlugOrId, key, value)](#balena.models.application.envVar.set) ⇒ <code>Promise</code>
             * [.remove(nameOrSlugOrId, key)](#balena.models.application.envVar.remove) ⇒ <code>Promise</code>
+        * [.getDashboardUrl(id)](#balena.models.application.getDashboardUrl) ⇒ <code>String</code>
         * [.getAll([options])](#balena.models.application.getAll) ⇒ <code>Promise</code>
         * [.getAllWithDeviceServiceDetails([options])](#balena.models.application.getAllWithDeviceServiceDetails) ⇒ <code>Promise</code>
         * [.get(nameOrSlugOrId, [options])](#balena.models.application.get) ⇒ <code>Promise</code>
@@ -531,6 +533,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.get(nameOrSlugOrId, key)](#balena.models.application.envVar.get) ⇒ <code>Promise</code>
         * [.set(nameOrSlugOrId, key, value)](#balena.models.application.envVar.set) ⇒ <code>Promise</code>
         * [.remove(nameOrSlugOrId, key)](#balena.models.application.envVar.remove) ⇒ <code>Promise</code>
+    * [.getDashboardUrl(id)](#balena.models.application.getDashboardUrl) ⇒ <code>String</code>
     * [.getAll([options])](#balena.models.application.getAll) ⇒ <code>Promise</code>
     * [.getAllWithDeviceServiceDetails([options])](#balena.models.application.getAllWithDeviceServiceDetails) ⇒ <code>Promise</code>
     * [.get(nameOrSlugOrId, [options])](#balena.models.application.get) ⇒ <code>Promise</code>
@@ -948,6 +951,25 @@ balena.models.application.envVar.remove('MyApp', 'VAR', function(error) {
 	if (error) throw error;
 	...
 });
+```
+<a name="balena.models.application.getDashboardUrl"></a>
+
+##### application.getDashboardUrl(id) ⇒ <code>String</code>
+**Kind**: static method of [<code>application</code>](#balena.models.application)  
+**Summary**: Get Dashboard URL for a specific application  
+**Returns**: <code>String</code> - - Dashboard URL for the specific application  
+**Throws**:
+
+- Exception if the id is not a finite number
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>Number</code> | Application id |
+
+**Example**  
+```js
+dashboardApplicationUrl = balena.models.application.getDashboardUrl(1)
 ```
 <a name="balena.models.application.getAll"></a>
 

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -105,7 +105,10 @@ getApplicationModel = (deps, opts) ->
 	# @throws Exception if the id is not a finite number
 	#
 	# @example
-	# dashboardApplicationUrl = balena.models.application.getDashboardUrl(1)
+	# balena.models.application.get('MyApp').then(function(application) {
+	# 	const dashboardApplicationUrl = balena.models.application.getDashboardUrl(application.id);
+	# 	console.log(dashboardApplicationUrl);
+	# });
 	###
 	exports.getDashboardUrl = getDashboardUrl = (id) ->
 		if typeof id != 'number' || !Number.isFinite(id)

--- a/tests/integration/models/application.spec.coffee
+++ b/tests/integration/models/application.spec.coffee
@@ -8,6 +8,7 @@ m = require('mochainon')
 	givenAnApplication
 	givenLoggedInUser
 	givenMulticontainerApplicationWithADevice
+	sdkOpts
 } = require('../setup')
 {
 	itShouldSetGetAndRemoveTags
@@ -718,3 +719,21 @@ describe 'Application Model', ->
 					.then (applications) =>
 						m.chai.expect(applications).to.have.lengthOf(1)
 						itShouldBeAnApplicationWithDeviceServiceDetails.call(this, applications[0], true)
+
+	describe 'helpers', ->
+
+		describe 'balena.models.application.getDashboardUrl()', ->
+
+			it 'should return the respective DashboardUrl when an application id is provided', ->
+				dashboardUrl = sdkOpts.apiUrl.replace(/api/, 'dashboard')
+				m.chai.expect(
+					balena.models.application.getDashboardUrl(1)
+				).to.equal("#{dashboardUrl}/apps/1")
+
+			it 'should throw when an application id is not a number', ->
+				m.chai.expect( -> balena.models.application.getDashboardUrl('my-app'))
+				.to.throw()
+
+			it 'should throw when an application id is not provided', ->
+				m.chai.expect( -> balena.models.application.getDashboardUrl())
+				.to.throw()


### PR DESCRIPTION
Requirement to make dashboard url visible for cli app commands.

See: https://github.com/balena-io/balena-cli/issues/1440
Change-type: minor
Signed-off-by: Thomas Manning <thomasm@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [ ] Includes typings
- [x] Includes updated documentation
- [ ] Includes updated build output
