### PR TITLE
Abstract callback support out of the method implementations

### DIFF
--- a/lib/2fa.ts
+++ b/lib/2fa.ts
@@ -50,13 +50,8 @@ const get2fa = function(
 	 * 	}
 	 * });
 	 */
-	function isEnabled(
-		callback?: (error?: Error, result?: boolean) => void,
-	): Promise<boolean> {
-		return auth
-			.needs2FA()
-			.then(twoFactorRequired => twoFactorRequired != null)
-			.asCallback(callback);
+	function isEnabled(): Promise<boolean> {
+		return auth.needs2FA().then(twoFactorRequired => twoFactorRequired != null);
 	}
 
 	/**
@@ -85,13 +80,8 @@ const get2fa = function(
 	 * 	}
 	 * });
 	 */
-	function isPassed(
-		callback?: (error?: Error, result?: boolean) => void,
-	): Promise<boolean> {
-		return auth
-			.needs2FA()
-			.then(twoFactorRequired => !twoFactorRequired)
-			.asCallback(callback);
+	function isPassed(): Promise<boolean> {
+		return auth.needs2FA().then(twoFactorRequired => !twoFactorRequired);
 	}
 
 	/**
@@ -112,10 +102,7 @@ const get2fa = function(
 	 * 	if (error) throw error;
 	 * });
 	 */
-	function challenge(
-		code: string,
-		callback?: (error?: Error) => void,
-	): Promise<void> {
+	function challenge(code: string): Promise<void> {
 		return request
 			.send({
 				method: 'POST',
@@ -124,8 +111,7 @@ const get2fa = function(
 				body: { code },
 			})
 			.get('body')
-			.then(auth.setKey)
-			.asCallback(callback);
+			.then(auth.setKey);
 	}
 
 	return {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -124,13 +124,10 @@ const getAuth = function(
 	 * 	}
 	 * });
 	 */
-	function whoami(
-		callback?: (error?: Error, result?: string | undefined) => void,
-	): Promise<string | undefined> {
+	function whoami(): Promise<string | undefined> {
 		return getUserDetails()
 			.then(userDetails => userDetails?.username)
-			.catchReturn(errors.BalenaNotLoggedIn, undefined)
-			.asCallback(callback);
+			.catchReturn(errors.BalenaNotLoggedIn, undefined);
 	}
 
 	/**
@@ -164,13 +161,10 @@ const getAuth = function(
 	 * 	console.log('My token is:', token);
 	 * });
 	 */
-	function authenticate(
-		credentials: {
-			email: string;
-			password: string;
-		},
-		callback?: (error?: Error, result?: string) => void,
-	): Promise<string> {
+	function authenticate(credentials: {
+		email: string;
+		password: string;
+	}): Promise<string> {
 		return request
 			.send<string>({
 				method: 'POST',
@@ -182,8 +176,7 @@ const getAuth = function(
 				},
 				sendToken: false,
 			})
-			.get('body')
-			.asCallback(callback);
+			.get('body');
 	}
 
 	/**
@@ -209,17 +202,12 @@ const getAuth = function(
 	 * 	if (error) throw error;
 	 * });
 	 */
-	function login(
-		credentials: {
-			email: string;
-			password: string;
-		},
-		callback?: (error?: Error) => void,
-	): Promise<void> {
+	function login(credentials: {
+		email: string;
+		password: string;
+	}): Promise<void> {
 		userDetailsCache = null;
-		return authenticate(credentials)
-			.then(auth.setKey)
-			.asCallback(callback);
+		return authenticate(credentials).then(auth.setKey);
 	}
 
 	/**
@@ -242,12 +230,9 @@ const getAuth = function(
 	 * 	if (error) throw error;
 	 * });
 	 */
-	function loginWithToken(
-		authToken: string,
-		callback?: (error?: Error) => void,
-	): Promise<void> {
+	function loginWithToken(authToken: string): Promise<void> {
 		userDetailsCache = null;
-		return auth.setKey(authToken).asCallback(callback);
+		return auth.setKey(authToken);
 	}
 
 	/**
@@ -280,13 +265,10 @@ const getAuth = function(
 	 * 	}
 	 * });
 	 */
-	function isLoggedIn(
-		callback?: (error?: Error, result?: boolean) => void,
-	): Promise<boolean> {
+	function isLoggedIn(): Promise<boolean> {
 		return getUserDetails()
 			.return(true)
-			.catchReturn(errors.BalenaNotLoggedIn, false)
-			.asCallback(callback);
+			.catchReturn(errors.BalenaNotLoggedIn, false);
 	}
 
 	/**
@@ -312,15 +294,10 @@ const getAuth = function(
 	 * 	console.log(token);
 	 * });
 	 */
-	function getToken(
-		callback?: (error?: Error, result?: string) => void,
-	): Promise<string> {
-		return auth
-			.getKey()
-			.catch(function(err) {
-				throw normalizeAuthError(err);
-			})
-			.asCallback(callback);
+	function getToken(): Promise<string> {
+		return auth.getKey().catch(function(err) {
+			throw normalizeAuthError(err);
+		});
 	}
 
 	/**
@@ -346,12 +323,8 @@ const getAuth = function(
 	 * 	console.log(userId);
 	 * });
 	 */
-	function getUserId(
-		callback?: (error?: Error, result?: number) => void,
-	): Promise<number> {
-		return getUserDetails()
-			.get('id')
-			.asCallback(callback);
+	function getUserId(): Promise<number> {
+		return getUserDetails().get('id');
 	}
 
 	/**
@@ -377,12 +350,8 @@ const getAuth = function(
 	 * 	console.log(email);
 	 * });
 	 */
-	function getEmail(
-		callback?: (error?: Error, result?: string) => void,
-	): Promise<string> {
-		return getUserDetails()
-			.get('email')
-			.asCallback(callback);
+	function getEmail(): Promise<string> {
+		return getUserDetails().get('email');
 	}
 
 	/**
@@ -402,9 +371,9 @@ const getAuth = function(
 	 * 	if (error) throw error;
 	 * });
 	 */
-	function logout(callback?: (error?: Error) => void): Promise<void> {
+	function logout(): Promise<void> {
 		userDetailsCache = null;
-		return auth.removeKey().asCallback(callback);
+		return auth.removeKey();
 	}
 
 	/**
@@ -439,14 +408,11 @@ const getAuth = function(
 	 * 	console.log(token);
 	 * });
 	 */
-	function register(
-		credentials: {
-			email: string;
-			password: string;
-			'g-recaptcha-response'?: string;
-		},
-		callback?: (error?: Error, result?: string) => void,
-	): Promise<string> {
+	function register(credentials: {
+		email: string;
+		password: string;
+		'g-recaptcha-response'?: string;
+	}): Promise<string> {
 		return request
 			.send({
 				method: 'POST',
@@ -455,12 +421,13 @@ const getAuth = function(
 				body: credentials,
 				sendToken: false,
 			})
-			.get('body')
-			.asCallback(callback);
+			.get('body');
 	}
 
 	return {
-		twoFactor,
+		twoFactor: require('./util/callbacks').addCallbackSupportToModule(
+			twoFactor,
+		) as typeof twoFactor,
 		whoami,
 		authenticate,
 		login,

--- a/lib/balena.js
+++ b/lib/balena.js
@@ -67,16 +67,22 @@ const getSdk = function(opts) {
 	 */
 	const sdkTemplate = {
 		auth() {
-			return require('./auth').default;
+			const { addCallbackSupportToModuleFactory } = require('./util/callbacks');
+			return addCallbackSupportToModuleFactory(require('./auth').default);
 		},
 		models() {
+			// don't try to add callbacks for this, since it's just a namespace
+			// and it would otherwise break lazy loading since it would enumerate
+			// all properties
 			return require('./models');
 		},
 		logs() {
-			return require('./logs').default;
+			const { addCallbackSupportToModuleFactory } = require('./util/callbacks');
+			return addCallbackSupportToModuleFactory(require('./logs').default);
 		},
 		settings() {
-			return require('./settings').default;
+			const { addCallbackSupportToModuleFactory } = require('./util/callbacks');
+			return addCallbackSupportToModuleFactory(require('./settings').default);
 		},
 	};
 

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -19,7 +19,6 @@ import * as querystring from 'querystring';
 import { EventEmitter } from 'events';
 import * as ndjson from 'ndjson';
 import { AbortController as AbortControllerPonyfill } from 'abortcontroller-polyfill/dist/cjs-ponyfill';
-import { findCallback } from './util';
 import { globalEnv } from './util/global-env';
 
 const AbortController =
@@ -184,14 +183,12 @@ const getLogs = function(deps, opts) {
 		 * 	});
 		 * });
 		 */
-		subscribe(uuidOrId, options, callback) {
+		subscribe(uuidOrId, options) {
 			// TODO: We should consider making this a readable stream.
-			callback = findCallback(arguments);
 
 			return deviceModel
 				.get(uuidOrId, { $select: 'uuid' })
-				.then(device => subscribeToApiLogs(device, options))
-				.asCallback(callback);
+				.then(device => subscribeToApiLogs(device, options));
 		},
 
 		/**
@@ -233,13 +230,10 @@ const getLogs = function(deps, opts) {
 		 * 	});
 		 * });
 		 */
-		history(uuidOrId, options, callback) {
-			callback = findCallback(arguments);
-
+		history(uuidOrId, options) {
 			return deviceModel
 				.get(uuidOrId, { $select: 'uuid' })
-				.then(device => getLogsFromApi(device, options))
-				.asCallback(callback);
+				.then(device => getLogsFromApi(device, options));
 		},
 	};
 

--- a/lib/models/api-key.ts
+++ b/lib/models/api-key.ts
@@ -19,7 +19,7 @@ import * as Promise from 'bluebird';
 
 import * as BalenaSdk from '../../typings/balena-sdk';
 import { InjectedDependenciesParam, InjectedOptionsParam } from '../balena';
-import { findCallback, mergePineOptions } from '../util';
+import { mergePineOptions } from '../util';
 
 const getApiKeysModel = function(
 	deps: InjectedDependenciesParam,
@@ -63,10 +63,7 @@ const getApiKeysModel = function(
 	exports.create = function(
 		name: string,
 		description: string | null = null,
-		_callback?: (error?: Error, result?: string) => void,
 	): Promise<string> {
-		_callback = findCallback(arguments);
-
 		const apiKeyBody: { name: string; description?: string | null } = {
 			name,
 		};
@@ -83,8 +80,7 @@ const getApiKeysModel = function(
 			.get('body')
 			.catch(function() {
 				throw new errors.BalenaNotLoggedIn();
-			})
-			.asCallback(_callback);
+			});
 	};
 
 	/**
@@ -111,28 +107,24 @@ const getApiKeysModel = function(
 	 */
 	exports.getAll = function(
 		options: BalenaSdk.PineOptionsFor<BalenaSdk.ApiKey> = {},
-		callback?: (error?: Error, apiKeys?: BalenaSdk.ApiKey[]) => void,
 	): Promise<BalenaSdk.ApiKey[]> {
-		callback = findCallback(arguments);
-		return pine
-			.get<BalenaSdk.ApiKey>({
-				resource: 'api_key',
-				options: mergePineOptions(
-					{
-						// the only way to reason whether
-						// it's a named user api key is whether
-						// it has a name
-						$filter: {
-							name: {
-								$ne: null,
-							},
+		return pine.get<BalenaSdk.ApiKey>({
+			resource: 'api_key',
+			options: mergePineOptions(
+				{
+					// the only way to reason whether
+					// it's a named user api key is whether
+					// it has a name
+					$filter: {
+						name: {
+							$ne: null,
 						},
-						$orderby: 'name asc',
 					},
-					options,
-				),
-			})
-			.asCallback(callback);
+					$orderby: 'name asc',
+				},
+				options,
+			),
+		});
 	};
 
 	/**
@@ -164,7 +156,6 @@ const getApiKeysModel = function(
 	exports.update = function(
 		id: number,
 		apiKeyInfo: { name?: string; description?: string },
-		callback?: (error?: Error) => void,
 	): Promise<void> {
 		return Promise.try<void>(() => {
 			if (!apiKeyInfo) {
@@ -197,7 +188,7 @@ const getApiKeysModel = function(
 					},
 				})
 				.return();
-		}).asCallback(callback);
+		});
 	};
 
 	/**
@@ -218,10 +209,7 @@ const getApiKeysModel = function(
 	 * 	if (error) throw error;
 	 * });
 	 */
-	exports.revoke = function(
-		id: number,
-		callback?: (error?: Error) => void,
-	): Promise<void> {
+	exports.revoke = function(id: number): Promise<void> {
 		return pine
 			.delete({
 				resource: 'api_key',
@@ -236,8 +224,7 @@ const getApiKeysModel = function(
 					},
 				},
 			})
-			.return()
-			.asCallback(callback);
+			.return();
 	};
 
 	return exports;

--- a/lib/models/application.js
+++ b/lib/models/application.js
@@ -24,7 +24,6 @@ import {
 	isId,
 	isNoApplicationForKeyResponse,
 	isNotFoundResponse,
-	findCallback,
 	mergePineOptions,
 	treatAsMissingApplication,
 	LOCKED_STATUS_CODE,
@@ -154,11 +153,10 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(applications);
 		 * });
 		 */
-		getAll(options, callback = undefined) {
+		getAll(options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return pine
 				.get({
@@ -168,8 +166,7 @@ const getApplicationModel = function(deps, opts) {
 				.map(function(application) {
 					normalizeApplication(application);
 					return application;
-				})
-				.asCallback(callback);
+				});
 		},
 
 		/**
@@ -203,11 +200,10 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(applications);
 		 * });
 		 */
-		getAllWithDeviceServiceDetails(options, callback) {
+		getAllWithDeviceServiceDetails(options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			const serviceOptions = mergePineOptions(
 				{
@@ -218,17 +214,14 @@ const getApplicationModel = function(deps, opts) {
 				options,
 			);
 
-			return exports
-				.getAll(serviceOptions)
-				.then(function(apps) {
-					apps.forEach(app => {
-						app.owns__device = app.owns__device.map(
-							generateCurrentServiceDetails,
-						);
-					});
-					return apps;
-				})
-				.asCallback(callback);
+			return exports.getAll(serviceOptions).then(function(apps) {
+				apps.forEach(app => {
+					app.owns__device = app.owns__device.map(
+						generateCurrentServiceDetails,
+					);
+				});
+				return apps;
+			});
 		},
 
 		/**
@@ -259,11 +252,10 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(application);
 		 * });
 		 */
-		get(nameOrSlugOrId, options, callback = undefined) {
+		get(nameOrSlugOrId, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return Promise.try(function() {
 				if (nameOrSlugOrId == null) {
@@ -309,9 +301,7 @@ const getApplicationModel = function(deps, opts) {
 						})
 						.get(0);
 				}
-			})
-				.tap(normalizeApplication)
-				.asCallback(callback);
+			}).tap(normalizeApplication);
 		},
 
 		/**
@@ -349,11 +339,10 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(device);
 		 * });
 		 */
-		getWithDeviceServiceDetails(nameOrSlugOrId, options, callback) {
+		getWithDeviceServiceDetails(nameOrSlugOrId, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			const serviceOptions = mergePineOptions(
 				{
@@ -364,18 +353,15 @@ const getApplicationModel = function(deps, opts) {
 				options,
 			);
 
-			return exports
-				.get(nameOrSlugOrId, serviceOptions)
-				.then(function(app) {
-					if (app && app.owns__device) {
-						app.owns__device = app.owns__device.map(
-							generateCurrentServiceDetails,
-						);
-					}
+			return exports.get(nameOrSlugOrId, serviceOptions).then(function(app) {
+				if (app && app.owns__device) {
+					app.owns__device = app.owns__device.map(
+						generateCurrentServiceDetails,
+					);
+				}
 
-					return app;
-				})
-				.asCallback(callback);
+				return app;
+			});
 		},
 
 		/**
@@ -396,11 +382,10 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(application);
 		 * });
 		 */
-		getAppByOwner(appName, owner, options, callback) {
+		getAppByOwner(appName, owner, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			appName = appName.toLowerCase();
 			owner = owner.toLowerCase();
@@ -426,8 +411,7 @@ const getApplicationModel = function(deps, opts) {
 					}
 				})
 				.get(0)
-				.tap(normalizeApplication)
-				.asCallback(callback);
+				.tap(normalizeApplication);
 		},
 
 		/**
@@ -457,12 +441,11 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(hasApp);
 		 * });
 		 */
-		has: (nameOrSlugOrId, callback) =>
+		has: nameOrSlugOrId =>
 			exports
 				.get(nameOrSlugOrId, { $select: ['id'] })
 				.return(true)
-				.catch(errors.BalenaApplicationNotFound, () => false)
-				.asCallback(callback),
+				.catch(errors.BalenaApplicationNotFound, () => false),
 
 		/**
 		 * @summary Check if the user has any applications
@@ -485,11 +468,10 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log('Has any?', hasAny);
 		 * });
 		 */
-		hasAny: callback =>
+		hasAny: () =>
 			exports
 				.getAll({ $select: ['id'] })
-				.then(applications => applications.length !== 0)
-				.asCallback(callback),
+				.then(applications => applications.length !== 0),
 
 		/**
 		 * @summary Create an application
@@ -523,9 +505,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(application);
 		 * });
 		 */
-		create({ name, applicationType, deviceType, parent }, callback) {
-			callback = findCallback(arguments);
-
+		create({ name, applicationType, deviceType, parent }) {
 			const applicationTypePromise = !applicationType
 				? Promise.resolve()
 				: pine
@@ -562,34 +542,32 @@ const getApplicationModel = function(deps, opts) {
 				deviceManifestPromise,
 				applicationTypePromise,
 				parentAppPromise,
-			])
-				.then(function([deviceManifest, applicationTypeId, parentApplication]) {
-					if (deviceManifest.state === 'DISCONTINUED') {
-						throw new errors.BalenaDiscontinuedDeviceType(deviceType);
-					}
+			]).then(function([deviceManifest, applicationTypeId, parentApplication]) {
+				if (deviceManifest.state === 'DISCONTINUED') {
+					throw new errors.BalenaDiscontinuedDeviceType(deviceType);
+				}
 
-					const extraOptions = parentApplication
-						? { depends_on__application: parentApplication.id }
-						: {};
+				const extraOptions = parentApplication
+					? { depends_on__application: parentApplication.id }
+					: {};
 
-					if (applicationTypeId) {
-						Object.assign(extraOptions, {
-							application_type: applicationTypeId,
-						});
-					}
-
-					return pine.post({
-						resource: 'application',
-						body: Object.assign(
-							{
-								app_name: name,
-								device_type: deviceManifest.slug,
-							},
-							extraOptions,
-						),
+				if (applicationTypeId) {
+					Object.assign(extraOptions, {
+						application_type: applicationTypeId,
 					});
-				})
-				.asCallback(callback);
+				}
+
+				return pine.post({
+					resource: 'application',
+					body: Object.assign(
+						{
+							app_name: name,
+							device_type: deviceManifest.slug,
+						},
+						extraOptions,
+					),
+				});
+			});
 		},
 
 		/**
@@ -613,7 +591,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		remove: (nameOrSlugOrId, callback) =>
+		remove: nameOrSlugOrId =>
 			getId(nameOrSlugOrId)
 				.then(applicationId =>
 					pine.delete({
@@ -621,8 +599,7 @@ const getApplicationModel = function(deps, opts) {
 						id: applicationId,
 					}),
 				)
-				.catch(isNotFoundResponse, treatAsMissingApplication(nameOrSlugOrId))
-				.asCallback(callback),
+				.catch(isNotFoundResponse, treatAsMissingApplication(nameOrSlugOrId)),
 
 		/**
 		 * @summary Restart application
@@ -645,7 +622,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		restart: (nameOrSlugOrId, callback) =>
+		restart: nameOrSlugOrId =>
 			getId(nameOrSlugOrId)
 				.then(applicationId =>
 					request.send({
@@ -655,8 +632,7 @@ const getApplicationModel = function(deps, opts) {
 					}),
 				)
 				.return(undefined)
-				.catch(isNotFoundResponse, treatAsMissingApplication(nameOrSlugOrId))
-				.asCallback(callback),
+				.catch(isNotFoundResponse, treatAsMissingApplication(nameOrSlugOrId)),
 
 		/**
 		 * @summary Generate an API key for a specific application
@@ -690,10 +666,8 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(apiKey);
 		 * });
 		 */
-		generateApiKey: (
-			nameOrSlugOrId,
-			callback, // Do a full get, not just getId, because the actual api endpoint doesn't fail if the id
-		) =>
+		generateApiKey: nameOrSlugOrId =>
+			// Do a full get, not just getId, because the actual api endpoint doesn't fail if the id
 			// doesn't exist. TODO: Can use getId once https://github.com/balena-io/balena-api/issues/110 is resolved
 			exports
 				.get(nameOrSlugOrId, { $select: 'id' })
@@ -704,8 +678,7 @@ const getApplicationModel = function(deps, opts) {
 						baseUrl: apiUrl,
 					}),
 				)
-				.get('body')
-				.asCallback(callback),
+				.get('body'),
 
 		/**
 		 * @summary Generate a device provisioning key for a specific application
@@ -734,7 +707,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(key);
 		 * });
 		 */
-		generateProvisioningKey: (nameOrSlugOrId, callback = undefined) =>
+		generateProvisioningKey: nameOrSlugOrId =>
 			getId(nameOrSlugOrId)
 				.then(applicationId =>
 					request.send({
@@ -747,8 +720,7 @@ const getApplicationModel = function(deps, opts) {
 					isNoApplicationForKeyResponse,
 					treatAsMissingApplication(nameOrSlugOrId),
 				)
-				.get('body')
-				.asCallback(callback),
+				.get('body'),
 
 		/**
 		 * @summary Purge devices by application id
@@ -768,7 +740,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		purge: (appId, callback) =>
+		purge: appId =>
 			request
 				.send({
 					method: 'POST',
@@ -787,8 +759,7 @@ const getApplicationModel = function(deps, opts) {
 					}
 
 					throw err;
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Shutdown devices by application id
@@ -810,7 +781,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		shutdown(appId, options, callback) {
+		shutdown(appId, options) {
 			if (options == null) {
 				options = {};
 			}
@@ -832,8 +803,7 @@ const getApplicationModel = function(deps, opts) {
 					}
 
 					throw err;
-				})
-				.asCallback(callback);
+				});
 		},
 
 		/**
@@ -856,7 +826,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		reboot(appId, options, callback) {
+		reboot(appId, options) {
 			if (options == null) {
 				options = {};
 			}
@@ -878,8 +848,7 @@ const getApplicationModel = function(deps, opts) {
 					}
 
 					throw err;
-				})
-				.asCallback(callback);
+				});
 		},
 
 		/**
@@ -908,11 +877,10 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(isEnabled);
 		 * });
 		 */
-		willTrackNewReleases: (nameOrSlugOrId, callback) =>
+		willTrackNewReleases: nameOrSlugOrId =>
 			exports
 				.get(nameOrSlugOrId, { $select: 'should_track_latest_release' })
-				.get('should_track_latest_release')
-				.asCallback(callback),
+				.get('should_track_latest_release'),
 
 		/**
 		 * @summary Get whether the application is up to date and is tracking the latest release for updates
@@ -940,7 +908,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(isEnabled);
 		 * });
 		 */
-		isTrackingLatestRelease: (nameOrSlugOrId, callback) =>
+		isTrackingLatestRelease: nameOrSlugOrId =>
 			Promise.all([
 				exports.get(nameOrSlugOrId, {
 					$select: ['commit', 'should_track_latest_release'],
@@ -948,14 +916,12 @@ const getApplicationModel = function(deps, opts) {
 				releaseModel().getLatestByApplication(nameOrSlugOrId, {
 					$select: 'commit',
 				}),
-			])
-				.then(function([application, latestRelease]) {
-					return (
-						application.should_track_latest_release &&
-						(!latestRelease || application.commit === latestRelease.commit)
-					);
-				})
-				.asCallback(callback),
+			]).then(function([application, latestRelease]) {
+				return (
+					application.should_track_latest_release &&
+					(!latestRelease || application.commit === latestRelease.commit)
+				);
+			}),
 
 		/**
 		 * @summary Set a specific application to run a particular release
@@ -987,19 +953,17 @@ const getApplicationModel = function(deps, opts) {
 		 * 	...
 		 * });
 		 */
-		pinToRelease: (nameOrSlugOrId, fullReleaseHash, callback) =>
-			getId(nameOrSlugOrId)
-				.then(applicationId =>
-					pine.patch({
-						resource: 'application',
-						id: applicationId,
-						body: {
-							commit: fullReleaseHash,
-							should_track_latest_release: false,
-						},
-					}),
-				)
-				.asCallback(callback),
+		pinToRelease: (nameOrSlugOrId, fullReleaseHash) =>
+			getId(nameOrSlugOrId).then(applicationId =>
+				pine.patch({
+					resource: 'application',
+					id: applicationId,
+					body: {
+						commit: fullReleaseHash,
+						should_track_latest_release: false,
+					},
+				}),
+			),
 
 		/**
 		 * @summary Get the hash of the current release for a specific application
@@ -1027,11 +991,8 @@ const getApplicationModel = function(deps, opts) {
 		 * 	console.log(release);
 		 * });
 		 */
-		getTargetReleaseHash: (nameOrSlugOrId, callback) =>
-			exports
-				.get(nameOrSlugOrId, { $select: 'commit' })
-				.get('commit')
-				.asCallback(callback),
+		getTargetReleaseHash: nameOrSlugOrId =>
+			exports.get(nameOrSlugOrId, { $select: 'commit' }).get('commit'),
 
 		/**
 		 * @summary Configure a specific application to track the latest available release
@@ -1061,7 +1022,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	...
 		 * });
 		 */
-		trackLatestRelease: (nameOrSlugOrId, callback) =>
+		trackLatestRelease: nameOrSlugOrId =>
 			releaseModel()
 				.getLatestByApplication(nameOrSlugOrId, {
 					$select: ['commit', 'belongs_to__application'],
@@ -1094,8 +1055,7 @@ const getApplicationModel = function(deps, opts) {
 						id: applicationId,
 						body,
 					});
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Enable device urls for all devices that belong to an application
@@ -1118,23 +1078,20 @@ const getApplicationModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		enableDeviceUrls: (nameOrSlugOrId, callback) =>
-			exports
-				.get(nameOrSlugOrId, { $select: 'id' })
-				.then(({ id }) =>
-					pine.patch({
-						resource: 'device',
-						body: {
-							is_web_accessible: true,
+		enableDeviceUrls: nameOrSlugOrId =>
+			exports.get(nameOrSlugOrId, { $select: 'id' }).then(({ id }) =>
+				pine.patch({
+					resource: 'device',
+					body: {
+						is_web_accessible: true,
+					},
+					options: {
+						$filter: {
+							belongs_to__application: id,
 						},
-						options: {
-							$filter: {
-								belongs_to__application: id,
-							},
-						},
-					}),
-				)
-				.asCallback(callback),
+					},
+				}),
+			),
 
 		/**
 		 * @summary Disable device urls for all devices that belong to an application
@@ -1157,23 +1114,20 @@ const getApplicationModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		disableDeviceUrls: (nameOrSlugOrId, callback) =>
-			exports
-				.get(nameOrSlugOrId, { $select: 'id' })
-				.then(({ id }) =>
-					pine.patch({
-						resource: 'device',
-						body: {
-							is_web_accessible: false,
+		disableDeviceUrls: nameOrSlugOrId =>
+			exports.get(nameOrSlugOrId, { $select: 'id' }).then(({ id }) =>
+				pine.patch({
+					resource: 'device',
+					body: {
+						is_web_accessible: false,
+					},
+					options: {
+						$filter: {
+							belongs_to__application: id,
 						},
-						options: {
-							$filter: {
-								belongs_to__application: id,
-							},
-						},
-					}),
-				)
-				.asCallback(callback),
+					},
+				}),
+			),
 
 		/**
 		 * @summary Grant support access to an application until a specified time
@@ -1197,7 +1151,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		grantSupportAccess(nameOrSlugOrId, expiryTimestamp, callback) {
+		grantSupportAccess(nameOrSlugOrId, expiryTimestamp) {
 			if (expiryTimestamp == null || expiryTimestamp <= Date.now()) {
 				throw new errors.BalenaInvalidParameterError(
 					'expiryTimestamp',
@@ -1213,8 +1167,7 @@ const getApplicationModel = function(deps, opts) {
 						body: { is_accessible_by_support_until__date: expiryTimestamp },
 					}),
 				)
-				.catch(isNotFoundResponse, treatAsMissingApplication(nameOrSlugOrId))
-				.asCallback(callback);
+				.catch(isNotFoundResponse, treatAsMissingApplication(nameOrSlugOrId));
 		},
 
 		/**
@@ -1238,7 +1191,7 @@ const getApplicationModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		revokeSupportAccess: (nameOrSlugOrId, callback) =>
+		revokeSupportAccess: nameOrSlugOrId =>
 			getId(nameOrSlugOrId)
 				.then(applicationId =>
 					pine.patch({
@@ -1247,8 +1200,7 @@ const getApplicationModel = function(deps, opts) {
 						body: { is_accessible_by_support_until__date: null },
 					}),
 				)
-				.catch(isNotFoundResponse, treatAsMissingApplication(nameOrSlugOrId))
-				.asCallback(callback),
+				.catch(isNotFoundResponse, treatAsMissingApplication(nameOrSlugOrId)),
 
 		/**
 		 * @namespace balena.models.application.tags

--- a/lib/models/billing.ts
+++ b/lib/models/billing.ts
@@ -54,17 +54,14 @@ const getBillingModel = function(
 	 * 	console.log(billingAccount);
 	 * });
 	 */
-	exports.getAccount = (
-		callback?: (error?: Error, result?: BillingAccountInfo) => void,
-	): Promise<BillingAccountInfo> =>
+	exports.getAccount = (): Promise<BillingAccountInfo> =>
 		request
 			.send({
 				method: 'GET',
 				url: '/user/billing/account',
 				baseUrl: apiUrl,
 			})
-			.get('body')
-			.asCallback(callback);
+			.get('body');
 
 	/**
 	 * @summary Get the current billing plan
@@ -87,17 +84,14 @@ const getBillingModel = function(
 	 * 	console.log(billingPlan);
 	 * });
 	 */
-	exports.getPlan = (
-		callback?: (error?: Error, result?: BillingPlanInfo) => void,
-	): Promise<BillingPlanInfo> =>
+	exports.getPlan = (): Promise<BillingPlanInfo> =>
 		request
 			.send({
 				method: 'GET',
 				url: '/user/billing/plan',
 				baseUrl: apiUrl,
 			})
-			.get('body')
-			.asCallback(callback);
+			.get('body');
 
 	/**
 	 * @summary Get the current billing information
@@ -120,17 +114,14 @@ const getBillingModel = function(
 	 * 	console.log(billingInfo);
 	 * });
 	 */
-	exports.getBillingInfo = (
-		callback?: (error?: Error, result?: BillingInfo) => void,
-	): Promise<BillingInfo> =>
+	exports.getBillingInfo = (): Promise<BillingInfo> =>
 		request
 			.send({
 				method: 'GET',
 				url: '/user/billing/info',
 				baseUrl: apiUrl,
 			})
-			.get('body')
-			.asCallback(callback);
+			.get('body');
 
 	/**
 	 * @summary Update the current billing information
@@ -158,7 +149,6 @@ const getBillingModel = function(
 	 */
 	exports.updateBillingInfo = (
 		billingInfo: TokenBillingSubmitInfo,
-		callback?: (error?: Error, result?: BillingInfo) => void,
 	): Promise<BillingInfo> =>
 		request
 			.send({
@@ -167,8 +157,7 @@ const getBillingModel = function(
 				baseUrl: apiUrl,
 				body: billingInfo,
 			})
-			.get('body')
-			.asCallback(callback);
+			.get('body');
 
 	/**
 	 * @summary Get the available invoices
@@ -191,17 +180,14 @@ const getBillingModel = function(
 	 * 	console.log(invoices);
 	 * });
 	 */
-	exports.getInvoices = (
-		callback?: (error?: Error, result?: InvoiceInfo[]) => void,
-	): Promise<InvoiceInfo[]> =>
+	exports.getInvoices = (): Promise<InvoiceInfo[]> =>
 		request
 			.send({
 				method: 'GET',
 				url: '/user/billing/invoices',
 				baseUrl: apiUrl,
 			})
-			.get('body')
-			.asCallback(callback);
+			.get('body');
 
 	/**
 	 * @summary Download a specific invoice
@@ -226,21 +212,15 @@ const getBillingModel = function(
 	 */
 	exports.downloadInvoice = function(
 		invoiceNumber: string,
-		callback?: (
-			error?: Error,
-			result?: Blob | BalenaRequestStreamResult,
-		) => void,
 	): Promise<Blob | BalenaRequestStreamResult> {
 		const url = `/user/billing/invoices/${invoiceNumber}/download`;
 
 		if (!isBrowser) {
-			return request
-				.stream({
-					method: 'GET',
-					url,
-					baseUrl: apiUrl,
-				})
-				.asCallback(callback);
+			return request.stream({
+				method: 'GET',
+				url,
+				baseUrl: apiUrl,
+			});
 		}
 
 		return request
@@ -250,8 +230,7 @@ const getBillingModel = function(
 				baseUrl: apiUrl,
 				responseFormat: 'blob',
 			})
-			.get('body')
-			.asCallback(callback);
+			.get('body');
 	};
 
 	return exports;

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -73,7 +73,7 @@ const getConfigModel = function(deps, opts) {
 		 * 	console.log(config);
 		 * });
 		 */
-		getAll: callback =>
+		getAll: () =>
 			request
 				.send({
 					method: 'GET',
@@ -85,8 +85,7 @@ const getConfigModel = function(deps, opts) {
 				.then(function(body) {
 					body.deviceTypes = normalizeDeviceTypes(body.deviceTypes);
 					return body;
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Get device types
@@ -109,7 +108,7 @@ const getConfigModel = function(deps, opts) {
 		 * 	console.log(deviceTypes);
 		 * })
 		 */
-		getDeviceTypes: callback =>
+		getDeviceTypes: () =>
 			request
 				.send({
 					method: 'GET',
@@ -122,8 +121,7 @@ const getConfigModel = function(deps, opts) {
 						throw new Error('No device types');
 					}
 				})
-				.then(normalizeDeviceTypes)
-				.asCallback(callback),
+				.then(normalizeDeviceTypes),
 
 		/**
 		 * @summary Get configuration/initialization options for a device type
@@ -147,7 +145,7 @@ const getConfigModel = function(deps, opts) {
 		 * 	console.log(options);
 		 * });
 		 */
-		getDeviceOptions: (deviceType, callback) =>
+		getDeviceOptions: deviceType =>
 			deviceModel()
 				.getManifestBySlug(deviceType)
 				.then(function(manifest) {
@@ -155,8 +153,7 @@ const getConfigModel = function(deps, opts) {
 						manifest.initialization = {};
 					}
 					return union(manifest.options, manifest.initialization.options);
-				})
-				.asCallback(callback),
+				}),
 	};
 
 	return exports;

--- a/lib/models/device.js
+++ b/lib/models/device.js
@@ -26,7 +26,6 @@ import {
 	isId,
 	isNoDeviceForKeyResponse,
 	isNotFoundResponse,
-	findCallback,
 	getOsUpdateHelper as _getOsUpdateHelper,
 	deviceTypes as deviceTypesUtil,
 	mergePineOptions,
@@ -185,20 +184,18 @@ const getDeviceModel = function(deps, opts) {
 		return device;
 	};
 
-	const setLockOverriden = (uuidOrId, shouldOverride, callback) =>
-		getId(uuidOrId)
-			.then(function(deviceId) {
-				const value = shouldOverride ? '1' : '0';
-				return request.send({
-					method: 'POST',
-					url: `/device/${deviceId}/lock-override`,
-					baseUrl: apiUrl,
-					body: {
-						value,
-					},
-				});
-			})
-			.asCallback(callback);
+	const setLockOverriden = (uuidOrId, shouldOverride) =>
+		getId(uuidOrId).then(function(deviceId) {
+			const value = shouldOverride ? '1' : '0';
+			return request.send({
+				method: 'POST',
+				url: `/device/${deviceId}/lock-override`,
+				baseUrl: apiUrl,
+				body: {
+					value,
+				},
+			});
+		});
 
 	const exports = {
 		OverallStatus,
@@ -257,19 +254,17 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(devices);
 		 * });
 		 */
-		getAll(options, callback = undefined) {
+		getAll(options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return pine
 				.get({
 					resource: 'device',
 					options: mergePineOptions({ $orderby: 'device_name asc' }, options),
 				})
-				.map(addExtraInfo)
-				.asCallback(callback);
+				.map(addExtraInfo);
 		},
 
 		/**
@@ -312,11 +307,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(devices);
 		 * });
 		 */
-		getAllByApplication(nameOrSlugOrId, options, callback) {
+		getAllByApplication(nameOrSlugOrId, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return applicationModel()
 				.get(nameOrSlugOrId, { $select: 'id' })
@@ -326,7 +320,6 @@ const getDeviceModel = function(deps, opts) {
 							{ $filter: { belongs_to__application: id } },
 							options,
 						),
-						callback,
 					),
 				);
 		},
@@ -359,11 +352,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(devices);
 		 * });
 		 */
-		getAllByParentDevice(parentUuidOrId, options, callback) {
+		getAllByParentDevice(parentUuidOrId, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return exports
 				.get(parentUuidOrId, { $select: 'id' })
@@ -373,7 +365,6 @@ const getDeviceModel = function(deps, opts) {
 							{ $filter: { is_managed_by__device: id } },
 							options,
 						),
-						callback,
 					),
 				);
 		},
@@ -418,11 +409,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(device);
 		 * });
 		 */
-		get(uuidOrId, options, callback = undefined) {
+		get(uuidOrId, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return Promise.try(function() {
 				if (uuidOrId == null) {
@@ -465,9 +455,7 @@ const getDeviceModel = function(deps, opts) {
 						})
 						.get(0);
 				}
-			})
-				.then(addExtraInfo)
-				.asCallback(callback);
+			}).then(addExtraInfo);
 		},
 
 		/**
@@ -505,19 +493,17 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(device);
 		 * });
 		 */
-		getWithServiceDetails(uuidOrId, options, callback) {
+		getWithServiceDetails(uuidOrId, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return exports
 				.get(
 					uuidOrId,
 					mergePineOptions(getCurrentServiceDetailsPineOptions(true), options),
 				)
-				.then(generateCurrentServiceDetails)
-				.asCallback(callback);
+				.then(generateCurrentServiceDetails);
 		},
 
 		/**
@@ -542,11 +528,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(devices);
 		 * });
 		 */
-		getByName(name, options, callback) {
+		getByName(name, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return exports
 				.getAll(mergePineOptions({ $filter: { device_name: name } }, options))
@@ -554,8 +539,7 @@ const getDeviceModel = function(deps, opts) {
 					if (devices.length === 0) {
 						throw new errors.BalenaDeviceNotFound(name);
 					}
-				})
-				.asCallback(callback);
+				});
 		},
 
 		/**
@@ -585,11 +569,8 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(deviceName);
 		 * });
 		 */
-		getName: (uuidOrId, callback) =>
-			exports
-				.get(uuidOrId, { $select: 'device_name' })
-				.get('device_name')
-				.asCallback(callback),
+		getName: uuidOrId =>
+			exports.get(uuidOrId, { $select: 'device_name' }).get('device_name'),
 
 		/**
 		 * @summary Get application name
@@ -618,14 +599,13 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(applicationName);
 		 * });
 		 */
-		getApplicationName: (uuidOrId, callback) =>
+		getApplicationName: uuidOrId =>
 			exports
 				.get(uuidOrId, {
 					$select: 'id',
 					$expand: { belongs_to__application: { $select: 'app_name' } },
 				})
-				.then(device => device.belongs_to__application[0].app_name)
-				.asCallback(callback),
+				.then(device => device.belongs_to__application[0].app_name),
 
 		/**
 		 * @summary Get application container information
@@ -658,7 +638,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(appInfo);
 		 * });
 		 */
-		getApplicationInfo: (uuidOrId, callback) =>
+		getApplicationInfo: uuidOrId =>
 			exports
 				.get(uuidOrId, {
 					$select: ['id', 'supervisor_version'],
@@ -681,8 +661,7 @@ const getDeviceModel = function(deps, opts) {
 						},
 					});
 				})
-				.get('body')
-				.asCallback(callback),
+				.get('body'),
 
 		/**
 		 * @summary Check if a device exists
@@ -711,12 +690,11 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(hasDevice);
 		 * });
 		 */
-		has: (uuidOrId, callback) =>
+		has: uuidOrId =>
 			exports
 				.get(uuidOrId, { $select: ['id'] })
 				.return(true)
-				.catch(errors.BalenaDeviceNotFound, () => false)
-				.asCallback(callback),
+				.catch(errors.BalenaDeviceNotFound, () => false),
 
 		/**
 		 * @summary Check if a device is online
@@ -745,11 +723,8 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log('Is device online?', isOnline);
 		 * });
 		 */
-		isOnline: (uuidOrId, callback) =>
-			exports
-				.get(uuidOrId, { $select: 'is_online' })
-				.get('is_online')
-				.asCallback(callback),
+		isOnline: uuidOrId =>
+			exports.get(uuidOrId, { $select: 'is_online' }).get('is_online'),
 
 		/**
 		 * @summary Get the local IP addresses of a device
@@ -786,7 +761,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	});
 		 * });
 		 */
-		getLocalIPAddresses: (uuidOrId, callback) =>
+		getLocalIPAddresses: uuidOrId =>
 			exports
 				.get(uuidOrId, { $select: ['is_online', 'ip_address', 'vpn_address'] })
 				.then(function({ is_online, ip_address, vpn_address }) {
@@ -796,8 +771,7 @@ const getDeviceModel = function(deps, opts) {
 
 					const ips = ip_address.split(' ');
 					return ips.filter(ip => ip !== vpn_address);
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Remove device
@@ -820,20 +794,17 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		remove: (uuidOrId, callback) =>
-			exports
-				.get(uuidOrId, { $select: 'uuid' })
-				.then(({ uuid }) =>
-					pine.delete({
-						resource: 'device',
-						options: {
-							$filter: {
-								uuid,
-							},
+		remove: uuidOrId =>
+			exports.get(uuidOrId, { $select: 'uuid' }).then(({ uuid }) =>
+				pine.delete({
+					resource: 'device',
+					options: {
+						$filter: {
+							uuid,
 						},
-					}),
-				)
-				.asCallback(callback),
+					},
+				}),
+			),
 
 		/**
 		 * @summary Identify device
@@ -856,7 +827,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		identify: (uuidOrId, callback) =>
+		identify: uuidOrId =>
 			exports
 				.get(uuidOrId)
 				.then(device =>
@@ -869,8 +840,7 @@ const getDeviceModel = function(deps, opts) {
 						},
 					}),
 				)
-				.return(undefined)
-				.asCallback(callback),
+				.return(undefined),
 
 		/**
 		 * @summary Rename device
@@ -895,23 +865,20 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		rename: (uuidOrId, newName, callback) =>
-			exports
-				.get(uuidOrId, { $select: 'uuid' })
-				.then(({ uuid }) =>
-					pine.patch({
-						resource: 'device',
-						body: {
-							device_name: newName,
+		rename: (uuidOrId, newName) =>
+			exports.get(uuidOrId, { $select: 'uuid' }).then(({ uuid }) =>
+				pine.patch({
+					resource: 'device',
+					body: {
+						device_name: newName,
+					},
+					options: {
+						$filter: {
+							uuid,
 						},
-						options: {
-							$filter: {
-								uuid,
-							},
-						},
-					}),
-				)
-				.asCallback(callback),
+					},
+				}),
+			),
 
 		/**
 		 * @summary Note a device
@@ -936,23 +903,20 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		note: (uuidOrId, note, callback) =>
-			exports
-				.get(uuidOrId, { $select: 'uuid' })
-				.then(({ uuid }) =>
-					pine.patch({
-						resource: 'device',
-						body: {
-							note,
+		note: (uuidOrId, note) =>
+			exports.get(uuidOrId, { $select: 'uuid' }).then(({ uuid }) =>
+				pine.patch({
+					resource: 'device',
+					body: {
+						note,
+					},
+					options: {
+						$filter: {
+							uuid,
 						},
-						options: {
-							$filter: {
-								uuid,
-							},
-						},
-					}),
-				)
-				.asCallback(callback),
+					},
+				}),
+			),
 
 		/**
 		 * @summary Set a custom location for a device
@@ -977,24 +941,21 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		setCustomLocation: (uuidOrId, location, callback) =>
-			exports
-				.get(uuidOrId, { $select: 'uuid' })
-				.then(({ uuid }) =>
-					pine.patch({
-						resource: 'device',
-						body: {
-							custom_latitude: String(location.latitude),
-							custom_longitude: String(location.longitude),
+		setCustomLocation: (uuidOrId, location) =>
+			exports.get(uuidOrId, { $select: 'uuid' }).then(({ uuid }) =>
+				pine.patch({
+					resource: 'device',
+					body: {
+						custom_latitude: String(location.latitude),
+						custom_longitude: String(location.longitude),
+					},
+					options: {
+						$filter: {
+							uuid,
 						},
-						options: {
-							$filter: {
-								uuid,
-							},
-						},
-					}),
-				)
-				.asCallback(callback),
+					},
+				}),
+			),
 
 		/**
 		 * @summary Clear the custom location of a device
@@ -1018,15 +979,11 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		unsetCustomLocation: (uuidOrId, callback) =>
-			exports.setCustomLocation(
-				uuidOrId,
-				{
-					latitude: '',
-					longitude: '',
-				},
-				callback,
-			),
+		unsetCustomLocation: uuidOrId =>
+			exports.setCustomLocation(uuidOrId, {
+				latitude: '',
+				longitude: '',
+			}),
 
 		/**
 		 * @summary Move a device to another application
@@ -1054,46 +1011,44 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		move: (uuidOrId, applicationNameOrSlugOrId, callback) =>
+		move: (uuidOrId, applicationNameOrSlugOrId) =>
 			Promise.props({
 				device: exports.get(uuidOrId, { $select: ['uuid', 'device_type'] }),
 				deviceTypes: configModel().getDeviceTypes(),
 				application: applicationModel().get(applicationNameOrSlugOrId, {
 					$select: ['id', 'device_type'],
 				}),
-			})
-				.then(function({ application, device, deviceTypes }) {
-					const osDeviceType = deviceTypesUtil.getBySlug(
-						deviceTypes,
-						device.device_type,
+			}).then(function({ application, device, deviceTypes }) {
+				const osDeviceType = deviceTypesUtil.getBySlug(
+					deviceTypes,
+					device.device_type,
+				);
+				const targetAppDeviceType = deviceTypesUtil.getBySlug(
+					deviceTypes,
+					application.device_type,
+				);
+				const isCompatibleMove = deviceTypesUtil.isDeviceTypeCompatibleWith(
+					osDeviceType,
+					targetAppDeviceType,
+				);
+				if (!isCompatibleMove) {
+					throw new errors.BalenaInvalidDeviceType(
+						`Incompatible application: ${applicationNameOrSlugOrId}`,
 					);
-					const targetAppDeviceType = deviceTypesUtil.getBySlug(
-						deviceTypes,
-						application.device_type,
-					);
-					const isCompatibleMove = deviceTypesUtil.isDeviceTypeCompatibleWith(
-						osDeviceType,
-						targetAppDeviceType,
-					);
-					if (!isCompatibleMove) {
-						throw new errors.BalenaInvalidDeviceType(
-							`Incompatible application: ${applicationNameOrSlugOrId}`,
-						);
-					}
+				}
 
-					return pine.patch({
-						resource: 'device',
-						body: {
-							belongs_to__application: application.id,
+				return pine.patch({
+					resource: 'device',
+					body: {
+						belongs_to__application: application.id,
+					},
+					options: {
+						$filter: {
+							uuid: device.uuid,
 						},
-						options: {
-							$filter: {
-								uuid: device.uuid,
-							},
-						},
-					});
-				})
-				.asCallback(callback),
+					},
+				});
+			}),
 
 		/**
 		 * @summary Start application on device
@@ -1126,7 +1081,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(containerId);
 		 * });
 		 */
-		startApplication: (uuidOrId, callback) =>
+		startApplication: uuidOrId =>
 			exports
 				.get(uuidOrId, {
 					$select: ['id', 'supervisor_version'],
@@ -1150,8 +1105,7 @@ const getDeviceModel = function(deps, opts) {
 					});
 				})
 				.get('body')
-				.get('containerId')
-				.asCallback(callback),
+				.get('containerId'),
 
 		/**
 		 * @summary Stop application on device
@@ -1184,7 +1138,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(containerId);
 		 * });
 		 */
-		stopApplication: (uuidOrId, callback) =>
+		stopApplication: uuidOrId =>
 			exports
 				.get(uuidOrId, {
 					$select: ['id', 'supervisor_version'],
@@ -1208,8 +1162,7 @@ const getDeviceModel = function(deps, opts) {
 					});
 				})
 				.get('body')
-				.get('containerId')
-				.asCallback(callback),
+				.get('containerId'),
 
 		/**
 		 * @summary Restart application on device
@@ -1237,7 +1190,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		restartApplication: (uuidOrId, callback) =>
+		restartApplication: uuidOrId =>
 			getId(uuidOrId)
 				.then(deviceId =>
 					request.send({
@@ -1248,8 +1201,7 @@ const getDeviceModel = function(deps, opts) {
 					}),
 				)
 				.get('body')
-				.catch(isNotFoundResponse, treatAsMissingDevice(uuidOrId))
-				.asCallback(callback),
+				.catch(isNotFoundResponse, treatAsMissingDevice(uuidOrId)),
 
 		/**
 		 * @summary Start a service on a device
@@ -1278,7 +1230,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	...
 		 * });
 		 */
-		startService: (uuidOrId, imageId, callback) =>
+		startService: (uuidOrId, imageId) =>
 			exports
 				.get(uuidOrId, {
 					$select: ['id', 'supervisor_version'],
@@ -1304,8 +1256,7 @@ const getDeviceModel = function(deps, opts) {
 						},
 						timeout: CONTAINER_ACTION_ENDPOINT_TIMEOUT,
 					});
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Stop a service on a device
@@ -1334,7 +1285,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	...
 		 * });
 		 */
-		stopService: (uuidOrId, imageId, callback) =>
+		stopService: (uuidOrId, imageId) =>
 			exports
 				.get(uuidOrId, {
 					$select: ['id', 'supervisor_version'],
@@ -1360,8 +1311,7 @@ const getDeviceModel = function(deps, opts) {
 						},
 						timeout: CONTAINER_ACTION_ENDPOINT_TIMEOUT,
 					});
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Restart a service on a device
@@ -1390,7 +1340,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	...
 		 * });
 		 */
-		restartService: (uuidOrId, imageId, callback) =>
+		restartService: (uuidOrId, imageId) =>
 			exports
 				.get(uuidOrId, {
 					$select: ['id', 'supervisor_version'],
@@ -1416,8 +1366,7 @@ const getDeviceModel = function(deps, opts) {
 						},
 						timeout: CONTAINER_ACTION_ENDPOINT_TIMEOUT,
 					});
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Reboot device
@@ -1442,11 +1391,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		reboot(uuidOrId, options, callback) {
+		reboot(uuidOrId, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return getId(uuidOrId)
 				.then(deviceId =>
@@ -1471,8 +1419,7 @@ const getDeviceModel = function(deps, opts) {
 						}),
 				)
 				.get('body')
-				.catch(isNotFoundResponse, treatAsMissingDevice(uuidOrId))
-				.asCallback(callback);
+				.catch(isNotFoundResponse, treatAsMissingDevice(uuidOrId));
 		},
 
 		/**
@@ -1498,11 +1445,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		shutdown(uuidOrId, options, callback) {
+		shutdown(uuidOrId, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return exports
 				.get(uuidOrId, {
@@ -1530,8 +1476,7 @@ const getDeviceModel = function(deps, opts) {
 
 							throw err;
 						}),
-				)
-				.asCallback(callback);
+				);
 		},
 
 		/**
@@ -1558,7 +1503,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		purge: (uuidOrId, callback) =>
+		purge: uuidOrId =>
 			exports
 				.get(uuidOrId, {
 					$select: 'id',
@@ -1585,8 +1530,7 @@ const getDeviceModel = function(deps, opts) {
 
 							throw err;
 						}),
-				)
-				.asCallback(callback),
+				),
 
 		/**
 		 * @summary Trigger an update check on the supervisor
@@ -1617,11 +1561,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		update(uuidOrId, options, callback) {
+		update(uuidOrId, options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
 			return exports
 				.get(uuidOrId, {
@@ -1641,8 +1584,7 @@ const getDeviceModel = function(deps, opts) {
 							},
 						},
 					}),
-				)
-				.asCallback(callback);
+				);
 		},
 
 		/**
@@ -1671,7 +1613,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(state);
 		 * });
 		 */
-		getSupervisorTargetState: (uuidOrId, callback) =>
+		getSupervisorTargetState: uuidOrId =>
 			exports
 				.get(uuidOrId, { $select: 'uuid' })
 				.then(({ uuid }) =>
@@ -1680,8 +1622,7 @@ const getDeviceModel = function(deps, opts) {
 						baseUrl: apiUrl,
 					}),
 				)
-				.get('body')
-				.asCallback(callback),
+				.get('body'),
 
 		/**
 		 * @summary Get the supervisor state on a device
@@ -1709,7 +1650,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(state);
 		 * });
 		 */
-		getSupervisorState: (uuidOrId, callback) =>
+		getSupervisorState: uuidOrId =>
 			exports
 				.get(uuidOrId, { $select: 'uuid' })
 				.then(({ uuid }) =>
@@ -1723,8 +1664,7 @@ const getDeviceModel = function(deps, opts) {
 						},
 					}),
 				)
-				.get('body')
-				.asCallback(callback),
+				.get('body'),
 
 		/**
 		 * @summary Get display name for a device
@@ -1752,7 +1692,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	// Raspberry Pi
 		 * });
 		 */
-		getDisplayName: (deviceTypeSlug, callback) =>
+		getDisplayName: deviceTypeSlug =>
 			exports
 				.getManifestBySlug(deviceTypeSlug)
 				.get('name')
@@ -1762,8 +1702,7 @@ const getDeviceModel = function(deps, opts) {
 					}
 
 					throw error;
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Get device slug
@@ -1791,7 +1730,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	// raspberry-pi
 		 * });
 		 */
-		getDeviceSlug: (deviceTypeName, callback) =>
+		getDeviceSlug: deviceTypeName =>
 			exports
 				.getManifestBySlug(deviceTypeName)
 				.get('slug')
@@ -1801,8 +1740,7 @@ const getDeviceModel = function(deps, opts) {
 					}
 
 					throw error;
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Get supported device types
@@ -1830,11 +1768,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	});
 		 * });
 		 */
-		getSupportedDeviceTypes: callback =>
+		getSupportedDeviceTypes: () =>
 			configModel()
 				.getDeviceTypes()
-				.then(deviceTypes => deviceTypes.map(dt => dt.name))
-				.asCallback(callback),
+				.then(deviceTypes => deviceTypes.map(dt => dt.name)),
 
 		/**
 		 * @summary Get a device manifest by slug
@@ -1858,7 +1795,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(manifest);
 		 * });
 		 */
-		getManifestBySlug: (slug, callback = undefined) =>
+		getManifestBySlug: slug =>
 			configModel()
 				.getDeviceTypes()
 				.then(deviceTypes =>
@@ -1875,8 +1812,7 @@ const getDeviceModel = function(deps, opts) {
 					}
 
 					return deviceManifest;
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Get a device manifest by application name
@@ -1905,12 +1841,11 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(manifest);
 		 * });
 		 */
-		getManifestByApplication: (nameOrSlugOrId, callback) =>
+		getManifestByApplication: nameOrSlugOrId =>
 			applicationModel()
 				.get(nameOrSlugOrId, { $select: 'device_type' })
 				.get('device_type')
-				.then(exports.getManifestBySlug)
-				.asCallback(callback),
+				.then(exports.getManifestBySlug),
 
 		/**
 		 * @summary Generate a random key, useful for both uuid and api key.
@@ -1960,9 +1895,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(registrationInfo);
 		 * });
 		 */
-		register(applicationNameOrSlugOrId, uuid, callback) {
-			callback = findCallback(arguments);
-
+		register(applicationNameOrSlugOrId, uuid) {
 			return Promise.props({
 				userId: sdkInstance.auth.getUserId(),
 				apiKey: applicationModel().generateProvisioningKey(
@@ -1971,18 +1904,16 @@ const getDeviceModel = function(deps, opts) {
 				application: applicationModel().get(applicationNameOrSlugOrId, {
 					$select: ['id', 'device_type'],
 				}),
-			})
-				.then(({ userId, apiKey, application }) =>
-					registerDevice.register({
-						userId,
-						applicationId: application.id,
-						uuid,
-						deviceType: application.device_type,
-						provisioningApiKey: apiKey,
-						apiEndpoint: apiUrl,
-					}),
-				)
-				.asCallback(callback);
+			}).then(({ userId, apiKey, application }) =>
+				registerDevice.register({
+					userId,
+					applicationId: application.id,
+					uuid,
+					deviceType: application.device_type,
+					provisioningApiKey: apiKey,
+					apiEndpoint: apiUrl,
+				}),
+			);
 		},
 
 		/**
@@ -2011,7 +1942,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(deviceApiKey);
 		 * });
 		 */
-		generateDeviceKey: (uuidOrId, callback) =>
+		generateDeviceKey: uuidOrId =>
 			getId(uuidOrId)
 				.then(deviceId =>
 					request.send({
@@ -2021,8 +1952,7 @@ const getDeviceModel = function(deps, opts) {
 					}),
 				)
 				.get('body')
-				.catch(isNoDeviceForKeyResponse, treatAsMissingDevice(uuidOrId))
-				.asCallback(callback),
+				.catch(isNoDeviceForKeyResponse, treatAsMissingDevice(uuidOrId)),
 
 		/**
 		 * @summary Check if a device is web accessible with device utls
@@ -2058,11 +1988,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	}
 		 * });
 		 */
-		hasDeviceUrl: (uuidOrId, callback = undefined) =>
+		hasDeviceUrl: uuidOrId =>
 			exports
 				.get(uuidOrId, { $select: 'is_web_accessible' })
-				.get('is_web_accessible')
-				.asCallback(callback),
+				.get('is_web_accessible'),
 
 		/**
 		 * @summary Get a device url
@@ -2091,22 +2020,19 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(url);
 		 * });
 		 */
-		getDeviceUrl: (uuidOrId, callback) =>
-			exports
-				.hasDeviceUrl(uuidOrId)
-				.then(function(hasDeviceUrl) {
-					if (!hasDeviceUrl) {
-						throw new Error(`Device is not web accessible: ${uuidOrId}`);
-					}
+		getDeviceUrl: uuidOrId =>
+			exports.hasDeviceUrl(uuidOrId).then(function(hasDeviceUrl) {
+				if (!hasDeviceUrl) {
+					throw new Error(`Device is not web accessible: ${uuidOrId}`);
+				}
 
-					return getDeviceUrlsBase().then($deviceUrlsBase =>
-						exports
-							.get(uuidOrId, { $select: 'uuid' })
-							.get('uuid')
-							.then(uuid => `https://${uuid}.${$deviceUrlsBase}`),
-					);
-				})
-				.asCallback(callback),
+				return getDeviceUrlsBase().then($deviceUrlsBase =>
+					exports
+						.get(uuidOrId, { $select: 'uuid' })
+						.get('uuid')
+						.then(uuid => `https://${uuid}.${$deviceUrlsBase}`),
+				);
+			}),
 
 		/**
 		 * @summary Enable device url for a device
@@ -2129,23 +2055,20 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		enableDeviceUrl: (uuidOrId, callback) =>
-			exports
-				.get(uuidOrId, { $select: 'uuid' })
-				.then(({ uuid }) =>
-					pine.patch({
-						resource: 'device',
-						body: {
-							is_web_accessible: true,
+		enableDeviceUrl: uuidOrId =>
+			exports.get(uuidOrId, { $select: 'uuid' }).then(({ uuid }) =>
+				pine.patch({
+					resource: 'device',
+					body: {
+						is_web_accessible: true,
+					},
+					options: {
+						$filter: {
+							uuid,
 						},
-						options: {
-							$filter: {
-								uuid,
-							},
-						},
-					}),
-				)
-				.asCallback(callback),
+					},
+				}),
+			),
 
 		/**
 		 * @summary Disable device url for a device
@@ -2168,23 +2091,20 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		disableDeviceUrl: (uuidOrId, callback) =>
-			exports
-				.get(uuidOrId, { $select: 'uuid' })
-				.then(({ uuid }) =>
-					pine.patch({
-						resource: 'device',
-						body: {
-							is_web_accessible: false,
+		disableDeviceUrl: uuidOrId =>
+			exports.get(uuidOrId, { $select: 'uuid' }).then(({ uuid }) =>
+				pine.patch({
+					resource: 'device',
+					body: {
+						is_web_accessible: false,
+					},
+					options: {
+						$filter: {
+							uuid,
 						},
-						options: {
-							$filter: {
-								uuid,
-							},
-						},
-					}),
-				)
-				.asCallback(callback),
+					},
+				}),
+			),
 
 		/**
 		 * @summary Enable local mode
@@ -2207,15 +2127,14 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		enableLocalMode(uuidOrId, callback) {
+		enableLocalMode(uuidOrId) {
 			const selectedProps = ['id', ...LOCAL_MODE_SUPPORT_PROPERTIES];
 			return exports
 				.get(uuidOrId, { $select: selectedProps })
 				.then(function(device) {
 					checkLocalModeSupported(device);
 					return exports.configVar.set(device.id, LOCAL_MODE_ENV_VAR, '1');
-				})
-				.asCallback(callback);
+				});
 		},
 
 		/**
@@ -2239,10 +2158,8 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		disableLocalMode: (uuidOrId, callback) =>
-			exports.configVar
-				.set(uuidOrId, LOCAL_MODE_ENV_VAR, '0')
-				.asCallback(callback),
+		disableLocalMode: uuidOrId =>
+			exports.configVar.set(uuidOrId, LOCAL_MODE_ENV_VAR, '0'),
 
 		/**
 		 * @summary Check if local mode is enabled on the device
@@ -2278,11 +2195,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	}
 		 * });
 		 */
-		isInLocalMode: (uuidOrId, callback) =>
+		isInLocalMode: uuidOrId =>
 			exports.configVar
 				.get(uuidOrId, LOCAL_MODE_ENV_VAR)
-				.then(value => value === '1')
-				.asCallback(callback),
+				.then(value => value === '1'),
 
 		/**
 		 * @summary Returns whether local mode is supported along with a message describing the reason why local mode is not supported.
@@ -2322,8 +2238,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		enableLockOverride: (uuidOrId, callback) =>
-			setLockOverriden(uuidOrId, true, callback),
+		enableLockOverride: uuidOrId => setLockOverriden(uuidOrId, true),
 
 		/**
 		 * @summary Disable lock override
@@ -2346,8 +2261,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		disableLockOverride: (uuidOrId, callback) =>
-			setLockOverriden(uuidOrId, false, callback),
+		disableLockOverride: uuidOrId => setLockOverriden(uuidOrId, false),
 
 		/**
 		 * @summary Check if a device has the lock override enabled
@@ -2370,7 +2284,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		hasLockOverride: (uuidOrId, callback) =>
+		hasLockOverride: uuidOrId =>
 			getId(uuidOrId)
 				.then(deviceId =>
 					request.send({
@@ -2379,8 +2293,7 @@ const getDeviceModel = function(deps, opts) {
 						baseUrl: apiUrl,
 					}),
 				)
-				.then(({ body }) => body === '1')
-				.asCallback(callback),
+				.then(({ body }) => body === '1'),
 
 		/**
 		 * @summary Ping a device
@@ -2406,7 +2319,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		ping: (uuidOrId, callback) =>
+		ping: uuidOrId =>
 			exports
 				.get(uuidOrId, {
 					$select: 'id',
@@ -2423,8 +2336,7 @@ const getDeviceModel = function(deps, opts) {
 							appId: device.belongs_to__application[0].id,
 						},
 					}),
-				)
-				.asCallback(callback),
+				),
 
 		/**
 		 * @summary Get the status of a device
@@ -2460,15 +2372,14 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(status);
 		 * });
 		 */
-		getStatus(uuidOrId, callback) {
+		getStatus(uuidOrId) {
 			if (typeof uuidOrId !== 'string' && typeof uuidOrId !== 'number') {
 				throw new errors.BalenaInvalidParameterError('uuidOrId', uuidOrId);
 			}
 
 			return exports
 				.get(uuidOrId, { $select: 'overall_status' })
-				.then(({ overall_status }) => overall_status)
-				.asCallback(callback);
+				.then(({ overall_status }) => overall_status);
 		},
 
 		/**
@@ -2505,15 +2416,14 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(progress);
 		 * });
 		 */
-		getProgress(uuidOrId, callback) {
+		getProgress(uuidOrId) {
 			if (typeof uuidOrId !== 'string' && typeof uuidOrId !== 'number') {
 				throw new errors.BalenaInvalidParameterError('uuidOrId', uuidOrId);
 			}
 
 			return exports
 				.get(uuidOrId, { $select: 'overall_progress' })
-				.then(({ overall_progress }) => overall_progress)
-				.asCallback(callback);
+				.then(({ overall_progress }) => overall_progress);
 		},
 
 		/**
@@ -2538,7 +2448,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		grantSupportAccess(uuidOrId, expiryTimestamp, callback) {
+		grantSupportAccess(uuidOrId, expiryTimestamp) {
 			if (expiryTimestamp == null || expiryTimestamp <= Date.now()) {
 				throw new errors.BalenaInvalidParameterError(
 					'expiryTimestamp',
@@ -2546,16 +2456,13 @@ const getDeviceModel = function(deps, opts) {
 				);
 			}
 
-			return exports
-				.get(uuidOrId, { $select: 'id' })
-				.then(({ id }) =>
-					pine.patch({
-						resource: 'device',
-						id,
-						body: { is_accessible_by_support_until__date: expiryTimestamp },
-					}),
-				)
-				.asCallback(callback);
+			return exports.get(uuidOrId, { $select: 'id' }).then(({ id }) =>
+				pine.patch({
+					resource: 'device',
+					id,
+					body: { is_accessible_by_support_until__date: expiryTimestamp },
+				}),
+			);
 		},
 
 		/**
@@ -2579,17 +2486,14 @@ const getDeviceModel = function(deps, opts) {
 		 * 	if (error) throw error;
 		 * });
 		 */
-		revokeSupportAccess: (uuidOrId, callback) =>
-			exports
-				.get(uuidOrId, { $select: 'id' })
-				.then(({ id }) =>
-					pine.patch({
-						resource: 'device',
-						id,
-						body: { is_accessible_by_support_until__date: null },
-					}),
-				)
-				.asCallback(callback),
+		revokeSupportAccess: uuidOrId =>
+			exports.get(uuidOrId, { $select: 'id' }).then(({ id }) =>
+				pine.patch({
+					resource: 'device',
+					id,
+					body: { is_accessible_by_support_until__date: null },
+				}),
+			),
 
 		/**
 		 * @summary Get a string showing when a device was last set as online
@@ -2663,11 +2567,10 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(isEnabled);
 		 * });
 		 */
-		isTrackingApplicationRelease: (uuidOrId, callback) =>
+		isTrackingApplicationRelease: uuidOrId =>
 			exports
 				.get(uuidOrId, { $select: 'should_be_running__release' })
-				.then(({ should_be_running__release }) => !should_be_running__release)
-				.asCallback(callback),
+				.then(({ should_be_running__release }) => !should_be_running__release),
 
 		/**
 		 * @summary Get the hash of the currently tracked release for a specific device
@@ -2690,7 +2593,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(release);
 		 * });
 		 */
-		getTargetReleaseHash: (uuidOrId, callback) =>
+		getTargetReleaseHash: uuidOrId =>
 			exports
 				.get(uuidOrId, {
 					$select: 'id',
@@ -2711,8 +2614,7 @@ const getDeviceModel = function(deps, opts) {
 						return should_be_running__release[0].commit;
 					}
 					return belongs_to__application[0].commit;
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @summary Set a specific device to run a particular release
@@ -2744,7 +2646,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	...
 		 * });
 		 */
-		pinToRelease: (uuidOrId, fullReleaseHashOrId, callback) =>
+		pinToRelease: (uuidOrId, fullReleaseHashOrId) =>
 			Promise.try(function() {
 				if (isId(uuidOrId) && isId(fullReleaseHashOrId)) {
 					return {
@@ -2787,15 +2689,13 @@ const getDeviceModel = function(deps, opts) {
 							releaseId: release.id,
 						};
 					});
-			})
-				.then(({ deviceId, releaseId }) =>
-					pine.patch({
-						resource: 'device',
-						id: deviceId,
-						body: { should_be_running__release: releaseId },
-					}),
-				)
-				.asCallback(callback),
+			}).then(({ deviceId, releaseId }) =>
+				pine.patch({
+					resource: 'device',
+					id: deviceId,
+					body: { should_be_running__release: releaseId },
+				}),
+			),
 
 		/**
 		 * @summary Configure a specific device to track the current application release
@@ -2820,16 +2720,14 @@ const getDeviceModel = function(deps, opts) {
 		 * 	...
 		 * });
 		 */
-		trackApplicationRelease: (uuidOrId, callback) =>
-			getId(uuidOrId)
-				.then(deviceId =>
-					pine.patch({
-						resource: 'device',
-						id: deviceId,
-						body: { should_be_running__release: null },
-					}),
-				)
-				.asCallback(callback),
+		trackApplicationRelease: uuidOrId =>
+			getId(uuidOrId).then(deviceId =>
+				pine.patch({
+					resource: 'device',
+					id: deviceId,
+					body: { should_be_running__release: null },
+				}),
+			),
 
 		/**
 		 * @summary Check whether the provided device can update to the target os version
@@ -2896,7 +2794,7 @@ const getDeviceModel = function(deps, opts) {
 
 		// TODO: This is a temporary solution for ESR, as the ESR-supported versions are not part of the SDK yet.
 		// 	It should be removed once the getSupportedVersions is updated to support ESR as well.
-		_startOsUpdate: (uuid, targetOsVersion, skipCheck, callback) =>
+		_startOsUpdate: (uuid, targetOsVersion, skipCheck) =>
 			Promise.try(function() {
 				if (!targetOsVersion) {
 					throw new errors.BalenaInvalidParameterError(
@@ -2937,8 +2835,7 @@ const getDeviceModel = function(deps, opts) {
 				})
 				.then(osUpdateHelper =>
 					osUpdateHelper.startOsUpdate(uuid, targetOsVersion),
-				)
-				.asCallback(callback),
+				),
 		/**
 		 * @summary Start an OS update on a device
 		 * @name startOsUpdate
@@ -2965,7 +2862,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(result.status);
 		 * });
 		 */
-		startOsUpdate: (uuid, targetOsVersion, callback) =>
+		startOsUpdate: (uuid, targetOsVersion) =>
 			Promise.try(function() {
 				if (!targetOsVersion) {
 					throw new errors.BalenaInvalidParameterError(
@@ -2999,8 +2896,7 @@ const getDeviceModel = function(deps, opts) {
 				})
 				.then(osUpdateHelper =>
 					osUpdateHelper.startOsUpdate(uuid, targetOsVersion),
-				)
-				.asCallback(callback),
+				),
 
 		/**
 		 * @summary Get the OS update status of a device
@@ -3024,7 +2920,7 @@ const getDeviceModel = function(deps, opts) {
 		 * 	console.log(result.status);
 		 * });
 		 */
-		getOsUpdateStatus: (uuid, callback) =>
+		getOsUpdateStatus: uuid =>
 			getOsUpdateHelper()
 				.then(osUpdateHelper => osUpdateHelper.getOsUpdateStatus(uuid))
 				.catch(function(err) {
@@ -3041,8 +2937,7 @@ const getDeviceModel = function(deps, opts) {
 							// if the device exists, then re-throw the original error
 							.throw(err)
 					);
-				})
-				.asCallback(callback),
+				}),
 
 		/**
 		 * @namespace balena.models.device.tags
@@ -3077,7 +2972,7 @@ const getDeviceModel = function(deps, opts) {
 			 * 	console.log(tags)
 			 * });
 			 */
-			getAllByApplication(nameOrSlugOrId, options, callback) {
+			getAllByApplication(nameOrSlugOrId, options) {
 				if (options == null) {
 					options = {};
 				}
@@ -3100,8 +2995,7 @@ const getDeviceModel = function(deps, opts) {
 								options,
 							),
 						),
-					)
-					.asCallback(callback);
+					);
 			},
 
 			/**
@@ -3269,11 +3163,10 @@ const getDeviceModel = function(deps, opts) {
 			 * 	console.log(vars)
 			 * });
 			 */
-			getAllByApplication(nameOrSlugOrId, options, callback) {
+			getAllByApplication(nameOrSlugOrId, options) {
 				if (options == null) {
 					options = {};
 				}
-				callback = findCallback(arguments);
 
 				return applicationModel()
 					.get(nameOrSlugOrId, { $select: 'id' })
@@ -3299,8 +3192,7 @@ const getDeviceModel = function(deps, opts) {
 								options,
 							),
 						),
-					)
-					.asCallback(callback);
+					);
 			},
 
 			/**
@@ -3456,11 +3348,10 @@ const getDeviceModel = function(deps, opts) {
 			 * 	console.log(vars)
 			 * });
 			 */
-			getAllByApplication(nameOrSlugOrId, options, callback) {
+			getAllByApplication(nameOrSlugOrId, options) {
 				if (options == null) {
 					options = {};
 				}
-				callback = findCallback(arguments);
 
 				return applicationModel()
 					.get(nameOrSlugOrId, { $select: 'id' })
@@ -3486,8 +3377,7 @@ const getDeviceModel = function(deps, opts) {
 								options,
 							),
 						),
-					)
-					.asCallback(callback);
+					);
 			},
 
 			/**
@@ -3613,11 +3503,10 @@ const getDeviceModel = function(deps, opts) {
 			 * 	console.log(vars)
 			 * });
 			 */
