### PR TITLE
Add updated OS methods

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -278,6 +278,8 @@ const sdk = fromSharedOptions();
             * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
             * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
             * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
+        * [.hostapp](#balena.models.hostapp) : <code>object</code>
+            * [.getAllOsVersions(deviceTypes)](#balena.models.hostapp.getAllOsVersions) ⇒ <code>Promise</code>
         * [.config](#balena.models.config) : <code>object</code>
             * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
             * [.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>
@@ -617,6 +619,8 @@ balena.models.device.get(123).catch(function (error) {
         * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
         * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
         * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
+    * [.hostapp](#balena.models.hostapp) : <code>object</code>
+        * [.getAllOsVersions(deviceTypes)](#balena.models.hostapp.getAllOsVersions) ⇒ <code>Promise</code>
     * [.config](#balena.models.config) : <code>object</code>
         * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
         * [.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>
@@ -5514,6 +5518,27 @@ console.log(result1);
 
 const result2 = balena.models.os.isArchitectureCompatibleWith('armv7hf', 'amd64');
 console.log(result2);
+```
+<a name="balena.models.hostapp"></a>
+
+#### models.hostapp : <code>object</code>
+**Beta** The hostapp methods are still in beta and might change in a non-major release.
+
+**Kind**: static namespace of [<code>models</code>](#balena.models)  
+<a name="balena.models.hostapp.getAllOsVersions"></a>
+
+##### hostapp.getAllOsVersions(deviceTypes) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>hostapp</code>](#balena.models.hostapp)  
+**Summary**: Get all OS versions for the passed device types  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| deviceTypes | <code>Array.&lt;String&gt;</code> | device type slugs |
+
+**Example**  
+```js
+balena.models.hostapp.getAllOsVersions(['fincm3', 'raspberrypi3']);
 ```
 <a name="balena.models.config"></a>
 

--- a/lib/models/hostapp.ts
+++ b/lib/models/hostapp.ts
@@ -1,0 +1,253 @@
+import * as bSemver from 'balena-semver';
+import { InjectedDependenciesParam } from '..';
+import {
+	ResourceTagBase,
+	ApplicationTag,
+	Application,
+	Release,
+	OsVersion,
+	OsVersionsByDeviceType,
+	DeviceType,
+} from '../../typings/balena-sdk';
+import { Dictionary } from '../../typings/utils';
+import { getAuthDependentMemoize } from '../util/cache';
+
+const RELEASE_POLICY_TAG_NAME = 'release-policy';
+const ESR_NEXT_TAG_NAME = 'esr-next';
+const ESR_CURRENT_TAG_NAME = 'esr-current';
+const ESR_SUNSET_TAG_NAME = 'esr-sunset';
+const VARIANT_TAG_NAME = 'variant';
+const VERSION_TAG_NAME = 'version';
+const BASED_ON_VERSION_TAG_NAME = 'meta-balena-base';
+
+export enum OsTypes {
+	DEFAULT = 'default',
+	ESR = 'esr',
+}
+
+const getHostappModel = function (deps: InjectedDependenciesParam) {
+	const { pine, pubsub } = deps;
+
+	type HostAppTagSet = ReturnType<typeof getOsAppTags>;
+	type AppWithDeviceType = Application & {
+		is_for__device_type: [{ slug: DeviceType['slug'] }];
+	};
+
+	const sortVersions = (a: OsVersion, b: OsVersion) => {
+		return bSemver.rcompare(a.rawVersion, b.rawVersion);
+	};
+
+	const getTagValue = (tags: ResourceTagBase[], tagKey: string) => {
+		return tags.find((tag) => tag.tag_key === tagKey)?.value;
+	};
+
+	const getOsAppTags = (applicationTag: ApplicationTag[]) => {
+		return {
+			osType:
+				getTagValue(applicationTag, RELEASE_POLICY_TAG_NAME) ?? OsTypes.DEFAULT,
+			nextLineVersionRange:
+				getTagValue(applicationTag, ESR_NEXT_TAG_NAME) ?? '',
+			currentLineVersionRange:
+				getTagValue(applicationTag, ESR_CURRENT_TAG_NAME) ?? '',
+			sunsetLineVersionRange:
+				getTagValue(applicationTag, ESR_SUNSET_TAG_NAME) ?? '',
+		};
+	};
+
+	const getOsVersionReleaseLine = (version: string, appTags: HostAppTagSet) => {
+		// All patches belong to the same line.
+		if (bSemver.satisfies(version, `^${appTags.nextLineVersionRange}`)) {
+			return 'next';
+		}
+		if (bSemver.satisfies(version, `^${appTags.currentLineVersionRange}`)) {
+			return 'current';
+		}
+		if (bSemver.satisfies(version, `^${appTags.sunsetLineVersionRange}`)) {
+			return 'sunset';
+		}
+
+		if (appTags.osType?.toLowerCase() === OsTypes.ESR) {
+			return 'outdated';
+		}
+	};
+
+	const normalizeVariant = (variant: string) => {
+		switch (variant) {
+			case 'production':
+				return 'prod';
+			case 'development':
+				return 'dev';
+			default:
+				return variant;
+		}
+	};
+
+	const getOsVersionsFromReleases = (
+		releases: Release[],
+		appTags: HostAppTagSet,
+	): OsVersion[] => {
+		return releases.map((release) => {
+			// The variant in the tags is a full noun, such as `production` and `development`.
+			const variant =
+				getTagValue(release.release_tag!, VARIANT_TAG_NAME) ?? 'production';
+			const normalizedVariant = normalizeVariant(variant);
+			const version = getTagValue(release.release_tag!, VERSION_TAG_NAME) ?? '';
+			const basedOnVersion =
+				getTagValue(release.release_tag!, BASED_ON_VERSION_TAG_NAME) ?? version;
+			const line = getOsVersionReleaseLine(version, appTags);
+			const lineFormat = line ? ` (${line})` : '';
+
+			// TODO: Don't append the variant and sent it as a separate parameter when requesting a download when we don't use /device-types anymore and the API and image maker can handle it. Also rename `rawVersion` -> `versionWithVariant` if it is needed (it might not be needed anymore).
+			// The version coming from release tags doesn't contain the variant, so we append it here
+			return {
+				id: release.id,
+				osType: appTags.osType,
+				line,
+				strippedVersion: version,
+				rawVersion: `${version}.${normalizedVariant}`,
+				basedOnVersion,
+				variant: normalizedVariant,
+				formattedVersion: `v${version}${lineFormat}`,
+			};
+		});
+	};
+
+	const transformHostApps = (apps: AppWithDeviceType[]) => {
+		const res: OsVersionsByDeviceType = apps.reduce(
+			(osVersionsByDeviceType: OsVersionsByDeviceType, hostApp) => {
+				if (!hostApp) {
+					return osVersionsByDeviceType;
+				}
+
+				const hostAppDeviceType = hostApp.is_for__device_type[0].slug;
+
+				if (!hostAppDeviceType) {
+					return osVersionsByDeviceType;
+				}
+
+				let osVersions = osVersionsByDeviceType[hostAppDeviceType];
+				if (!osVersions) {
+					osVersions = [];
+				}
+
+				const appTags = getOsAppTags(hostApp.application_tag ?? []);
+				osVersions = osVersions.concat(
+					getOsVersionsFromReleases(hostApp.owns__release ?? [], appTags),
+				);
+				osVersionsByDeviceType[hostAppDeviceType] = osVersions;
+
+				return osVersionsByDeviceType;
+			},
+			{},
+		);
+
+		return res;
+	};
+
+	// This mutates the passed object.
+	const transformVersionSets = (
+		osVersionsByDeviceType: OsVersionsByDeviceType,
+	) => {
+		Object.keys(osVersionsByDeviceType).forEach((deviceType) => {
+			osVersionsByDeviceType[deviceType].sort(sortVersions);
+			const recommendedPerOsType: Dictionary<boolean> = {};
+
+			// Note: the recommended version settings might come from the server in the future, for now we just set it to the latest version for each os type.
+			osVersionsByDeviceType[deviceType].forEach((version) => {
+				if (!recommendedPerOsType[version.osType]) {
+					if (
+						version.variant !== 'dev' &&
+						!bSemver.prerelease(version.rawVersion)
+					) {
+						const additionalFormat = version.line
+							? ` (${version.line}, recommended)`
+							: ' (recommended)';
+
+						version.isRecommended = true;
+						version.formattedVersion = `v${version.strippedVersion}${additionalFormat}`;
+						recommendedPerOsType[version.osType] = true;
+					}
+				}
+			});
+		});
+
+		return osVersionsByDeviceType;
+	};
+
+	const getOsVersions = (deviceTypes: string[]) => {
+		return pine.get<AppWithDeviceType>({
+			resource: 'application',
+			options: {
+				$filter: {
+					is_host: true,
+					is_for__device_type: {
+						$any: {
+							$alias: 'dt',
+							$expr: {
+								dt: {
+									slug: { $in: deviceTypes },
+								},
+							},
+						},
+					},
+				},
+				$select: ['id', 'app_name'],
+				$expand: {
+					application_tag: {
+						$select: ['id', 'tag_key', 'value'],
+					},
+					is_for__device_type: {
+						$select: ['slug'],
+					},
+					owns__release: {
+						$select: ['id'],
+						$expand: {
+							release_tag: {
+								$select: ['id', 'tag_key', 'value'],
+							},
+						},
+						$filter: {
+							is_invalidated: false,
+						},
+					},
+				},
+			},
+		});
+	};
+
+	const getTransformedOsVersions = async (deviceTypes: string[]) => {
+		const hostapps = await getOsVersions(deviceTypes);
+		return transformVersionSets(transformHostApps(hostapps));
+	};
+
+	const memoizedGetTransformedOsVersions = getAuthDependentMemoize(pubsub)(
+		getTransformedOsVersions,
+	);
+
+	/**
+	 * @summary Get all OS versions for the passed device types
+	 * @name getAllOsVersions
+	 * @public
+	 * @function
+	 * @memberof balena.models.hostapp
+	 *
+	 * @param {String[]} deviceTypes - device type slugs
+	 * @returns {Promise}
+	 *
+	 * @example
+	 * balena.models.hostapp.getAllOsVersions(['fincm3', 'raspberrypi3']);
+	 */
+	const getAllOsVersions = async (
+		deviceTypes: string[],
+	): Promise<OsVersionsByDeviceType> => {
+		const sortedDeviceTypes = deviceTypes.sort();
+		return memoizedGetTransformedOsVersions(sortedDeviceTypes);
+	};
+
+	return {
+		OsTypes,
+		getAllOsVersions,
+	};
+};
+
+export default getHostappModel;

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -56,6 +56,14 @@ const modelsTemplate = {
 	os: () => (require('./os') as typeof import('./os')).default,
 
 	/**
+	 * @namespace hostapp
+	 * @memberof balena.models
+	 * @description
+	 * **Beta** The hostapp methods are still in beta and might change in a non-major release.
+	 */
+	hostapp: () => (require('./hostapp') as typeof import('./hostapp')).default,
+
+	/**
 	 * @namespace config
 	 * @memberof balena.models
 	 */

--- a/lib/util/cache.ts
+++ b/lib/util/cache.ts
@@ -1,0 +1,20 @@
+import * as memoizee from 'memoizee';
+import type { PubSub } from './pubsub';
+const DEFAULT_CACHING_INTERVAL = 10 * 60 * 1000; // 10 minutes
+
+export const getAuthDependentMemoize = (
+	pubsub: PubSub,
+	cacheInterval = DEFAULT_CACHING_INTERVAL,
+) => {
+	return <T extends (...args: any[]) => any>(fn: T) => {
+		const memoizedFn = memoizee(fn, {
+			maxAge: cacheInterval,
+			primitive: true,
+			promise: true,
+		});
+
+		pubsub.subscribe('auth.keyChange', () => memoizedFn.clear());
+
+		return memoizedFn;
+	};
+};

--- a/tests/integration/models/hostapp.spec.ts
+++ b/tests/integration/models/hostapp.spec.ts
@@ -1,0 +1,75 @@
+// tslint:disable-next-line:import-blacklist
+import * as _ from 'lodash';
+import * as m from 'mochainon';
+import { balena } from '../setup';
+import type * as BalenaSdk from '../../..';
+const { expect } = m.chai;
+
+const containsVersion = (
+	versions: BalenaSdk.OsVersion[],
+	expected: Partial<BalenaSdk.OsVersion>,
+) => {
+	const os = _.find(versions, expected);
+	expect(os).to.not.be.undefined;
+};
+
+describe('Hostapp model', function () {
+	describe('balena.models.hostapp.getAllOsVersions()', function () {
+		it("should contain both balenaOS and balenaOS ESR OS types'", async () => {
+			const res = await balena.models.hostapp.getAllOsVersions([
+				'fincm3',
+				'raspberrypi3',
+			]);
+
+			containsVersion(res['fincm3'], {
+				strippedVersion: '2.29.0+rev1',
+				variant: 'dev',
+			});
+			containsVersion(res['fincm3'], {
+				strippedVersion: '2.29.0+rev1',
+				variant: 'prod',
+			});
+			containsVersion(res['fincm3'], {
+				strippedVersion: '2020.04.0',
+				variant: 'dev',
+			});
+			containsVersion(res['fincm3'], {
+				strippedVersion: '2020.04.0',
+				variant: 'prod',
+			});
+
+			containsVersion(res['raspberrypi3'], {
+				strippedVersion: '2.29.0+rev1',
+				variant: 'dev',
+			});
+			containsVersion(res['raspberrypi3'], {
+				strippedVersion: '2.29.0+rev1',
+				variant: 'prod',
+			});
+			containsVersion(res['raspberrypi3'], {
+				strippedVersion: '2020.04.0',
+				variant: 'dev',
+			});
+			containsVersion(res['raspberrypi3'], {
+				strippedVersion: '2020.04.0',
+				variant: 'prod',
+			});
+		});
+
+		it('should return an empty object for non-existent DTs', async () => {
+			const res = await balena.models.hostapp.getAllOsVersions(['blahbleh']);
+
+			return expect(res).to.deep.equal({});
+		});
+
+		it('should cache the results', async () => {
+			const firstRes = await balena.models.hostapp.getAllOsVersions([
+				'raspberrypi3',
+			]);
+			const secondRes = await balena.models.hostapp.getAllOsVersions([
+				'raspberrypi3',
+			]);
+			expect(firstRes).to.equal(secondRes);
+		});
+	});
+});

--- a/typings/balena-sdk/index.d.ts
+++ b/typings/balena-sdk/index.d.ts
@@ -7,6 +7,7 @@ import type {
 	BalenaRequestStreamResult,
 } from '../balena-request';
 import type * as DeviceOverallStatus from './device-overall-status';
+import type * as OsTypes from './os-types';
 import type * as Pine from '../pinejs-client-core';
 import { AtLeast } from '../utils';
 import type * as DeviceState from './device-state';
@@ -330,6 +331,25 @@ export interface OsUpdateVersions {
 	versions: string[];
 	recommended: string | undefined;
 	current: string | undefined;
+}
+
+export type OsLines = 'next' | 'current' | 'sunset' | 'outdated' | undefined;
+
+export interface OsVersion {
+	id: number;
+	rawVersion: string;
+	strippedVersion: string;
+	basedOnVersion?: string;
+	osType: string;
+	line?: OsLines;
+	variant?: string;
+
+	formattedVersion: string;
+	isRecommended?: boolean;
+}
+
+export interface OsVersionsByDeviceType {
+	[deviceTypeSlug: string]: OsVersion[];
 }
 
 // See: https://github.com/balena-io/resin-proxy/issues/51#issuecomment-274251469
@@ -911,6 +931,12 @@ export interface BalenaSDK {
 				};
 			};
 		};
+
+		hostapp: {
+			OsTypes: typeof OsTypes.OsTypes;
+			getAllOsVersions(deviceTypes: string[]): Promise<OsVersionsByDeviceType>;
+		};
+
 		os: {
 			getConfig(
 				nameOrId: string | number,

--- a/typings/balena-sdk/os-types.d.ts
+++ b/typings/balena-sdk/os-types.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Extracted from the enum defined in `hostapp.ts`.
+ */
+export enum OsTypes {
+	DEFAULT = 'default',
+	ESR = 'esr',
+}


### PR DESCRIPTION
open balena and bob don't have hostapps out of the box, so we want to keep the existing OS methods for now.

Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
