### PR TITLE
Release balena-sdk v13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ language: node_js
 matrix:
   include:
     - node_js:
-      - '8'
+      - '10'
 before_install:
 - npm -g install npm@6
 script:

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -135,7 +135,7 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.disableLockOverride(uuidOrId)](#balena.models.device.disableLockOverride) ⇒ <code>Promise</code>
             * [.hasLockOverride(uuidOrId)](#balena.models.device.hasLockOverride) ⇒ <code>Promise</code>
             * [.ping(uuidOrId)](#balena.models.device.ping) ⇒ <code>Promise</code>
-            * [.getStatus(device)](#balena.models.device.getStatus) ⇒ <code>Promise</code>
+            * [.getStatus(uuidOrId)](#balena.models.device.getStatus) ⇒ <code>Promise</code>
             * [.grantSupportAccess(uuidOrId, expiryTimestamp)](#balena.models.device.grantSupportAccess) ⇒ <code>Promise</code>
             * [.revokeSupportAccess(uuidOrId)](#balena.models.device.revokeSupportAccess) ⇒ <code>Promise</code>
             * [.lastOnline(device)](#balena.models.device.lastOnline) ⇒ <code>String</code>
@@ -446,7 +446,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.disableLockOverride(uuidOrId)](#balena.models.device.disableLockOverride) ⇒ <code>Promise</code>
         * [.hasLockOverride(uuidOrId)](#balena.models.device.hasLockOverride) ⇒ <code>Promise</code>
         * [.ping(uuidOrId)](#balena.models.device.ping) ⇒ <code>Promise</code>
-        * [.getStatus(device)](#balena.models.device.getStatus) ⇒ <code>Promise</code>
+        * [.getStatus(uuidOrId)](#balena.models.device.getStatus) ⇒ <code>Promise</code>
         * [.grantSupportAccess(uuidOrId, expiryTimestamp)](#balena.models.device.grantSupportAccess) ⇒ <code>Promise</code>
         * [.revokeSupportAccess(uuidOrId)](#balena.models.device.revokeSupportAccess) ⇒ <code>Promise</code>
         * [.lastOnline(device)](#balena.models.device.lastOnline) ⇒ <code>String</code>
@@ -1732,7 +1732,7 @@ balena.models.application.revokeSupportAccess('MyApp', function(error) {
     * [.disableLockOverride(uuidOrId)](#balena.models.device.disableLockOverride) ⇒ <code>Promise</code>
     * [.hasLockOverride(uuidOrId)](#balena.models.device.hasLockOverride) ⇒ <code>Promise</code>
     * [.ping(uuidOrId)](#balena.models.device.ping) ⇒ <code>Promise</code>
-    * [.getStatus(device)](#balena.models.device.getStatus) ⇒ <code>Promise</code>
+    * [.getStatus(uuidOrId)](#balena.models.device.getStatus) ⇒ <code>Promise</code>
     * [.grantSupportAccess(uuidOrId, expiryTimestamp)](#balena.models.device.grantSupportAccess) ⇒ <code>Promise</code>
     * [.revokeSupportAccess(uuidOrId)](#balena.models.device.revokeSupportAccess) ⇒ <code>Promise</code>
     * [.lastOnline(device)](#balena.models.device.lastOnline) ⇒ <code>String</code>
@@ -3940,32 +3940,36 @@ balena.models.device.ping('7cf02a6', function(error) {
 ```
 <a name="balena.models.device.getStatus"></a>
 
-##### device.getStatus(device) ⇒ <code>Promise</code>
-Computes the status of an already retrieved device object.
-It's recommended to use `balena.models.device.get(deviceUuid, { $select: ['overall_status'] })` instead,
+##### device.getStatus(uuidOrId) ⇒ <code>Promise</code>
+Convenience method for getting the overall status of a device.
+It's recommended to use `balena.models.device.get()` instead,
 in case that you need to retrieve more device fields than just the status.
 
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
 **Summary**: Get the status of a device  
 **Access**: public  
 **Fulfil**: <code>String</code> - device status  
-**See**: [getWithServiceDetails](#balena.models.device.getWithServiceDetails) for retrieving the device object that this method accepts.  
+**See**: [get](#balena.models.device.get) for an example on selecting the `overall_status` field.  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| device | <code>Object</code> | A device object |
+| uuidOrId | <code>String</code> \| <code>Number</code> | device uuid (string) or id (number) |
 
 **Example**  
 ```js
-balena.models.device.getWithServiceDetails('7cf02a6').then(function(device) {
-	return balena.models.device.getStatus(device);
-}).then(function(status) {
+balena.models.device.getStatus('7cf02a6').then(function(status) {
 	console.log(status);
 });
 ```
 **Example**  
 ```js
-balena.models.device.getStatus(device, function(error, status) {
+balena.models.device.getStatus(123).then(function(status) {
+	console.log(status);
+});
+```
+**Example**  
+```js
+balena.models.device.getStatus('7cf02a6', function(error, status) {
 	if (error) throw error;
 	console.log(status);
 });

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ var balena = require('balena-sdk')({
 Where the factory method accepts the following options:
 * `apiUrl`, string, *optional*, is the balena API url. Defaults to `https://api.balena-cloud.com/`,
 * `builderUrl`, string, *optional* , is the balena builder url. Defaults to `https://builder.balena-cloud.com/`,
-* `imageMakerUrl`, string, *optional* *deprecated* , is the balena image maker url. Defaults to `https://img.balena-cloud.com/`,
 * `deviceUrlsBase`, string, *optional*, is the base balena device API url. Defaults to `balena-devices.com`,
 * `dataDirectory`, string, *optional*, *ignored in the browser*, is the directory where the user settings are stored, normally retrieved like `require('balena-settings-client').get('dataDirectory')`. Defaults to `$HOME/.balena`,
 * `isBrowser`, boolean, *optional*, is the flag to tell if the module works in the browser. If not set will be computed based on the presence of the global `window` value,

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install --save balena-sdk
 Platforms
 ---------
 
-We currently support NodeJS (6+) and the browser.
+We currently support NodeJS (10+) and the browser.
 
 The following features are node-only:
 - OS image streaming download (`balena.models.os.download`),

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ matrix:
 # what combinations to test
 environment:
   matrix:
-  - nodejs_version: 8
+  - nodejs_version: 10
     TEST_EMAIL: test2+juan@resin.io
     TEST_PASSWORD:
       secure: JyPzqbiGRJML/FHbP/8Ixg==
@@ -24,7 +24,7 @@ environment:
       secure: 5q1vra242X+0xjTU5msqOQ==
     TEST_REGISTER_USERNAME: test2_register_juan
     TEST_ONLY_ON_ENVIRONMENT: node
-  - nodejs_version: 8
+  - nodejs_version: 10
     TEST_EMAIL: sdk+tests+thgreasi@resin.io
     TEST_PASSWORD:
       secure: O8/sOQP/5A4Ykiu/T6Uvyw==

--- a/lib/balena.js
+++ b/lib/balena.js
@@ -84,8 +84,6 @@ const getSdk = function(opts) {
 		{
 			apiUrl: 'https://api.balena-cloud.com/',
 			builderUrl: 'https://builder.balena-cloud.com/',
-			// deprecated
-			imageMakerUrl: 'https://img.balena-cloud.com/',
 			isBrowser: typeof window !== 'undefined' && window !== null,
 			// API version is configurable but only do so if you know what you're doing,
 			// as the SDK is directly tied to a specific version.

--- a/lib/models/device.js
+++ b/lib/models/device.js
@@ -22,7 +22,6 @@ const without = require('lodash/without');
 import * as bSemver from 'balena-semver';
 import * as semver from 'semver';
 import * as errors from 'balena-errors';
-import * as deviceStatus from 'balena-device-status';
 
 import {
 	isId,
@@ -2435,33 +2434,42 @@ const getDeviceModel = function(deps, opts) {
 		 * @memberof balena.models.device
 		 *
 		 * @description
-		 * Computes the status of an already retrieved device object.
-		 * It's recommended to use `balena.models.device.get(deviceUuid, { $select: ['overall_status'] })` instead,
+		 * Convenience method for getting the overall status of a device.
+		 * It's recommended to use `balena.models.device.get()` instead,
 		 * in case that you need to retrieve more device fields than just the status.
 		 *
-		 * @see {@link balena.models.device.getWithServiceDetails} for retrieving the device object that this method accepts.
+		 * @see {@link balena.models.device.get} for an example on selecting the `overall_status` field.
 		 *
-		 * @param {Object} device - A device object
+		 * @param {String|Number} uuidOrId - device uuid (string) or id (number)
 		 * @fulfil {String} - device status
 		 * @returns {Promise}
 		 *
 		 * @example
-		 * balena.models.device.getWithServiceDetails('7cf02a6').then(function(device) {
-		 * 	return balena.models.device.getStatus(device);
-		 * }).then(function(status) {
+		 * balena.models.device.getStatus('7cf02a6').then(function(status) {
 		 * 	console.log(status);
 		 * });
 		 *
 		 * @example
-		 * balena.models.device.getStatus(device, function(error, status) {
+		 * balena.models.device.getStatus(123).then(function(status) {
+		 * 	console.log(status);
+		 * });
+		 *
+		 * @example
+		 * balena.models.device.getStatus('7cf02a6', function(error, status) {
 		 * 	if (error) throw error;
 		 * 	console.log(status);
 		 * });
 		 */
-		getStatus: (device, callback) =>
-			Promise.try(() => deviceStatus.getStatus(device).key).asCallback(
-				callback,
-			),
+		getStatus(uuidOrId, callback) {
+			if (typeof uuidOrId !== 'string' && typeof uuidOrId !== 'number') {
+				throw new errors.BalenaInvalidParameterError('uuidOrId', uuidOrId);
+			}
+
+			return exports
+				.get(uuidOrId, { $select: 'overall_status' })
+				.then(({ overall_status }) => overall_status)
+				.asCallback(callback);
+		},
 
 		/**
 		 * @summary Grant support access to a device until a specified time

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@types/node": "^8.10.59",
     "abortcontroller-polyfill": "^1.4.0",
     "balena-auth": "^3.0.1",
-    "balena-device-status": "^3.2.1",
     "balena-errors": "^4.3.0",
     "balena-hup-action-utils": "~4.0.0",
     "balena-pine": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "author": "Juan Cruz Viotti <juan@balena.io>",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=10.0"
   },
   "devDependencies": {
     "@balena/lint": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:node": "gulp test",
     "test:browser": "karma start",
     "test:ts-js": "npx tsc --noEmit --project ./tsconfig.js.json",
-    "test:ts-compatibility": "npx typescript@~3.4.0 --noEmit --project ./tsconfig.dist.json",
+    "test:ts-compatibility": "npx typescript@~3.8.2 --noEmit --project ./tsconfig.dist.json",
     "test:typings": "dtslint --localTs node_modules/typescript/lib --expectOnly typing_tests",
     "build:ts": "tsc && gulp inject-version",
     "build": "npm run lint && npm run clean && npm run build:ts && gulp build && npm run docs",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "balena-device-status": "^3.2.1",
     "balena-errors": "^4.3.0",
     "balena-hup-action-utils": "~4.0.0",
-    "balena-pine": "^10.1.1",
+    "balena-pine": "^11.0.0",
     "balena-register-device": "^6.0.1",
     "balena-request": "^10.0.8",
     "balena-semver": "^2.2.0",

--- a/tests/integration/models/config.spec.ts
+++ b/tests/integration/models/config.spec.ts
@@ -63,6 +63,10 @@ const itNormalizesDeviceTypes = function() {
 };
 
 describe('Config Model', function() {
+	before(function() {
+		return balena.auth.logout();
+	});
+
 	describe('balena.models.config.getAll()', function() {
 		it('should return all the configuration', () =>
 			balena.models.config.getAll().then(function(config) {

--- a/tests/integration/models/device.spec.coffee
+++ b/tests/integration/models/device.spec.coffee
@@ -96,33 +96,6 @@ describe 'Device Model', ->
 				balena.models.device.getManifestBySlug('raspberrypi').then (manifest) ->
 					m.chai.expect(manifest.slug).to.equal('raspberry-pi')
 
-		describe 'balena.models.device.getStatus()', ->
-
-			it 'should return inactive for inactive devices', ->
-				promise = balena.models.device.getStatus
-					is_active: false
-				m.chai.expect(promise).to.eventually.equal('inactive')
-
-			it 'should return configuring for devices that have never sent a connectivity event', ->
-				promise = balena.models.device.getStatus
-					is_active: true
-					last_connectivity_event: null
-				m.chai.expect(promise).to.eventually.equal('configuring')
-
-			it 'should return offline for offline devices', ->
-				promise = balena.models.device.getStatus
-					is_active: true
-					last_connectivity_event: '2019-05-13T16:14'
-					is_online: false
-				m.chai.expect(promise).to.eventually.equal('offline')
-
-			it 'should return idle for idle devices', ->
-				promise = balena.models.device.getStatus
-					is_active: true
-					last_connectivity_event: '2019-05-13T16:14'
-					is_online: true
-				m.chai.expect(promise).to.eventually.equal('idle')
-
 	describe 'given a single application without devices', ->
 
 		describe '[read operations]', ->
@@ -1293,6 +1266,53 @@ describe 'Device Model', ->
 			it 'should be rejected if the device exists but is inaccessible', ->
 				promise = balena.models.device.getSupervisorState(@device.id)
 				m.chai.expect(promise).to.be.rejectedWith('No online device(s) found')
+
+		describe 'balena.models.device.getStatus()', ->
+
+			givenAnApplicationWithADevice(before)
+
+			# This tests that we give a sensible error for users of older SDK versions
+			# that haven't migrated their code.
+			it 'should throw when passing an object as a parameter', ->
+				balena.models.device.get(@device.id).then (device) ->
+					m.chai.expect( -> balena.models.device.getStatus(device))
+					.to.throw("[object Object] is not a valid value for parameter 'uuidOrId'")
+
+			describe 'Given an inactive device', ->
+
+				['id', 'uuid'].forEach (prop) ->
+					it "should return inactive when retrieving by #{prop}", ->
+						promise = balena.models.device.getStatus(@device[prop])
+						m.chai.expect(promise).to.eventually.equal('inactive')
+
+			describe 'Given an online device', ->
+
+				before ->
+					balena.pine.patch
+						resource: 'device'
+						id: @device.id
+						body:
+							# this also activates the device
+							is_online: true
+
+				['id', 'uuid'].forEach (prop) ->
+					it "should return idle when retrieving by #{prop}", ->
+						promise = balena.models.device.getStatus(@device[prop])
+						m.chai.expect(promise).to.eventually.equal('idle')
+
+			describe 'Given an offline device', ->
+
+				before ->
+					balena.pine.patch
+						resource: 'device'
+						id: @device.id
+						body:
+							is_online: false
+
+				['id', 'uuid'].forEach (prop) ->
+					it "should return offline when retrieving by #{prop}", ->
+						promise = balena.models.device.getStatus(@device[prop])
+						m.chai.expect(promise).to.eventually.equal('offline')
 
 	describe 'given a single application with a single online device', ->
 

--- a/tests/integration/models/os.spec.ts
+++ b/tests/integration/models/os.spec.ts
@@ -107,6 +107,10 @@ const describeAllAuthUserChanges = function(
 };
 
 describe('OS model', function() {
+	before(function() {
+		return balena.auth.logout();
+	});
+
 	describe('balena.models.os._getMaxSatisfyingVersion()', function() {
 		const osVersions = {
 			versions: [

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -230,13 +230,11 @@ declare namespace BalenaSdk {
 	}
 
 	interface Application {
+		id: number;
 		app_name: string;
 		device_type: string;
 		slug: string;
 		commit: string;
-		id: number;
-		device_type_info?: DeviceType;
-		has_dependent?: boolean;
 		is_accessible_by_support_until__date: string;
 		is_host: boolean;
 		should_track_latest_release: boolean;

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -1084,7 +1084,7 @@ declare namespace BalenaSdk {
 				enableTcpPing(uuidOrId: string | number): Promise<void>;
 				disableTcpPing(uuidOrId: string | number): Promise<void>;
 				ping(uuidOrId: string | number): Promise<void>;
-				getStatus(device: DeviceWithServiceDetails): Promise<string>;
+				getStatus(uuidOrId: string | number): Promise<string>;
 				lastOnline(device: Device): string;
 				getOsVersion(device: Device): string;
 				isTrackingApplicationRelease(

--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -1272,10 +1272,6 @@ declare namespace BalenaSdk {
 		 * @deprecated Use balena.auth.loginWithToken(apiKey) instead
 		 */
 		apiKey?: string;
-		/**
-		 * @deprecated Not used
-		 */
-		imageMakerUrl?: string;
 		builderUrl?: string;
 		dataDirectory?: string;
 		isBrowser?: boolean;


### PR DESCRIPTION
The highlight of this release is being able to do:
```js
await sdk.auth.logout();
await sdk.pine.get({
	resource: 'application',
	options: {
		// $expand: 'device', // for this we need public device support on the api
		$filter: {
			is_public: true,
			slug: {$startswith: 'balenalabs/rosetta-at-home'}
		}
	}
});
```

Change-type: major
See: https://github.com/balena-io/balena-sdk/pull/880
See: https://github.com/balena-io-modules/balena-pine/pull/57
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