-			getAllByDevice(uuidOrId, options, callback) {
+			getAllByDevice(uuidOrId, options) {
 				if (options == null) {
 					options = {};
 				}
-				callback = findCallback(arguments);
 
 				return exports
 					.get(uuidOrId, { $select: 'id' })
@@ -3639,8 +3528,7 @@ const getDeviceModel = function(deps, opts) {
 								options,
 							),
 						}),
-					)
-					.asCallback(callback);
+					);
 			},
 
 			/**
@@ -3671,11 +3559,10 @@ const getDeviceModel = function(deps, opts) {
 			 * 	console.log(vars)
 			 * });
 			 */
-			getAllByApplication(nameOrSlugOrId, options, callback) {
+			getAllByApplication(nameOrSlugOrId, options) {
 				if (options == null) {
 					options = {};
 				}
-				callback = findCallback(arguments);
 
 				return applicationModel()
 					.get(nameOrSlugOrId, { $select: 'id' })
@@ -3711,8 +3598,7 @@ const getDeviceModel = function(deps, opts) {
 								options,
 							),
 						}),
-					)
-					.asCallback(callback);
+					);
 			},
 
 			/**
@@ -3744,9 +3630,7 @@ const getDeviceModel = function(deps, opts) {
 			 * 	console.log(value)
 			 * });
 			 */
