### PR TITLE
device.getStatus: Suggest selecting the overall_status field directly

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3942,6 +3942,8 @@ balena.models.device.ping('7cf02a6', function(error) {
 
 ##### device.getStatus(device) ⇒ <code>Promise</code>
 Computes the status of an already retrieved device object.
+It's recommended to use `balena.models.device.get(deviceUuid, { $select: ['overall_status'] })` instead,
+in case that you need to retrieve more device fields than just the status.
 
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
 **Summary**: Get the status of a device  

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3941,10 +3941,13 @@ balena.models.device.ping('7cf02a6', function(error) {
 <a name="balena.models.device.getStatus"></a>
 
 ##### device.getStatus(device) ⇒ <code>Promise</code>
+Computes the status of an already retrieved device object.
+
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
 **Summary**: Get the status of a device  
 **Access**: public  
 **Fulfil**: <code>String</code> - device status  
+**See**: [getWithServiceDetails](#balena.models.device.getWithServiceDetails) for retrieving the device object that this method accepts.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3952,7 +3955,9 @@ balena.models.device.ping('7cf02a6', function(error) {
 
 **Example**  
 ```js
-balena.models.device.getStatus(device).then(function(status) {
+balena.models.device.getWithServiceDetails('7cf02a6').then(function(device) {
+	return balena.models.device.getStatus(device);
+}).then(function(status) {
 	console.log(status);
 });
 ```

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -2150,6 +2150,8 @@ getDeviceModel = (deps, opts) ->
 	#
 	# @description
 	# Computes the status of an already retrieved device object.
+	# It's recommended to use `balena.models.device.get(deviceUuid, { $select: ['overall_status'] })` instead,
+	# in case that you need to retrieve more device fields than just the status.
 	#
 	# @see {@link balena.models.device.getWithServiceDetails} for retrieving the device object that this method accepts.
 	#

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -2148,12 +2148,19 @@ getDeviceModel = (deps, opts) ->
 	# @function
 	# @memberof balena.models.device
 	#
+	# @description
+	# Computes the status of an already retrieved device object.
+	#
+	# @see {@link balena.models.device.getWithServiceDetails} for retrieving the device object that this method accepts.
+	#
 	# @param {Object} device - A device object
 	# @fulfil {String} - device status
 	# @returns {Promise}
 	#
 	# @example
-	# balena.models.device.getStatus(device).then(function(status) {
+	# balena.models.device.getWithServiceDetails('7cf02a6').then(function(device) {
+	# 	return balena.models.device.getStatus(device);
+	# }).then(function(status) {
 	# 	console.log(status);
 	# });
 	#


### PR DESCRIPTION
Did not deprecate it since the plan is to change it in
the next major to just be a convenience method for a
get() with the overall_status field, so that users can still 
find it easily.

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/KlyXZlJ86S-nvOuJbuOdpbmo54i
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/KlyXZlJ86S-nvOuJbuOdpbmo54i
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [x] Includes updated documentation
- [ ] Includes updated build output
