### PR TITLE
appveyor: Set to test against node 8

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -5,12 +5,13 @@ Welcome to the Balena SDK documentation.
 
 This document aims to describe all the functions supported by the SDK, as well as showing examples of their expected usage.
 
-If you feel something is missing, not clear or could be improved, please don't hesitate to open an [issue in GitHub](https://github.com/balena-io/balena-sdk/issues/new), we'll be happy to help.
+If you feel something is missing, not clear or could be improved, please don't hesitate to open an
+[issue in GitHub](https://github.com/balena-io/balena-sdk/issues/new), we'll be happy to help.
 
 **Kind**: global namespace  
 
 * [balena](#balena) : <code>object</code>
-    * [.interceptors](#balena.interceptors) : <code>[ &#x27;Array&#x27; ].&lt;Interceptor&gt;</code>
+    * [.interceptors](#balena.interceptors) : <code>Array.&lt;Interceptor&gt;</code>
         * [.Interceptor](#balena.interceptors.Interceptor) : <code>object</code>
     * [.request](#balena.request) : <code>Object</code>
     * [.pine](#balena.pine) : <code>Object</code>
@@ -228,7 +229,7 @@ If you feel something is missing, not clear or could be improved, please don't h
 
 <a name="balena.interceptors"></a>
 
-### balena.interceptors : <code>[ &#x27;Array&#x27; ].&lt;Interceptor&gt;</code>
+### balena.interceptors : <code>Array.&lt;Interceptor&gt;</code>
 The current array of interceptors to use. Interceptors intercept requests made
 internally and are executed in the order they appear in this array for requests,
 and in the reverse order for responses.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ matrix:
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 6
+    - nodejs_version: 8
       TEST_EMAIL: 'test3+juan@resin.io'
       TEST_USERNAME: 'test3_juan'
       TEST_REGISTER_EMAIL: 'test3+register+juan@resin.io'


### PR DESCRIPTION
The latest resin-lint doesn't work on node 6, which is
EOL. In the next major release we will also change
the engines field of the package.json and the node
typings.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
