### PR TITLE
Add device status enum and typings

### DIFF
--- a/lib/models/device-ts.ts
+++ b/lib/models/device-ts.ts
@@ -1,0 +1,11 @@
+export enum OverallStatus {
+	CONFIGURING = 'configuring',
+	IDLE = 'idle',
+	OFFLINE = 'offline',
+	INACTIVE = 'inactive',
+	POST_PROVISIONING = 'post-provisioning',
+	UPDATING = 'updating',
+	ORDERED = 'ordered',
+	PREPARING = 'preparing',
+	SHIPPED = 'shipped',
+}

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -55,6 +55,9 @@ deviceStatus = require('balena-device-status')
 	LOCAL_MODE_ENV_VAR
 	LOCAL_MODE_SUPPORT_PROPERTIES
 } = require('../util/local-mode')
+{
+	OverallStatus
+} = require('./device-ts')
 
 # The min version where /apps API endpoints are implemented is 1.8.0 but we'll
 # be accepting >= 1.8.0-alpha.0 instead. This is a workaround for a published 1.8.0-p1
@@ -106,20 +109,8 @@ getDeviceModel = (deps, opts) ->
 		ResourceNotFoundError: errors.BalenaDeviceNotFound
 	}
 
-	overallStatus = {
-		CONFIGURING: 'configuring',
-		IDLE: 'idle',
-		OFFLINE: 'offline',
-		INACTIVE: 'inactive',
-		POST_PROVISIONING: 'post-provisioning',
-		UPDATING: 'updating',
-		ORDERED: 'ordered',
-		PREPARING: 'preparing',
-		SHIPPED: 'shipped',
-	}
-
 	exports = {
-		overallStatus
+		OverallStatus
 	}
 
 	# Infer dashboardUrl from apiUrl if former is undefined

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -106,7 +106,21 @@ getDeviceModel = (deps, opts) ->
 		ResourceNotFoundError: errors.BalenaDeviceNotFound
 	}
 
-	exports = {}
+	overallStatus = {
+		CONFIGURING: 'configuring',
+		IDLE: 'idle',
+		OFFLINE: 'offline',
+		INACTIVE: 'inactive',
+		POST_PROVISIONING: 'post-provisioning',
+		UPDATING: 'updating',
+		ORDERED: 'ordered',
+		PREPARING: 'preparing',
+		SHIPPED: 'shipped',
+	}
+
+	exports = {
+		overallStatus
+	}
 
 	# Infer dashboardUrl from apiUrl if former is undefined
 	if not dashboardUrl?

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -426,6 +426,20 @@ declare namespace BalenaSdk {
 		state: 'pending' | 'paid' | 'failed' | 'past_due';
 	}
 
+	export interface DeviceOverallStatusMap {
+		readonly CONFIGURING: 'configuring';
+		readonly IDLE: 'idle';
+		readonly OFFLINE: 'offline';
+		readonly INACTIVE: 'inactive';
+		readonly POST_PROVISIONING: 'post-provisioning';
+		readonly UPDATING: 'updating';
+		readonly ORDERED: 'ordered';
+		readonly PREPARING: 'preparing';
+		readonly SHIPPED: 'shipped';
+	}
+
+	export type DeviceOverallStatus = DeviceOverallStatusMap[keyof DeviceOverallStatusMap];
+
 	interface Device {
 		app_name: string;
 		created_at: string;
@@ -463,6 +477,7 @@ declare namespace BalenaSdk {
 		vpn_address: string | null;
 		should_be_managed_by__supervisor_release: number;
 		api_heartbeat_state: 'online' | 'offline' | 'timeout' | 'unknown';
+		overall_status: DeviceOverallStatus;
 
 		belongs_to__application: NavigationResource<Application>;
 		belongs_to__user: NavigationResource<User>;
@@ -1171,6 +1186,7 @@ declare namespace BalenaSdk {
 						key: string,
 					): Promise<void>;
 				};
+				overallStatus: DeviceOverallStatusMap;
 			};
 			service: {
 				getAllByApplication(

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -6,6 +6,7 @@ import { Readable } from 'stream';
 
 import * as BalenaPine from './balena-pine';
 import { BalenaRequest, BalenaRequestStreamResult } from './balena-request';
+import * as DeviceOverallStatus from './device-overall-status';
 import * as Pine from './pinejs-client-core';
 import { Dictionary } from './utils';
 
@@ -13,6 +14,8 @@ import { Dictionary } from './utils';
 declare namespace BalenaSdk {
 	type WithId = Pine.WithId;
 	type PineDeferred = Pine.PineDeferred;
+	type DeviceOverallStatus = DeviceOverallStatus.DeviceOverallStatus;
+
 	/**
 	 * When not selected-out holds a deferred.
 	 * When expanded hold an array with a single element.
@@ -426,20 +429,6 @@ declare namespace BalenaSdk {
 		state: 'pending' | 'paid' | 'failed' | 'past_due';
 	}
 
-	export interface DeviceOverallStatusMap {
-		readonly CONFIGURING: 'configuring';
-		readonly IDLE: 'idle';
-		readonly OFFLINE: 'offline';
-		readonly INACTIVE: 'inactive';
-		readonly POST_PROVISIONING: 'post-provisioning';
-		readonly UPDATING: 'updating';
-		readonly ORDERED: 'ordered';
-		readonly PREPARING: 'preparing';
-		readonly SHIPPED: 'shipped';
-	}
-
-	export type DeviceOverallStatus = DeviceOverallStatusMap[keyof DeviceOverallStatusMap];
-
 	interface Device {
 		app_name: string;
 		created_at: string;
@@ -477,7 +466,8 @@ declare namespace BalenaSdk {
 		vpn_address: string | null;
 		should_be_managed_by__supervisor_release: number;
 		api_heartbeat_state: 'online' | 'offline' | 'timeout' | 'unknown';
-		overall_status: DeviceOverallStatus;
+		/** This is a computed term */
+		overall_status: DeviceOverallStatus.DeviceOverallStatus;
 
 		belongs_to__application: NavigationResource<Application>;
 		belongs_to__user: NavigationResource<User>;
@@ -1186,7 +1176,7 @@ declare namespace BalenaSdk {
 						key: string,
 					): Promise<void>;
 				};
-				overallStatus: DeviceOverallStatusMap;
+				OverallStatus: typeof DeviceOverallStatus.DeviceOverallStatus;
 			};
 			service: {
 				getAllByApplication(

--- a/typings/device-overall-status.d.ts
+++ b/typings/device-overall-status.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Extracted from the enum defined in `device-ts.ts`.
+ */
+export enum DeviceOverallStatus {
+	CONFIGURING = 'configuring',
+	IDLE = 'idle',
+	OFFLINE = 'offline',
+	INACTIVE = 'inactive',
+	POST_PROVISIONING = 'post-provisioning',
+	UPDATING = 'updating',
+	ORDERED = 'ordered',
+	PREPARING = 'preparing',
+	SHIPPED = 'shipped',
+}


### PR DESCRIPTION
Adds the typings for the overall_status calculated term
and exports an enum with the possible status values

Anyone using https://github.com/balena-io-modules/balena-device-status should start using `overall_status` and the enum exported by the SDK instead.

Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