-			get(uuidOrId, serviceId, key, callback) {
-				callback = findCallback(arguments);
-
+			get(uuidOrId, serviceId, key) {
 				return exports
 					.get(uuidOrId, { $select: 'id' })
 					.get('id')
@@ -3772,8 +3656,7 @@ const getDeviceModel = function(deps, opts) {
 						}),
 					)
 					.get(0)
-					.then(variable => variable?.value)
-					.asCallback(callback);
+					.then(variable => variable?.value);
 			},
 
 			/**
@@ -3805,7 +3688,7 @@ const getDeviceModel = function(deps, opts) {
 			 * 	...
 			 * });
 			 */
-			set(uuidOrId, serviceId, key, value, callback) {
+			set(uuidOrId, serviceId, key, value) {
 				return Promise.try(function() {
 					value = String(value);
 
@@ -3842,21 +3725,19 @@ const getDeviceModel = function(deps, opts) {
 						})
 						.get(0)
 						.get('id');
-				})
-					.then(serviceInstallId =>
-						upsert(
-							{
-								resource: 'device_service_environment_variable',
-								body: {
-									service_install: serviceInstallId,
-									name: key,
-									value,
-								},
+				}).then(serviceInstallId =>
+					upsert(
+						{
+							resource: 'device_service_environment_variable',
+							body: {
+								service_install: serviceInstallId,
+								name: key,
+								value,
 							},
-							['service_install', 'name'],
-						),
-					)
-					.asCallback(callback);
+						},
+						['service_install', 'name'],
+					),
+				);
 			},
 
 			/**
@@ -3887,7 +3768,7 @@ const getDeviceModel = function(deps, opts) {
 			 * 	...
 			 * });
 			 */
