### PR TITLE
auth.getEmail: Fix confusing call expression

### DIFF
--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -318,7 +318,7 @@ getAuth = (deps, opts) ->
 	###
 	exports.getEmail = (callback) ->
 		getUserDetails()
-		.get ('email')
+		.get('email')
 		.asCallback(callback)
 
 	###*


### PR DESCRIPTION
The current code works as expected but it's confusing, since it literally gets translated to
```
.get(('email'))
```

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
