### PR TITLE
Fix a test case name typo for auth.whoami()

### DIFF
--- a/tests/integration/auth.spec.coffee
+++ b/tests/integration/auth.spec.coffee
@@ -156,7 +156,7 @@ describe 'SDK authentication', ->
 
 		describe 'balena.auth.whoami()', ->
 
-			it 'should eventually be false', ->
+			it 'should eventually be undefined', ->
 				promise = balena.auth.whoami()
 				m.chai.expect(promise).to.eventually.be.undefined
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
