### PR TITLE
Add tests for arbitary pine requests

### DIFF
--- a/tests/integration/arbitrary-pine-requests.spec.ts
+++ b/tests/integration/arbitrary-pine-requests.spec.ts
@@ -1,0 +1,114 @@
+import * as m from 'mochainon';
+import { describeExpandAssertions } from '../util_ts';
+import {
+	balena,
+	BalenaSdk,
+	givenAnApplication,
+	givenLoggedInUser,
+} from './setup';
+const { expect } = m.chai;
+
+describe('arbitrary pine requests', function() {
+	givenLoggedInUser(before);
+	givenAnApplication(before);
+
+	describeExpandAssertions<BalenaSdk.Application>({
+		resource: 'application',
+		options: {
+			$expand: {
+				organization: {},
+				// includes__user: {},
+				user__is_member_of__application: {},
+				// is_accessible_by__team: {},
+				team_application_access: {},
+			},
+		},
+	});
+
+	describeExpandAssertions<BalenaSdk.ApplicationMembership>({
+		resource: 'user__is_member_of__application',
+		options: {
+			$expand: {
+				user: {},
+				// application: {},
+				is_member_of__application: {},
+				application_membership_role: {},
+			},
+		},
+	});
+
+	describeExpandAssertions<BalenaSdk.User>({
+		resource: 'user',
+		options: {
+			$expand: {
+				// includes__organization_membership: {},
+				organization_membership: {},
+				// is_member_of__application: {},
+				// user_application_membership: {},
+				user__is_member_of__application: {},
+				// is_member_of__team: {},
+				team_membership: {},
+			},
+		},
+	});
+
+	describeExpandAssertions<BalenaSdk.Organization>({
+		resource: 'organization',
+		options: {
+			$expand: {
+				application: {},
+				organization_membership: {},
+				// includes__organization_membership: {},
+				owns__team: {},
+			},
+		},
+	});
+
+	describeExpandAssertions<BalenaSdk.OrganizationMembership>({
+		resource: 'organization_membership',
+		options: {
+			$expand: {
+				user: {},
+				// organization: {},
+				is_member_of__organization: {},
+				organization_membership_role: {},
+			},
+		},
+	});
+
+	describeExpandAssertions<BalenaSdk.TeamMembership>({
+		resource: 'team_membership',
+		options: {
+			$expand: {
+				user: {},
+				// team: {},
+				is_member_of__team: {},
+			},
+		},
+	});
+
+	describeExpandAssertions<BalenaSdk.Team>({
+		resource: 'team',
+		options: {
+			$expand: {
+				belongs_to__organization: {},
+				// includes__user: {},
+				team_membership: {},
+				// grants_access_to__application: {},
+				team_application_access: {},
+			},
+		},
+	});
+
+	describeExpandAssertions<BalenaSdk.TeamApplicationAccess>({
+		resource: 'team_application_access',
+		options: {
+			$expand: {
+				team: {},
+				// application: {},
+				grants_access_to__application: {},
+				application_membership_role: {},
+			},
+		},
+	});
+});

--- a/tests/util_ts.ts
+++ b/tests/util_ts.ts
@@ -1,0 +1,38 @@
+import * as m from 'mochainon';
+import { AnyObject } from '../typings/utils';
+import { balena, BalenaSdk } from './integration/setup';
+const { expect } = m.chai;
+
+export const describeExpandAssertions = async <T>(
+	params: BalenaSdk.PineParams<T>,
+) => {
+	describe(`expanding from ${params.resource}`, function() {
+		Object.keys(params.options.$expand).forEach(key => {
+			describe(`to ${key}`, function() {
+				it('should succeed', async function() {
+					const [result] = await balena.pine.get<AnyObject>({
+						...params,
+						options: {
+							...params.options,
+							$expand: {
+								[key]: params.options.$expand[key],
+							},
+						},
+					});
+					this.result = result;
+				});
+
+				it('should include the expanded property', function() {
+					if (!this.result) {
+						this.skip();
+						return;
+					}
+
+					expect(this.result)
+						.to.have.property(key)
+						.that.is.an('array');
+				});
+			});
+		});
+	});
+};


### PR DESCRIPTION
This makes sure that the typings that we have are indeed working.
Once the orgs PR finalizes we could move the respective requests under their tests cases and clean them up, but for now it's on a separate file to ease rebasing.

The commented lines are alt options for the same expands that do work.
I chose the non-commented ones based on what made more sense based on the SBVR and when in doubt I tried to use the same terms as the ones that we use in the API.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