-			remove(uuidOrId, serviceId, key, callback) {
+			remove(uuidOrId, serviceId, key) {
 				return exports
 					.get(uuidOrId, { $select: 'id' })
 					.get('id')
@@ -3911,8 +3792,7 @@ const getDeviceModel = function(deps, opts) {
 								},
 							},
 						}),
-					)
-					.asCallback(callback);
+					);
 			},
 		},
 	};

--- a/lib/models/image.ts
+++ b/lib/models/image.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import * as errors from 'balena-errors';
 import { Image, PineOptionsFor } from '../../typings/balena-sdk';
 import { InjectedDependenciesParam, InjectedOptionsParam } from '../balena';
-import { findCallback, mergePineOptions } from '../util';
+import { mergePineOptions } from '../util';
 
 const getImageModel = function(
 	deps: InjectedDependenciesParam,
@@ -52,10 +52,7 @@ const getImageModel = function(
 	exports.get = function(
 		id: number,
 		options: PineOptionsFor<Image> = {},
-		callback?: (error?: Error, result?: Image) => void,
 	): Promise<Image> {
-		callback = findCallback(arguments);
-
 		return pine
 			.get({
 				resource: 'image',
@@ -85,8 +82,7 @@ const getImageModel = function(
 				if (image == null) {
 					throw new errors.BalenaImageNotFound(id);
 				}
-			})
-			.asCallback(callback);
+			});
 	};
 
 	/**
@@ -111,14 +107,8 @@ const getImageModel = function(
 	 * 	console.log(logs);
 	 * });
 	 */
-	exports.getLogs = (
-		id: number,
-		callback?: (error?: Error, result?: string) => void,
-	): Promise<string> =>
-		exports
-			.get(id, { $select: 'build_log' })
-			.get('build_log')
-			.asCallback(callback);
+	exports.getLogs = (id: number): Promise<string> =>
+		exports.get(id, { $select: 'build_log' }).get('build_log');
 
 	return exports;
 };

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -88,11 +88,14 @@ export = (deps: InjectedDependenciesParam, opts: InjectedOptionsParam) => {
 				enumerable: true,
 				configurable: true,
 				get() {
+					const { addCallbackSupportToModule } = require('../util/callbacks');
 					const moduleFactory = modelsTemplate[moduleName]();
 					// We need the delete first as the current property is read-only
 					// and the delete removes that restriction
 					delete this[moduleName];
-					return (this[moduleName] = moduleFactory(deps, opts));
+					return (this[moduleName] = addCallbackSupportToModule(
+						moduleFactory(deps, opts),
+					));
 				},
 			});
 		},

