### PR TITLE
**BREAKING**: Change the device.getStatus() to expect a uuid or id arg

### DIFF
--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -26,7 +26,6 @@ map = require('lodash/map')
 bSemver = require('balena-semver')
 semver = require('semver')
 errors = require('balena-errors')
-deviceStatus = require('balena-device-status')
 
 {
 	isId
@@ -2160,32 +2159,38 @@ getDeviceModel = (deps, opts) ->
 	# @memberof balena.models.device
 	#
 	# @description
-	# Computes the status of an already retrieved device object.
-	# It's recommended to use `balena.models.device.get(deviceUuid, { $select: ['overall_status'] })` instead,
+	# Convenience method for getting the overall status of a device.
+	# It's recommended to use `balena.models.device.get()` instead,
 	# in case that you need to retrieve more device fields than just the status.
 	#
-	# @see {@link balena.models.device.getWithServiceDetails} for retrieving the device object that this method accepts.
+	# @see {@link balena.models.device.get} for an example on selecting the `overall_status` field.
 	#
-	# @param {Object} device - A device object
+	# @param {String|Number} uuidOrId - device uuid (string) or id (number)
 	# @fulfil {String} - device status
 	# @returns {Promise}
 	#
 	# @example
-	# balena.models.device.getWithServiceDetails('7cf02a6').then(function(device) {
-	# 	return balena.models.device.getStatus(device);
-	# }).then(function(status) {
+	# balena.models.device.getStatus('7cf02a6').then(function(status) {
 	# 	console.log(status);
 	# });
 	#
 	# @example
-	# balena.models.device.getStatus(device, function(error, status) {
+	# balena.models.device.getStatus(123).then(function(status) {
+	# 	console.log(status);
+	# });
+	#
+	# @example
+	# balena.models.device.getStatus('7cf02a6', function(error, status) {
 	# 	if (error) throw error;
 	# 	console.log(status);
 	# });
 	###
-	exports.getStatus = (device, callback) ->
-		Promise.try ->
-			return deviceStatus.getStatus(device).key
+	exports.getStatus = (uuidOrId, callback) ->
+		if typeof uuidOrId != 'string' && typeof uuidOrId != 'number'
+			throw new errors.BalenaInvalidParameterError('uuidOrId', uuidOrId)
+
+		exports.get(uuidOrId, $select: 'overall_status')
+		.then ({ overall_status }) -> overall_status
 		.asCallback(callback)
 
 	###*

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "@types/node": "^8.10.59",
     "abortcontroller-polyfill": "^1.4.0",
     "balena-auth": "^3.0.1",
-    "balena-device-status": "^3.2.1",
     "balena-errors": "^4.2.1",
     "balena-hup-action-utils": "~4.0.0",
     "balena-pine": "^10.1.1",

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -1198,7 +1198,7 @@ declare namespace BalenaSdk {
 				enableTcpPing(uuidOrId: string | number): Promise<void>;
 				disableTcpPing(uuidOrId: string | number): Promise<void>;
 				ping(uuidOrId: string | number): Promise<void>;
-				getStatus(device: DeviceWithServiceDetails): Promise<string>;
+				getStatus(uuidOrId: string | number): Promise<string>;
 				lastOnline(device: Device): string;
 				getOsVersion(device: Device): string;
 				isTrackingApplicationRelease(


### PR DESCRIPTION
Keeping the method for discoverability & convenience reasons. I also expect this to be easier for users
upgrading from an older version.

Change-type: major
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/KlyXZlJ86S-nvOuJbuOdpbmo54i
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [x] Includes updated build output
