### PR TITLE
*BREAKING*: Stop actively supporting node 6 & 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ language: node_js
 matrix:
   include:
     - node_js:
-      - '8'
+      - '10'
 before_install:
 - npm -g install npm@6
 script:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install --save balena-sdk
 Platforms
 ---------
 
-We currently support NodeJS (6+) and the browser.
+We currently support NodeJS (10+) and the browser.
 
 The following features are node-only:
 - OS image streaming download (`balena.models.os.download`),

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ matrix:
 # what combinations to test
 environment:
   matrix:
-  - nodejs_version: 8
+  - nodejs_version: 10
     TEST_EMAIL: test2+juan@resin.io
     TEST_PASSWORD:
       secure: JyPzqbiGRJML/FHbP/8Ixg==
@@ -24,7 +24,7 @@ environment:
       secure: 5q1vra242X+0xjTU5msqOQ==
     TEST_REGISTER_USERNAME: test2_register_juan
     TEST_ONLY_ON_ENVIRONMENT: node
-  - nodejs_version: 8
+  - nodejs_version: 10
     TEST_EMAIL: sdk+tests+thgreasi@resin.io
     TEST_PASSWORD:
       secure: O8/sOQP/5A4Ykiu/T6Uvyw==

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "author": "Juan Cruz Viotti <juan@balena.io>",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=10.0"
   },
   "devDependencies": {
     "@resin.io/types-mochainon": "^2.0.1",


### PR DESCRIPTION
Node 6 & 8 may well still work with the SDK for quite a
while, but we'll no longer actively test against them
since they are now characterized as EOL, and it's quite
possible that it may stop working entirely in any
future release.

Change-type: major
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