--- a/lib/models/key.ts
+++ b/lib/models/key.ts
@@ -18,7 +18,7 @@ import * as errors from 'balena-errors';
 import * as Promise from 'bluebird';
 import * as BalenaSdk from '../../typings/balena-sdk';
 import { InjectedDependenciesParam, InjectedOptionsParam } from '../balena';
-import { findCallback, mergePineOptions } from '../util';
+import { mergePineOptions } from '../util';
 
 const getKeyModel = function(
 	deps: InjectedDependenciesParam,
@@ -54,15 +54,11 @@ const getKeyModel = function(
 	 */
 	function getAll(
 		options: BalenaSdk.PineOptionsFor<BalenaSdk.SSHKey> = {},
-		callback?: (error?: Error, result?: BalenaSdk.SSHKey[]) => void,
 	): Promise<BalenaSdk.SSHKey[]> {
-		callback = findCallback(arguments);
-		return pine
-			.get<BalenaSdk.SSHKey>({
-				resource: 'user__has__public_key',
-				options: mergePineOptions({}, options),
-			})
-			.asCallback(callback);
+		return pine.get<BalenaSdk.SSHKey>({
+			resource: 'user__has__public_key',
+			options: mergePineOptions({}, options),
+		});
 	}
 
 	/**
@@ -87,10 +83,7 @@ const getKeyModel = function(
 	 * 	console.log(key);
 	 * });
 	 */
-	function get(
-		id: number,
-		callback?: (error?: Error, result?: BalenaSdk.SSHKey) => void,
-	): Promise<BalenaSdk.SSHKey> {
+	function get(id: number): Promise<BalenaSdk.SSHKey> {
 		return pine
 			.get<BalenaSdk.SSHKey>({
 				resource: 'user__has__public_key',
@@ -100,8 +93,7 @@ const getKeyModel = function(
 				if (key == null) {
 					throw new errors.BalenaKeyNotFound(id);
 				}
-			})
-			.asCallback(callback);
+			});
 	}
 
 	/**
@@ -122,16 +114,11 @@ const getKeyModel = function(
 	 * 	if (error) throw error;
 	 * });
 	 */
-	function remove(
-		id: number,
-		callback?: (error?: Error) => void,
-	): Promise<string> {
-		return pine
-			.delete<BalenaSdk.SSHKey>({
-				resource: 'user__has__public_key',
-				id,
-			})
-			.asCallback(callback);
+	function remove(id: number): Promise<string> {
+		return pine.delete<BalenaSdk.SSHKey>({
+			resource: 'user__has__public_key',
+			id,
+		});
 	}
 
 	/**
@@ -158,11 +145,7 @@ const getKeyModel = function(
 	 * 	console.log(key);
 	 * });
 	 */
-	function create(
-		title: string,
-		key: string,
-		callback?: (error?: Error, result?: BalenaSdk.SSHKey) => void,
-	): Promise<BalenaSdk.SSHKey> {
+	function create(title: string, key: string): Promise<BalenaSdk.SSHKey> {
 		return Promise.try(() => {
 			// Avoid ugly whitespaces
 			key = key.trim();
@@ -177,7 +160,7 @@ const getKeyModel = function(
 					},
 				}),
 			);
-		}).asCallback(callback);
+		});
 	}
 
 	return {

--- a/lib/models/service.ts
+++ b/lib/models/service.ts
@@ -23,7 +23,7 @@ import {
 	ServiceEnvironmentVariable,
 } from '../../typings/balena-sdk';
 import { InjectedDependenciesParam, InjectedOptionsParam } from '../balena';
-import { findCallback, mergePineOptions } from '../util';
+import { mergePineOptions } from '../util';
 
 const getServiceModel = (
 	deps: InjectedDependenciesParam,
@@ -95,10 +95,7 @@ const getServiceModel = (
 	exports.getAllByApplication = function(
 		nameOrSlugOrId: string | number,
 		options: PineOptionsFor<Service> = {},
-		callback?: (error?: Error, result?: Service[]) => void,
 	): Promise<Service[]> {
-		callback = findCallback(arguments);
-
 		return applicationModel()
 			.get(nameOrSlugOrId, { $select: 'id' })
 			.then(({ id }: { id: number }) =>
@@ -106,8 +103,7 @@ const getServiceModel = (
 					resource: 'service',
 					options: mergePineOptions({ $filter: { application: id } }, options),
 				}),
-			)
-			.asCallback(callback);
+			);
 	};
 
 	/**
@@ -171,10 +167,7 @@ const getServiceModel = (
 		getAllByApplication(
 			nameOrSlugOrId: string | number,
 			options: PineOptionsFor<ServiceEnvironmentVariable> = {},
-			callback?: (error?: Error, result?: ServiceEnvironmentVariable[]) => void,
 		): ServiceEnvironmentVariable[] {
-			callback = findCallback(arguments);
-
 			return applicationModel()
 				.get(nameOrSlugOrId, { $select: 'id' })
 				.get('id')
@@ -199,8 +192,7 @@ const getServiceModel = (
 							options,
 						),
 					),
-				)
-				.asCallback(callback);
+				);
 		},
 
 		/**

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -40,8 +40,7 @@ const getSettings = function({ settings }) {
 		 * 	console.log(apiUrl);
 		 * });
 		 */
-		get: (key, callback) =>
-			Promise.try(() => settings.get(key)).asCallback(callback),
+		get: key => Promise.try(() => settings.get(key)),
 
 		/**
 		 * @summary Get all settings **Only implemented in Node.js**
@@ -64,8 +63,7 @@ const getSettings = function({ settings }) {
 		 * 	console.log(settings);
 		 * });
 		 */
-		getAll: callback =>
-			Promise.try(() => settings.getAll()).asCallback(callback),
+		getAll: () => Promise.try(() => settings.getAll()),
 	};
 
 	return exports;

