### PR TITLE
appveyor: Run node & browser tests in parallel

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,11 +14,26 @@ matrix:
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 8
-      TEST_EMAIL: 'test3+juan@resin.io'
-      TEST_USERNAME: 'test3_juan'
-      TEST_REGISTER_EMAIL: 'test3+register+juan@resin.io'
-      TEST_REGISTER_USERNAME: 'test3_register_juan'
+  - nodejs_version: 8
+    TEST_EMAIL: test2+juan@resin.io
+    TEST_PASSWORD:
+      secure: JyPzqbiGRJML/FHbP/8Ixg==
+    TEST_USERNAME: test2_juan
+    TEST_REGISTER_EMAIL: test2+register+juan@resin.io
+    TEST_REGISTER_PASSWORD:
+      secure: 5q1vra242X+0xjTU5msqOQ==
+    TEST_REGISTER_USERNAME: test2_register_juan
+    TEST_ONLY_ON_ENVIRONMENT: node
+  - nodejs_version: 8
+    TEST_EMAIL: sdk+tests+thgreasi@resin.io
+    TEST_PASSWORD:
+      secure: O8/sOQP/5A4Ykiu/T6Uvyw==
+    TEST_USERNAME: sdk_tests_thgreasi
+    TEST_REGISTER_EMAIL: sdk+tests+thgreasi+register@resin.io
+    TEST_REGISTER_PASSWORD:
+      secure: cjQpH4aI3I85w1La/f0uiA==
+    TEST_REGISTER_USERNAME: sdk_tests_thgreasi_register
+    TEST_ONLY_ON_ENVIRONMENT: browser
 
 install:
   - ps: Install-Product node $env:nodejs_version x64

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -29,8 +29,15 @@ OPTIONS =
 		doc: 'doc/'
 		build: 'build/'
 
-gulp.task 'test', ->
+gulp.task 'test', (cb) ->
 	loadEnv()
+
+	{ TEST_ONLY_ON_ENVIRONMENT } = process.env
+	if TEST_ONLY_ON_ENVIRONMENT && TEST_ONLY_ON_ENVIRONMENT != 'node'
+		console.log("TEST_ONLY_ON_ENVIRONMENT is set to #{TEST_ONLY_ON_ENVIRONMENT}")
+		console.log('Skipping node tests')
+		return cb()
+
 	gulp.src(OPTIONS.files.tests, read: false)
 		.pipe(mocha({
 			reporter: 'spec',

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -24,6 +24,13 @@ module.exports = (config) ->
 		'tests/**/*.spec.ts'
 	]
 
+	{ TEST_ONLY_ON_ENVIRONMENT } = process.env
+	if TEST_ONLY_ON_ENVIRONMENT && TEST_ONLY_ON_ENVIRONMENT != 'browser'
+		console.log("TEST_ONLY_ON_ENVIRONMENT is set to #{TEST_ONLY_ON_ENVIRONMENT}")
+		console.log('Skipping browser tests')
+		karmaConfig.files = []
+		karmaConfig.failOnEmptyTestSuite = false
+
 	karmaConfig.browserConsoleLogOptions =
 		level: 'log'
 		format: '%b %T: %m'

--- a/tests/integration/setup.coffee
+++ b/tests/integration/setup.coffee
@@ -32,6 +32,9 @@ _.assign opts,
 	isBrowser: IS_BROWSER,
 	retries: 3
 
+console.log("Running SDK tests against: #{opts.apiUrl}")
+console.log("TEST_USERNAME: #{env?.TEST_USERNAME}")
+
 buildCredentials = ->
 	if not env
 		throw new Error('Missing environment object?!')


### PR DESCRIPTION
That's on top of #818 whose tests atm take more than an hour to complete and as a result fail on appveyor.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