--- a/lib/util/callbacks.ts
+++ b/lib/util/callbacks.ts
@@ -1,0 +1,61 @@
+import * as Bluebird from 'bluebird';
+import { Dictionary } from '../../typings/utils';
+
+// Use with: `findCallback(arguments)`.
+const findCallback = (args: IArguments): ((...args: any[]) => any) | void => {
+	const lastArg = args[args.length - 1];
+	if (typeof lastArg === 'function') {
+		return lastArg;
+	}
+
+	return;
+};
+
+const isThenable = (a: any): a is PromiseLike<any> => {
+	return typeof a === 'object' && typeof a.then === 'function';
+};
+
+const addCallbackSupport = <T extends (...args: any[]) => any>(fn: T): T => {
+	return function() {
+		const callback = findCallback(arguments);
+		const result = fn.apply(this, arguments);
+		if (!callback || !isThenable(result)) {
+			return result;
+		}
+
+		const bluebirdPromise =
+			result instanceof Bluebird
+				? (result as Bluebird<any>)
+				: Bluebird.resolve(result);
+
+		return bluebirdPromise.asCallback(callback);
+	} as T;
+};
+
+export const addCallbackSupportToModule = <T extends Dictionary<any>>(
+	sdkModule: T,
+): T => {
+	const result = {} as T;
+	for (const key of Object.keys(sdkModule) as Array<keyof typeof sdkModule>) {
+		const moduleProp = sdkModule[key];
+		const shouldAddCallback =
+			typeof key === 'string' &&
+			!key.startsWith('_') &&
+			typeof moduleProp === 'function';
+
+		result[key] = shouldAddCallback
+			? addCallbackSupport(moduleProp)
+			: moduleProp;
+	}
+	return result;
+};
+
+export const addCallbackSupportToModuleFactory = <
+	T extends (...args: any[]) => any
+>(
+	moduleFactory: T,
+): T => {
+	return function() {
+		return addCallbackSupportToModule(moduleFactory.apply(this, arguments));
+	} as T;
+};

--- a/lib/util/dependent-resource.js
+++ b/lib/util/dependent-resource.js
@@ -21,12 +21,7 @@ key-value resources directly attached to a parent (e.g. tags, config variables).
 
 import * as Promise from 'bluebird';
 
-import {
-	findCallback,
-	isId,
-	isUnauthorizedResponse,
-	mergePineOptions,
-} from '../util';
+import { isId, isUnauthorizedResponse, mergePineOptions } from '../util';
 import { getUpsertHelper } from '../util/upsert';
 
 export function buildDependentResource(
@@ -41,47 +36,39 @@ export function buildDependentResource(
 	const upsert = getUpsertHelper({ pine });
 
 	const exports = {
-		getAll(options, callback) {
+		getAll(options) {
 			if (options == null) {
 				options = {};
 			}
-			callback = findCallback(arguments);
 
-			return pine
-				.get({
-					resource: resourceName,
-					options: mergePineOptions(
-						{ $orderby: `${resourceKeyField} asc` },
+			return pine.get({
+				resource: resourceName,
+				options: mergePineOptions(
+					{ $orderby: `${resourceKeyField} asc` },
+					options,
+				),
+			});
+		},
+
+		getAllByParent(parentParam, options) {
+			if (options == null) {
+				options = {};
+			}
+
+			return getResourceId(parentParam).then(id =>
+				exports.getAll(
+					mergePineOptions(
+						{
+							$filter: { [parentResourceName]: id },
+							$orderby: `${resourceKeyField} asc`,
+						},
 						options,
 					),
-				})
-				.asCallback(callback);
+				),
+			);
 		},
 
-		getAllByParent(parentParam, options, callback) {
-			if (options == null) {
-				options = {};
-			}
-			callback = findCallback(arguments);
-
-			return getResourceId(parentParam)
-				.then(id =>
-					exports.getAll(
-						mergePineOptions(
-							{
-								$filter: { [parentResourceName]: id },
-								$orderby: `${resourceKeyField} asc`,
-							},
-							options,
-						),
-					),
-				)
-				.asCallback(callback);
-		},
-
-		get(parentParam, key, callback) {
-			callback = findCallback(arguments);
-
+		get(parentParam, key) {
 			return getResourceId(parentParam)
 				.then(id =>
 					pine.get({
@@ -98,11 +85,10 @@ export function buildDependentResource(
 					if (results[0]) {
 						return results[0].value;
 					}
-				})
-				.asCallback(callback);
+				});
 		},
 
-		set(parentParam, key, value, callback) {
+		set(parentParam, key, value) {
 			return Promise.try(function() {
 				value = String(value);
 
@@ -115,46 +101,42 @@ export function buildDependentResource(
 				} else {
 					return getResourceId(parentParam);
 				}
-			})
-				.then(parentId =>
-					upsert(
-						{
-							resource: resourceName,
-							body: {
-								[parentResourceName]: parentId,
-								[resourceKeyField]: key,
-								value,
-							},
+			}).then(parentId =>
+				upsert(
+					{
+						resource: resourceName,
+						body: {
+							[parentResourceName]: parentId,
+							[resourceKeyField]: key,
+							value,
 						},
-						[parentResourceName, resourceKeyField],
-					).tapCatch(isUnauthorizedResponse, function() {
-						// On Pine 7, when the post throws a 401
-						// then the associated parent resource might not exist.
-						// If we never checked that the resource actually exists
-						// then we should reject an appropriate error.
-						if (!isId(parentParam)) {
-							return;
-						}
-						return getResourceId(parentParam);
-					}),
-				)
-				.asCallback(callback);
+					},
+					[parentResourceName, resourceKeyField],
+				).tapCatch(isUnauthorizedResponse, function() {
+					// On Pine 7, when the post throws a 401
+					// then the associated parent resource might not exist.
+					// If we never checked that the resource actually exists
+					// then we should reject an appropriate error.
+					if (!isId(parentParam)) {
+						return;
+					}
+					return getResourceId(parentParam);
+				}),
+			);
 		},
 
-		remove(parentParam, key, callback) {
-			return getResourceId(parentParam)
-				.then(parentId =>
-					pine.delete({
-						resource: `${resourceName}`,
-						options: {
-							$filter: {
-								[parentResourceName]: parentId,
-								[resourceKeyField]: key,
-							},
+		remove(parentParam, key) {
+			return getResourceId(parentParam).then(parentId =>
+				pine.delete({
+					resource: `${resourceName}`,
+					options: {
+						$filter: {
+							[parentResourceName]: parentId,
+							[resourceKeyField]: key,
 						},
-					}),
-				)
-				.asCallback(callback);
+					},
+				}),
+			);
 		},
 	};
 

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -51,16 +51,6 @@ export const isId = (v?: any): v is number => typeof v === 'number';
 
 export const LOCKED_STATUS_CODE = 423;
 
-// Use with: `findCallback(arguments)`.
-export const findCallback = (args: IArguments) => {
-	const lastArg = args[args.length - 1];
-	if (typeof lastArg === 'function') {
-		return lastArg;
-	}
-
-	return;
-};
-
 const isBalenaRequestErrorResponseWithCode = (
 	error: Partial<errors.BalenaRequestError>,
 	statusCode: number,
@@ -273,7 +263,6 @@ export default {
 	timeSince,
 	isId,
 	LOCKED_STATUS_CODE,
-	findCallback,
 	isUnauthorizedResponse,
 	isNotFoundResponse,
 	isNoDeviceForKeyResponse,

--- a/tests/integration/models/application.spec.coffee
+++ b/tests/integration/models/application.spec.coffee
@@ -23,15 +23,30 @@ describe 'Application Model', ->
 
 		describe 'balena.models.application.getAll()', ->
 
-			it 'should eventually become an empty array', ->
+			it 'should eventually become an empty array [Promise]', ->
 				promise = balena.models.application.getAll()
 				m.chai.expect(promise).to.become([])
 
+			it 'should eventually become an empty array [callback]', (done) ->
+				balena.models.application.getAll (err, applications) ->
+					m.chai.expect(err).to.be.null
+					m.chai.expect(applications).to.deep.equal([])
+					done()
+				return
+
 		describe 'balena.models.application.getAppByOwner()', ->
 
-			it 'should eventually reject', ->
+			it 'should eventually reject [Promise]', ->
 				promise = balena.models.application.getAppByOwner('testapp', 'FooBar')
 				m.chai.expect(promise).to.be.rejected
+
+			it 'should eventually reject [callback]', (done) ->
+				balena.models.application.getAppByOwner('testapp', 'FooBar',
+					(err) ->
+						m.chai.expect(err).to.not.be.undefined
+						done()
+				)
+				return
 
 		describe 'balena.models.application.hasAny()', ->
 
@@ -183,10 +198,20 @@ describe 'Application Model', ->
 					balena.models.application.getAll().then (applications) =>
 						m.chai.expect(applications[0].id).to.equal(@application.id)
 
-				it 'should support arbitrary pinejs options', ->
+				it 'should support arbitrary pinejs options [Promise]', ->
 					balena.models.application.getAll($expand: 'user')
 					.then (applications) ->
 						m.chai.expect(applications[0].user[0].username).to.equal(credentials.username)
+
+				it 'should support arbitrary pinejs options [callback]', (done) ->
+					balena.models.application.getAll(
+						$expand: 'user',
+						(err, applications) ->
+							m.chai.expect(err).to.be.null
+							m.chai.expect(applications[0].user[0].username).to.equal(credentials.username)
+							done()
+					)
+					return
 
 			describe 'balena.models.application.get()', ->
 


### PR DESCRIPTION
Regardless of whether we later decide to completely drop callback support or not, this already goes through all modules and removes the special callback handling. If we indeed later decide to drop support for callbacks we will just need to:
* delete util/callbacks.ts and it's references
* remove the callback related doc examples

Technically this changes a bit how callbacks work in method that don't accept optional callbacks, since we will now be using the `findCallback` helper even on those. But as far as a user is following the doc examples for the way they call the methods, this shouldn't cause any issues.

Also drops the node build size from 354kb to 345kb
and the minified browser build from 843kb to 840kb.

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/XvE6YtBD5G4MqyGcVaVtBsnTilB
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
