### PR TITLE
Fully type the pine.get results

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1934,7 +1934,7 @@ balena.models.application.pinToRelease('MyApp', 'f7caf4ff80114deeaefb7ab4447ad9c
 **Kind**: static method of [<code>application</code>](#balena.models.application)  
 **Summary**: Get the hash of the current release for a specific application  
 **Access**: public  
-**Fulfil**: <code>String</code> - The release hash of the current release  
+**Fulfil**: <code>String\|undefined</code> - The release hash of the current release  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/lib/models/api-key.ts
+++ b/lib/models/api-key.ts
@@ -106,7 +106,7 @@ const getApiKeysModel = function (
 		getAll(
 			options: BalenaSdk.PineOptions<BalenaSdk.ApiKey> = {},
 		): Promise<BalenaSdk.ApiKey[]> {
-			return pine.get<BalenaSdk.ApiKey>({
+			return pine.get({
 				resource: 'api_key',
 				options: mergePineOptions(
 					{

--- a/lib/models/application-invite.ts
+++ b/lib/models/application-invite.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import * as errors from 'balena-errors';
 import type {
 	ApplicationInvite,
-	ApplicationMembershipRole,
 	PineOptions,
 	ApplicationInviteOptions,
 	BalenaSDK,
@@ -150,7 +149,7 @@ const getApplicationInviteModel = function (
 			const [{ id }, roles] = await Promise.all([
 				getApplication(nameOrSlugOrId, { $select: 'id' }),
 				roleName
-					? pine.get<ApplicationMembershipRole>({
+					? pine.get({
 							resource: 'application_membership_role',
 							options: {
 								$top: 1,

--- a/lib/models/device.ts
+++ b/lib/models/device.ts
@@ -18,20 +18,18 @@ import type { InjectedOptionsParam, InjectedDependenciesParam } from '..';
 import {
 	Device,
 	PineOptions,
-	ServiceInstall,
 	DeviceServiceEnvironmentVariable,
 	OsUpdateActionResult,
 	DeviceVariable,
 	DeviceTag,
-	SupervisorRelease,
 	Application,
-	Release,
 	SupervisorStatus,
 	DeviceTypeJson,
 	DeviceWithServiceDetails,
 	CurrentServiceWithCommit,
 	DeviceState,
 	DeviceMetrics,
+	PineTypedResult,
 } from '../..';
 
 import * as url from 'url';
@@ -49,6 +47,8 @@ import {
 	treatAsMissingDevice,
 	LOCKED_STATUS_CODE,
 } from '../util';
+
+import { toWritable } from '../util/types';
 
 import {
 	getDeviceOsSemverWithVariant,
@@ -342,7 +342,7 @@ const getDeviceModel = function (
 				resource: 'device',
 				options: mergePineOptions({ $orderby: 'device_name asc' }, options),
 			});
-			return devices.map(addExtraInfo);
+			return devices.map(addExtraInfo) as Device[];
 		},
 
 		/**
@@ -526,7 +526,7 @@ const getDeviceModel = function (
 				}
 				device = devices[0];
 			}
-			return addExtraInfo(device);
+			return addExtraInfo(device) as Device;
 		},
 
 		/**
@@ -683,10 +683,15 @@ const getDeviceModel = function (
 		 * });
 		 */
 		getApplicationName: async (uuidOrId: string | number): Promise<string> => {
-			const device = (await exports.get(uuidOrId, {
+			const deviceOptions = {
 				$select: 'id',
 				$expand: { belongs_to__application: { $select: 'app_name' } },
-			})) as Device & { belongs_to__application: [Application] };
+			} as const;
+
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			return device.belongs_to__application[0].app_name;
 		},
 
@@ -730,10 +735,15 @@ const getDeviceModel = function (
 			env: { [key: string]: string | number };
 			imageId: string;
 		}> => {
-			const device = (await exports.get(uuidOrId, {
-				$select: ['id', 'supervisor_version'],
+			const deviceOptions = {
+				$select: toWritable(['id', 'supervisor_version'] as const),
 				$expand: { belongs_to__application: { $select: 'id' } },
-			})) as Device & { belongs_to__application: [Application] };
+			} as const;
+
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			ensureSupervisorCompatibility(
 				device.supervisor_version,
 				MIN_SUPERVISOR_APPS_API,
@@ -1173,16 +1183,25 @@ const getDeviceModel = function (
 			uuidOrId: string | number,
 			applicationNameOrSlugOrId: string | number,
 		): Promise<void> => {
+			const deviceOptions = {
+				$select: 'uuid',
+				$expand: { is_of__device_type: { $select: 'slug' } },
+			} as const;
+
+			const applicationOptions = {
+				$select: 'id',
+				$expand: { is_for__device_type: { $select: 'slug' } },
+			} as const;
+
 			const [device, deviceTypes, application] = await Promise.all([
-				exports.get(uuidOrId, {
-					$select: 'uuid',
-					$expand: { is_of__device_type: { $select: 'slug' } },
-				}) as Promise<Device & { is_of__device_type: [DeviceType] }>,
+				exports.get(uuidOrId, deviceOptions) as Promise<
+					PineTypedResult<Device, typeof deviceOptions>
+				>,
 				configModel().getDeviceTypes(),
-				applicationModel().get(applicationNameOrSlugOrId, {
-					$select: 'id',
-					$expand: { is_for__device_type: { $select: 'slug' } },
-				}) as Promise<Application & { is_for__device_type: [DeviceType] }>,
+				applicationModel().get(
+					applicationNameOrSlugOrId,
+					applicationOptions,
+				) as Promise<PineTypedResult<Application, typeof applicationOptions>>,
 			]);
 			const osDeviceType = deviceTypesUtils().getBySlug(
 				deviceTypes,
@@ -1245,10 +1264,14 @@ const getDeviceModel = function (
 		 * });
 		 */
 		startApplication: async (uuidOrId: string | number): Promise<void> => {
-			const device = (await exports.get(uuidOrId, {
-				$select: ['id', 'supervisor_version'],
-				$expand: { belongs_to__application: { $select: 'id' } },
-			})) as Device & { belongs_to__application: [Application] };
+			const deviceOptions = {
+				$select: toWritable(['id', 'supervisor_version'] as const),
+				$expand: { belongs_to__application: { $select: 'id' as const } },
+			};
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			ensureSupervisorCompatibility(
 				device.supervisor_version,
 				MIN_SUPERVISOR_APPS_API,
@@ -1299,10 +1322,14 @@ const getDeviceModel = function (
 		 * });
 		 */
 		stopApplication: async (uuidOrId: string | number): Promise<void> => {
-			const device = (await exports.get(uuidOrId, {
-				$select: ['id', 'supervisor_version'],
-				$expand: { belongs_to__application: { $select: 'id' } },
-			})) as Device & { belongs_to__application: [Application] };
+			const deviceOptions = {
+				$select: toWritable(['id', 'supervisor_version'] as const),
+				$expand: { belongs_to__application: { $select: 'id' as const } },
+			};
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			ensureSupervisorCompatibility(
 				device.supervisor_version,
 				MIN_SUPERVISOR_APPS_API,
@@ -1396,10 +1423,14 @@ const getDeviceModel = function (
 			uuidOrId: string | number,
 			imageId: number,
 		): Promise<void> => {
-			const device = (await exports.get(uuidOrId, {
-				$select: ['id', 'supervisor_version'],
-				$expand: { belongs_to__application: { $select: 'id' } },
-			})) as Device & { belongs_to__application: [Application] };
+			const deviceOptions = {
+				$select: toWritable(['id', 'supervisor_version'] as const),
+				$expand: { belongs_to__application: { $select: 'id' as const } },
+			};
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			ensureSupervisorCompatibility(
 				device.supervisor_version,
 				MIN_SUPERVISOR_MC_API,
@@ -1452,10 +1483,14 @@ const getDeviceModel = function (
 			uuidOrId: string | number,
 			imageId: number,
 		): Promise<void> => {
-			const device = (await exports.get(uuidOrId, {
-				$select: ['id', 'supervisor_version'],
-				$expand: { belongs_to__application: { $select: 'id' } },
-			})) as Device & { belongs_to__application: [Application] };
+			const deviceOptions = {
+				$select: toWritable(['id', 'supervisor_version'] as const),
+				$expand: { belongs_to__application: { $select: 'id' as const } },
+			};
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			ensureSupervisorCompatibility(
 				device.supervisor_version,
 				MIN_SUPERVISOR_MC_API,
@@ -1508,10 +1543,14 @@ const getDeviceModel = function (
 			uuidOrId: string | number,
 			imageId: number,
 		): Promise<void> => {
-			const device = (await exports.get(uuidOrId, {
-				$select: ['id', 'supervisor_version'],
-				$expand: { belongs_to__application: { $select: 'id' } },
-			})) as Device & { belongs_to__application: [Application] };
+			const deviceOptions = {
+				$select: toWritable(['id', 'supervisor_version'] as const),
+				$expand: { belongs_to__application: { $select: 'id' as const } },
+			};
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			ensureSupervisorCompatibility(
 				device.supervisor_version,
 				MIN_SUPERVISOR_MC_API,
@@ -1625,10 +1664,15 @@ const getDeviceModel = function (
 				options = {};
 			}
 
-			const device = (await exports.get(uuidOrId, {
+			const deviceOptions = {
 				$select: 'id',
 				$expand: { belongs_to__application: { $select: 'id' } },
-			})) as Device & { belongs_to__application: [Application] };
+			} as const;
+
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			await request
 				.send({
 					method: 'POST',
@@ -1676,10 +1720,14 @@ const getDeviceModel = function (
 		 * });
 		 */
 		purge: async (uuidOrId: string | number): Promise<void> => {
-			const device = (await exports.get(uuidOrId, {
+			const deviceOptions = {
 				$select: 'id',
 				$expand: { belongs_to__application: { $select: 'id' } },
-			})) as Device & { belongs_to__application: [Application] };
+			} as const;
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			await request
 				.send({
 					method: 'POST',
@@ -1739,10 +1787,15 @@ const getDeviceModel = function (
 				options = {};
 			}
 
-			const device = (await exports.get(uuidOrId, {
+			const deviceOptions = {
 				$select: 'id',
 				$expand: { belongs_to__application: { $select: 'id' } },
-			})) as Device & { belongs_to__application: [Application] };
+			} as const;
+
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			await request.send({
 				method: 'POST',
 				url: '/supervisor/v1/update',
@@ -2017,10 +2070,15 @@ const getDeviceModel = function (
 		getManifestByApplication: async (
 			nameOrSlugOrId: string | number,
 		): Promise<DeviceTypeJson.DeviceType> => {
-			const app = (await applicationModel().get(nameOrSlugOrId, {
+			const applicationOptions = {
 				$select: 'id',
 				$expand: { is_for__device_type: { $select: 'slug' } },
-			})) as Application & { is_for__device_type: [DeviceType] };
+			} as const;
+
+			const app = (await applicationModel().get(
+				nameOrSlugOrId,
+				applicationOptions,
+			)) as PineTypedResult<Application, typeof applicationOptions>;
 			return await exports.getManifestBySlug(app.is_for__device_type[0].slug);
 		},
 
@@ -2083,13 +2141,18 @@ const getDeviceModel = function (
 			uuid: string;
 			api_key: string;
 		}> {
+			const applicationOptions = {
+				$select: 'id',
+				$expand: { is_for__device_type: { $select: 'slug' } },
+			} as const;
+
 			const [userId, apiKey, application] = await Promise.all([
 				sdkInstance.auth.getUserId(),
 				applicationModel().generateProvisioningKey(applicationNameOrSlugOrId),
-				applicationModel().get(applicationNameOrSlugOrId, {
-					$select: 'id',
-					$expand: { is_for__device_type: { $select: 'slug' } },
-				}) as Promise<Application & { is_for__device_type: [DeviceType] }>,
+				applicationModel().get(
+					applicationNameOrSlugOrId,
+					applicationOptions,
+				) as Promise<PineTypedResult<Application, typeof applicationOptions>>,
 			]);
 			return await registerDevice().register({
 				userId,
@@ -2489,10 +2552,15 @@ const getDeviceModel = function (
 		 * });
 		 */
 		ping: async (uuidOrId: string | number): Promise<void> => {
-			const device = (await exports.get(uuidOrId, {
+			const deviceOptions = {
 				$select: 'id',
 				$expand: { belongs_to__application: { $select: 'id' } },
-			})) as Device & { belongs_to__application: [Application] };
+			} as const;
+
+			const device = (await exports.get(
+				uuidOrId,
+				deviceOptions,
+			)) as PineTypedResult<Device, typeof deviceOptions>;
 			await request.send({
 				method: 'POST',
 				url: '/supervisor/ping',
@@ -2770,10 +2838,7 @@ const getDeviceModel = function (
 		getTargetReleaseHash: async (
 			uuidOrId: string | number,
 		): Promise<string | undefined> => {
-			const {
-				should_be_running__release,
-				belongs_to__application,
-			} = (await exports.get(uuidOrId, {
+			const deviceOptions = {
 				$select: 'id',
 				$expand: {
 					should_be_running__release: {
@@ -2781,17 +2846,18 @@ const getDeviceModel = function (
 					},
 					belongs_to__application: {
 						$select: 'id',
-						$expand: { should_be_running__release: { $select: ['commit'] } },
+						$expand: { should_be_running__release: { $select: 'commit' } },
 					},
 				},
-			})) as Device & {
-				should_be_running__release: [Release?];
-				belongs_to__application: [
-					Application & {
-						should_be_running__release: [Release?];
-					},
-				];
-			};
+			} as const;
+
+			const {
+				should_be_running__release,
+				belongs_to__application,
+			} = (await exports.get(uuidOrId, deviceOptions)) as PineTypedResult<
+				Device,
+				typeof deviceOptions
+			>;
 			if (should_be_running__release.length > 0) {
 				return should_be_running__release[0]!.commit;
 			}
@@ -2845,7 +2911,8 @@ const getDeviceModel = function (
 				const releaseFilterProperty = isId(fullReleaseHashOrId)
 					? 'id'
 					: 'commit';
-				const { id, belongs_to__application } = (await exports.get(uuidOrId, {
+
+				const deviceOptions = {
 					$select: 'id',
 					$expand: {
 						belongs_to__application: {
@@ -2863,13 +2930,12 @@ const getDeviceModel = function (
 							},
 						},
 					},
-				})) as Device & {
-					belongs_to__application: [
-						Application & {
-							owns__release: Release[];
-						},
-					];
-				};
+				} as const;
+
+				const { id, belongs_to__application } = (await exports.get(
+					uuidOrId,
+					deviceOptions,
+				)) as PineTypedResult<Device, typeof deviceOptions>;
 				const app = belongs_to__application[0];
 				const release = app.owns__release[0];
 				if (!release) {
@@ -2927,11 +2993,17 @@ const getDeviceModel = function (
 				const releaseFilterProperty = isId(supervisorVersionOrId)
 					? 'id'
 					: 'supervisor_version';
-				const device = (await exports.get(uuidOrId, {
+
+				const deviceOpts = {
 					$select: 'id',
 					$expand: { is_of__device_type: { $select: 'slug' } },
-				})) as Device & { is_of__device_type: [DeviceType] };
-				const [supervisorRelease] = await pine.get<SupervisorRelease>({
+				} as const;
+
+				const device = (await exports.get(
+					uuidOrId,
+					deviceOpts,
+				)) as PineTypedResult<Device, typeof deviceOpts>;
+				const [supervisorRelease] = await pine.get({
 					resource: 'supervisor_release',
 					options: {
 						$top: 1,
@@ -3014,7 +3086,9 @@ const getDeviceModel = function (
 				is_online,
 				os_version,
 				os_variant,
-			}: Device & { is_of__device_type: [DeviceType] },
+			}: Pick<Device, 'uuid' | 'is_online' | 'os_version' | 'os_variant'> & {
+				is_of__device_type: [Pick<DeviceType, 'slug'>];
+			},
 			targetOsVersion: string,
 		) {
 			if (!uuid) {
@@ -3076,10 +3150,16 @@ const getDeviceModel = function (
 				);
 			}
 
-			const device = (await exports.get(uuid, {
-				$select: ['is_online', 'os_version', 'os_variant'],
-				$expand: { is_of__device_type: { $select: 'slug' } },
-			})) as Device & { is_of__device_type: [DeviceType] };
+			const deviceOpts = {
+				$select: toWritable(['is_online', 'os_version', 'os_variant'] as const),
+				$expand: { is_of__device_type: { $select: 'slug' as const } },
+			};
+
+			const device = (await exports.get(uuid, deviceOpts)) as PineTypedResult<
+				Device,
+				typeof deviceOpts
+			> &
+				Pick<Device, 'uuid'>;
 
 			device.uuid = uuid;
 			// this will throw an error if the action isn't available
@@ -3139,10 +3219,16 @@ const getDeviceModel = function (
 				);
 			}
 
-			const device = (await exports.get(uuid, {
-				$select: ['is_online', 'os_version', 'os_variant'],
-				$expand: { is_of__device_type: { $select: 'slug' } },
-			})) as Device & { is_of__device_type: [DeviceType] };
+			const deviceOpts = {
+				$select: toWritable(['is_online', 'os_version', 'os_variant'] as const),
+				$expand: { is_of__device_type: { $select: 'slug' as const } },
+			};
+
+			const device = (await exports.get(uuid, deviceOpts)) as PineTypedResult<
+				Device,
+				typeof deviceOpts
+			> &
+				Pick<Device, 'uuid'>;
 
 			device.uuid = uuid;
 			// this will throw an error if the action isn't available
@@ -3903,7 +3989,7 @@ const getDeviceModel = function (
 				key: string,
 			): Promise<string | undefined> {
 				const { id: deviceId } = await exports.get(uuidOrId, { $select: 'id' });
-				const [variable] = await pine.get<DeviceServiceEnvironmentVariable>({
+				const [variable] = await pine.get({
 					resource: 'device_service_environment_variable',
 					options: {
 						$select: 'value',
@@ -3976,7 +4062,7 @@ const getDeviceModel = function (
 							},
 					  };
 
-				const serviceInstalls = await pine.get<ServiceInstall>({
+				const serviceInstalls = await pine.get({
 					resource: 'service_install',
 					options: {
 						$select: 'id',

--- a/lib/models/device.ts
+++ b/lib/models/device.ts
@@ -241,7 +241,9 @@ const getDeviceModel = function (
 		}
 	};
 
-	const addExtraInfo = function (device: Device) {
+	const addExtraInfo = function <
+		T extends Parameters<typeof normalizeDeviceOsVersion>[0]
+	>(device: T) {
 		normalizeDeviceOsVersion(device);
 		return device;
 	};

--- a/lib/models/key.ts
+++ b/lib/models/key.ts
@@ -54,7 +54,7 @@ const getKeyModel = function (
 	function getAll(
 		options: BalenaSdk.PineOptions<BalenaSdk.SSHKey> = {},
 	): Promise<BalenaSdk.SSHKey[]> {
-		return pine.get<BalenaSdk.SSHKey>({
+		return pine.get({
 			resource: 'user__has__public_key',
 			options: mergePineOptions({}, options),
 		});
@@ -83,7 +83,7 @@ const getKeyModel = function (
 	 * });
 	 */
 	async function get(id: number): Promise<BalenaSdk.SSHKey> {
-		const key = await pine.get<BalenaSdk.SSHKey>({
+		const key = await pine.get({
 			resource: 'user__has__public_key',
 			id,
 		});

--- a/lib/models/organization-membership.ts
+++ b/lib/models/organization-membership.ts
@@ -91,7 +91,7 @@ const getOrganizationMembershipModel = function (
 				);
 			}
 
-			const result = await pine.get<OrganizationMembership>({
+			const result = await pine.get({
 				resource: RESOURCE,
 				id: membershipId,
 				options,

--- a/lib/models/organization.ts
+++ b/lib/models/organization.ts
@@ -103,7 +103,7 @@ const getOrganizationModel = function (deps: InjectedDependenciesParam) {
 	const getAll = function (
 		options: BalenaSdk.PineOptions<BalenaSdk.Organization> = {},
 	): Promise<BalenaSdk.Organization[]> {
-		return pine.get<BalenaSdk.Organization>({
+		return pine.get({
 			resource: 'organization',
 			options: mergePineOptions(
 				{
@@ -150,7 +150,7 @@ const getOrganizationModel = function (deps: InjectedDependenciesParam) {
 			throw new errors.BalenaInvalidParameterError('handleOrId', handleOrId);
 		}
 
-		const organization = await pine.get<BalenaSdk.Organization>({
+		const organization = await pine.get({
 			resource: 'organization',
 			id: isId(handleOrId) ? handleOrId : { handle: handleOrId },
 			options,

--- a/lib/models/service.ts
+++ b/lib/models/service.ts
@@ -54,11 +54,11 @@ const getServiceModel = (
 	// Not exported for now, but we could document & export it in the future
 	// if there are external use cases for this.
 	const get = async (id: number, options: PineOptions<Service> = {}) => {
-		const service = (await pine.get({
+		const service = await pine.get({
 			resource: 'service',
 			id,
 			options,
-		})) as Service | undefined;
+		});
 		if (service == null) {
 			throw new errors.BalenaServiceNotFound(id);
 		}
@@ -98,9 +98,9 @@ const getServiceModel = (
 			nameOrSlugOrId: string | number,
 			options: PineOptions<Service> = {},
 		): Promise<Service[]> {
-			const { id } = (await applicationModel().get(nameOrSlugOrId, {
+			const { id } = await applicationModel().get(nameOrSlugOrId, {
 				$select: 'id',
-			})) as { id: number };
+			});
 			return pine.get({
 				resource: 'service',
 				options: mergePineOptions({ $filter: { application: id } }, options),
@@ -169,9 +169,9 @@ const getServiceModel = (
 				nameOrSlugOrId: string | number,
 				options: PineOptions<ServiceEnvironmentVariable> = {},
 			): Promise<ServiceEnvironmentVariable[]> {
-				const { id } = (await applicationModel().get(nameOrSlugOrId, {
+				const { id } = await applicationModel().get(nameOrSlugOrId, {
 					$select: 'id',
-				})) as { id: number };
+				});
 				return varModel.getAll(
 					mergePineOptions(
 						{

--- a/lib/util/device-os-version.ts
+++ b/lib/util/device-os-version.ts
@@ -2,7 +2,11 @@ import bSemver = require('balena-semver');
 import type * as BalenaSdk from '../..';
 import { isProvisioned } from './device';
 
-export const normalizeDeviceOsVersion = (device: BalenaSdk.Device) => {
+export const normalizeDeviceOsVersion = (
+	device: Partial<
+		Pick<BalenaSdk.Device, 'os_version'> & Parameters<typeof isProvisioned>[0]
+	>,
+) => {
 	if (
 		device.os_version != null &&
 		device.os_version.length === 0 &&

--- a/lib/util/device.ts
+++ b/lib/util/device.ts
@@ -1,9 +1,8 @@
 import type * as BalenaSdk from '../..';
 
 export const isProvisioned = (
-	device: Pick<
-		BalenaSdk.Device,
-		'supervisor_version' | 'last_connectivity_event'
+	device: Partial<
+		Pick<BalenaSdk.Device, 'supervisor_version' | 'last_connectivity_event'>
 	>,
 ) => {
 	return (

--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -1,0 +1,4 @@
+import type { Writable } from '../../typings/utils';
+
+export const toWritable = <T extends Readonly<any>>(obj: T) =>
+	obj as Writable<T>;

--- a/tests/integration/models/application.spec.js
+++ b/tests/integration/models/application.spec.js
@@ -281,21 +281,18 @@ describe('Application Model', function () {
 										.expect(childApplication.depends_on__application)
 										.to.have.property('__id', parentApplication.id);
 									// application.getAll() doesn't return dependent apps
-									// prettier-ignore
-									return balena.pine.get(
-										/** @type {import('../../../').PineParams<import('../../../').Application>} */ ({
-											resource: 'application',
-											options: {
-												$select: ['id', 'depends_on__application'],
-												$filter: {
-													id: {
-														$in: [parentApplication.id, childApplication.id],
-													},
+									return balena.pine.get({
+										resource: 'application',
+										options: {
+											$select: ['id', 'depends_on__application'],
+											$filter: {
+												id: {
+													$in: [parentApplication.id, childApplication.id],
 												},
-												$orderby: { id: 'asc' },
 											},
-										}),
-									);
+											$orderby: { id: 'asc' },
+										},
+									});
 								});
 						})
 						.then(function ([parentApplication, childApplication]) {

--- a/tests/integration/models/organization-membership.spec.ts
+++ b/tests/integration/models/organization-membership.spec.ts
@@ -16,9 +16,7 @@ describe('Organization Membership Model', function () {
 
 	before(async function () {
 		this.userId = await balena.auth.getUserId();
-		this.orgAdminRole = await balena.pine.get<
-			BalenaSdk.OrganizationMembershipRole
-		>({
+		this.orgAdminRole = await balena.pine.get({
 			resource: 'organization_membership_role',
 			id: { name: 'administrator' },
 			options: { $select: 'id' },

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -186,8 +186,8 @@ export function givenInitialOrganization(beforeFn: Mocha.HookFunction) {
 }
 
 const getDeviceType = memoize(
-	(deviceTypeId) =>
-		balena.pine.get<BalenaSdk.DeviceType>({
+	(deviceTypeId: number) =>
+		balena.pine.get({
 			resource: 'device_type',
 			id: deviceTypeId,
 			options: {

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -1,8 +1,7 @@
 import { balena } from './setup';
-import type * as BalenaSdk from '../..';
 
 export const getInitialOrganization = async () => {
-	const [org] = await balena.pine.get<BalenaSdk.Organization>({
+	const [org] = await balena.pine.get({
 		resource: 'organization',
 		options: {
 			$select: ['id', 'handle'],

--- a/tests/util_ts.ts
+++ b/tests/util_ts.ts
@@ -16,7 +16,7 @@ export const describeExpandAssertions = async <T>(
 		Object.keys(expand).forEach((key) => {
 			describe(`to ${key}`, function () {
 				it('should succeed and include the expanded property', async function () {
-					const [result] = await balena.pine.get({
+					const [result] = await balena.pine.get<T>({
 						...params,
 						options: {
 							...params.options,

--- a/typing_tests/pine-params.ts
+++ b/typing_tests/pine-params.ts
@@ -1,0 +1,300 @@
+/// <reference types="node" />
+import * as BalenaSdk from '../typings/balena-sdk';
+import { AnyObject } from '../typings/utils';
+import { Compute, Equals, EqualsTrue } from './utils';
+
+const sdk: BalenaSdk.BalenaSDK = {} as any;
+
+let aAny: any;
+let aNumber: number;
+let aNumberOrUndefined: number | undefined;
+let aString: string;
+
+// This file is in .prettierignore, since otherwise
+// the @ts-expect-error comments would move to the wrong place
+
+// AnyObject pine queries
+
+(async () => {
+	const result = await sdk.pine.get<AnyObject>({
+		resource: 'device',
+		options: {
+			$select: ['device_name', 'uuid'],
+			$expand: {
+				belongs_to__application: {},
+				device_tag: {},
+			},
+		},
+	});
+	const test: Equals<typeof result, AnyObject[]> = EqualsTrue;
+})();
+
+(async () => {
+	const result = await sdk.pine.get<AnyObject>({
+		resource: 'device',
+		id: 1,
+		options: {
+			$select: ['device_name', 'uuid'],
+			$expand: {
+				belongs_to__application: {},
+				device_tag: {},
+			},
+		},
+	});
+	const test: Equals<typeof result, AnyObject | undefined> = EqualsTrue;
+})();
+
+// Object level typed result
+
+(async () => {
+	const result = await sdk.pine.get<BalenaSdk.Device>({
+		resource: 'device',
+		options: {
+			$select: ['device_name', 'uuid'],
+			$expand: {
+				belongs_to__application: {},
+				device_tag: {},
+			},
+		},
+	});
+	const test: Equals<typeof result, BalenaSdk.Device[]> = EqualsTrue;
+})();
+
+(async () => {
+	const result = await sdk.pine.get<BalenaSdk.Device>({
+		resource: 'device',
+		id: 1,
+		options: {
+			$select: ['device_name', 'uuid'],
+			$expand: {
+				belongs_to__application: {},
+				device_tag: {},
+			},
+		},
+	});
+	const test: Equals<typeof result, BalenaSdk.Device | undefined> = EqualsTrue;
+})();
+
+// Explicitly providing the result type
+
+(async () => {
+	const result = await sdk.pine.get<BalenaSdk.Device, number>({
+		resource: 'device/$count',
+		options: {
+			$filter: {
+				device_tag: {
+					$any: {
+						$alias: 'dt',
+						$expr: {
+							1: 1,
+						},
+					},
+				},
+			},
+		},
+	});
+	const test: Equals<typeof result, number> = EqualsTrue;
+})();
+
+(async () => {
+	const result = await sdk.pine.get<BalenaSdk.Device, number>({
+		resource: 'device/$count',
+		id: 1,
+		options: {
+			$filter: {
+				device_tag: {
+					$any: {
+						$alias: 'dt',
+						$expr: {
+							1: 1,
+						},
+					},
+				},
+			},
+		},
+	});
+	const test: Equals<typeof result, number> = EqualsTrue;
+})();
+
+// Fully Typed result
+
+(async () => {
+	const [result] = await sdk.pine.get({
+		resource: 'device',
+	});
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumberOrUndefined = result.should_be_running__release?.__id;
+
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+	// @ts-expect-error
+	aAny = result.device_tag;
+})();
+
+(async () => {
+	const result = await sdk.pine.get({
+		resource: 'device',
+		id: 1,
+	});
+
+	const checkUndefined: typeof result = undefined;
+	if (result === undefined) {
+		throw 'Can be undefined';
+	}
+
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumberOrUndefined = result.should_be_running__release?.__id;
+
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+	// @ts-expect-error
+	aAny = result.device_tag;
+})();
+
+(async () => {
+	const result = await sdk.pine.get({
+		resource: 'device',
+		id: 1,
+		options: {
+			$select: ['id', 'device_name'],
+		},
+	});
+
+	const checkUndefined: typeof result = undefined;
+	if (result === undefined) {
+		throw 'Can be undefined';
+	}
+
+	aNumber = result.id;
+	aString = result.device_name;
+
+	// @ts-expect-error
+	aString = result.os_version;
+	// @ts-expect-error
+	aAny = result.belongs_to__application;
+	// @ts-expect-error
+	aAny = result.device_tag;
+})();
+
+(async () => {
+	const [result] = await sdk.pine.get({
+		resource: 'device',
+		options: {
+			$select: ['id', 'device_name', 'belongs_to__application'],
+			$expand: {
+				should_be_running__release: {},
+			},
+		},
+	});
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumberOrUndefined = result.should_be_running__release[0]?.id;
+
+	// @ts-expect-error
+	aString = result.os_version;
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+	// @ts-expect-error
+	aAny = result.device_tag;
+})();
+
+// $count
+
+(async () => {
+	const result = await sdk.pine.get({
+		resource: 'device',
+		options: {
+			$count: {},
+		}
+	});
+	aNumber = result;
+})();
+
+(async () => {
+	const [result] = await sdk.pine.get({
+		resource: 'device',
+		options: {
+			$select: ['id', 'device_name', 'belongs_to__application'],
+			$expand: {
+				should_be_running__release: {
+					$count: {}
+				},
+				device_tag: {},
+			},
+		},
+	});
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumber = result.should_be_running__release;
+	aNumber = result.device_tag[0]?.id;
+
+	// @ts-expect-error
+	aString = result.os_version;
+	// @ts-expect-error
+	aNumber = result.is_on__release.__id;
+})();
+
+(async () => {
+	const [result] = await sdk.pine.get({
+		resource: 'device',
+		options: {
+			$select: ['id', 'device_name', 'belongs_to__application'],
+			$expand: {
+				should_be_running__release: {},
+				device_tag: {
+					$count: {}
+				},
+			},
+		},
+	});
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumberOrUndefined = result.should_be_running__release[0]?.id;
+	aNumber = result.device_tag;
+
+	// @ts-expect-error
+	aString = result.os_version;
+	// @ts-expect-error
+	aNumber = result.is_on__release.__id;
+})();
+
+(async () => {
+	const result = await sdk.pine.get({
+		resource: 'device',
+		options: {
+			$select: ['id', 'device_name', 'belongs_to__application', 'asdf'],
+		},
+	});
+	const test: Equals<Compute<typeof result[number]>, {
+		id: any;
+		device_name: any;
+		belongs_to__application: any;
+		asdf: any;
+	}> = EqualsTrue;
+	// @ts-expect-error - TODO: This should either be never[] or even better the pine.get should error
+	const testTodo: Equals<typeof result, never[]> = EqualsTrue;
+})();
+
+(async () => {
+	const result = await sdk.pine.get({
+		resource: 'device',
+		options: {
+			$select: ['id', 'device_name', 'belongs_to__application'],
+			$expand: {
+				should_be_running__release: {},
+				asdf: {},
+				device_tag: {
+					$count: {}
+				},
+			},
+		},
+	});
+	const test: Equals<typeof result, never[]> = EqualsTrue;
+})();

--- a/typing_tests/pine-typed-result.ts
+++ b/typing_tests/pine-typed-result.ts
@@ -1,0 +1,528 @@
+/// <reference types="node" />
+import * as BalenaSdk from '../typings/balena-sdk';
+import { AnyObject } from '../typings/utils';
+import * as PineClient from '../typings/pinejs-client-core';
+
+const sdk: BalenaSdk.BalenaSDK = {} as any;
+
+let aAny: any;
+let aNumber: number;
+let aNumberOrUndefined: number | undefined;
+let aString: string;
+let aStringOrUndefined: string | undefined;
+
+// This file is in .prettierignore, since otherwise
+// the @ts-expect-error comments would move to the wrong place
+
+// $select
+
+{
+	type deviceOptionsNoProps = PineClient.TypedResult<
+		BalenaSdk.Device,
+		undefined
+	>;
+
+	const result: deviceOptionsNoProps = {} as any;
+
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumberOrUndefined = result.should_be_running__release?.__id;
+
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsNoProps = PineClient.TypedResult<BalenaSdk.Device, {}>;
+
+	const result: deviceOptionsNoProps = {} as any;
+
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumberOrUndefined = result.should_be_running__release?.__id;
+
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsSelectAsterisk = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: '*';
+		}
+	>;
+
+	const result: deviceOptionsSelectAsterisk = {} as any;
+
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumberOrUndefined = result.should_be_running__release?.__id;
+
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsSelectId = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'id';
+		}
+	>;
+
+	const result: deviceOptionsSelectId = {} as any;
+
+	aNumber = result.id;
+
+	// @ts-expect-error
+	aNumber = result.belongs_to__application.__id;
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsSelectRelease = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'belongs_to__application';
+		}
+	>;
+
+	const result: deviceOptionsSelectRelease = {} as any;
+
+	aNumber = result.belongs_to__application.__id;
+
+	// @ts-expect-error
+	aAny = result.should_be_running__release;
+	// @ts-expect-error
+	aNumber = result.id;
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsSelectRelease = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'should_be_running__release';
+		}
+	>;
+
+	const result: deviceOptionsSelectRelease = {} as any;
+
+	aNumberOrUndefined = result.should_be_running__release?.__id;
+
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+	// @ts-expect-error
+	aNumber = result.id;
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsSelectArray = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: ['id', 'note', 'device_name', 'uuid', 'belongs_to__application'];
+		}
+	>;
+
+	const result: deviceOptionsSelectArray = {} as any;
+
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+// $expand w/o $select
+
+{
+	type deviceOptionsExpandNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$expand: 'belongs_to__application';
+		}
+	>;
+
+	const result: deviceOptionsExpandNavigationResourceString = {} as any;
+
+	aNumber = result.belongs_to__application[0].id;
+	aNumber = result.id;
+	aString = result.device_name;
+
+	// @ts-expect-error
+	aAny = result.belongs_to__application[1];
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsExpandNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$expand: 'should_be_running__release';
+		}
+	>;
+
+	const result: deviceOptionsExpandNavigationResourceString = {} as any;
+
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumberOrUndefined = result.should_be_running__release[0]?.id;
+
+	// @ts-expect-error
+	aAny = result.should_be_running__release[0].id;
+	// @ts-expect-error
+	aAny = result.should_be_running__release.__id;
+	// @ts-expect-error
+	aAny = result.should_be_running__release[1];
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsExpandReverseNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$expand: 'device_tag';
+		}
+	>;
+
+	const result: deviceOptionsExpandReverseNavigationResourceString = {} as any;
+
+	aNumber = result.device_tag[1].id;
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumberOrUndefined = result.should_be_running__release?.__id;
+}
+
+// $expand w $select
+
+{
+	type deviceOptionsExpandNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'belongs_to__application';
+			$expand: 'belongs_to__application';
+		}
+	>;
+
+	const result: deviceOptionsExpandNavigationResourceString = {} as any;
+
+	aNumber = result.belongs_to__application[0].id;
+	aString = result.belongs_to__application[0].app_name;
+
+	// @ts-expect-error
+	aNumber = result.id;
+	// @ts-expect-error
+	aString = result.device_name;
+	// @ts-expect-error
+	aAny = result.belongs_to__application[1];
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsExpandNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'should_be_running__release';
+			$expand: 'should_be_running__release';
+		}
+	>;
+
+	const result: deviceOptionsExpandNavigationResourceString = {} as any;
+
+	aNumberOrUndefined = result.should_be_running__release[0]?.id;
+	aStringOrUndefined = result.should_be_running__release[0]?.commit;
+
+	// @ts-expect-error
+	aNumber = result.id;
+	// @ts-expect-error
+	aString = result.device_name;
+	// @ts-expect-error
+	aAny = result.should_be_running__release[1];
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsExpandReverseNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'id';
+			$expand: 'device_tag';
+		}
+	>;
+
+	const result: deviceOptionsExpandReverseNavigationResourceString = {} as any;
+
+	aNumber = result.device_tag[1].id;
+	aString = result.device_tag[1].tag_key;
+	aNumber = result.id;
+
+	// @ts-expect-error
+	aString = result.device_name;
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+}
+
+// empty $expand object
+
+{
+	type deviceOptionsExpandNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'belongs_to__application';
+			$expand: {
+				belongs_to__application: {};
+			};
+		}
+	>;
+
+	const result: deviceOptionsExpandNavigationResourceString = {} as any;
+
+	aNumber = result.belongs_to__application[0].id;
+	aString = result.belongs_to__application[0].app_name;
+
+	// @ts-expect-error
+	aNumber = result.id;
+	// @ts-expect-error
+	aString = result.device_name;
+	// @ts-expect-error
+	aAny = result.belongs_to__application[1];
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsExpandNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'should_be_running__release';
+			$expand: {
+				should_be_running__release: {};
+			};
+		}
+	>;
+
+	const result: deviceOptionsExpandNavigationResourceString = {} as any;
+
+	aNumberOrUndefined = result.should_be_running__release[0]?.id;
+	aStringOrUndefined = result.should_be_running__release[0]?.commit;
+
+	// @ts-expect-error
+	aNumber = result.id;
+	// @ts-expect-error
+	aString = result.device_name;
+	// @ts-expect-error
+	aAny = result.should_be_running__release[1];
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsExpandReverseNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'id';
+			$expand: {
+				device_tag: {};
+			};
+		}
+	>;
+
+	const result: deviceOptionsExpandReverseNavigationResourceString = {} as any;
+
+	aNumber = result.device_tag[1].id;
+	aString = result.device_tag[1].tag_key;
+	aNumber = result.id;
+
+	// @ts-expect-error
+	aString = result.device_name;
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+}
+
+// $expand object w/ nested options
+
+{
+	type deviceOptionsExpandNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'id';
+			$expand: {
+				belongs_to__application: {
+					$select: 'app_name';
+				};
+			};
+		}
+	>;
+
+	const result: deviceOptionsExpandNavigationResourceString = {} as any;
+
+	aNumber = result.id;
+	aString = result.belongs_to__application[0].app_name;
+
+	// @ts-expect-error
+	aNumber = result.belongs_to__application[0].id;
+	// @ts-expect-error
+	aString = result.device_name;
+	// @ts-expect-error
+	aAny = result.belongs_to__application[1];
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsExpandNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'id';
+			$expand: {
+				should_be_running__release: {
+					$select: 'commit';
+				};
+			};
+		}
+	>;
+
+	const result: deviceOptionsExpandNavigationResourceString = {} as any;
+
+	aNumber = result.id;
+	aStringOrUndefined = result.should_be_running__release[0]?.commit;
+
+	// @ts-expect-error
+	aNumberOrUndefined = result.should_be_running__release[0]?.id;
+	// @ts-expect-error
+	aString = result.device_name;
+	// @ts-expect-error
+	aAny = result.should_be_running__release[1];
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsExpandNavigationResourceString = PineClient.TypedResult<
+		AnyObject,
+		{
+			$select: 'id';
+			$expand: {
+				should_be_running__release: {
+					$select: 'commit';
+				};
+			};
+		}
+	>;
+
+	const result: deviceOptionsExpandNavigationResourceString = {} as any;
+
+	aNumber = result.id;
+	// Errors, since it could be an OptionalNavigationResource
+	// @ts-expect-error
+	aStringOrUndefined = result.should_be_running__release[0].commit;
+	aStringOrUndefined = result.should_be_running__release[0]?.commit;
+	// @ts-expect-error
+	aNumberOrUndefined = result.should_be_running__release[0]?.id;
+	// This also works, since the typings don't know whether this is Navigation or a Reverse Navigation Resounce
+	aAny = result.should_be_running__release[1].commit;
+
+	// @ts-expect-error
+	aString = result.device_name;
+	// @ts-expect-error
+	aAny = result.device_tag;
+}
+
+{
+	type deviceOptionsExpandReverseNavigationResourceString = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'id';
+			$expand: {
+				device_tag: {
+					$select: 'tag_key';
+				};
+			};
+		}
+	>;
+
+	const result: deviceOptionsExpandReverseNavigationResourceString = {} as any;
+
+	aNumber = result.id;
+	aString = result.device_tag[1].tag_key;
+
+	// @ts-expect-error
+	aString = result.device_name;
+	// @ts-expect-error
+	aNumber = result.device_tag[1].id;
+	// @ts-expect-error
+	aNumber = result.should_be_running__release.__id;
+}
+
+// $count
+
+{
+	type deviceOptionsNoProps = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{ $count: {} }
+	>;
+
+	const result: deviceOptionsNoProps = {} as any;
+
+	aNumber = result;
+}
+
+{
+	type deviceOptionsNoProps = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'id';
+			$expand: {
+				belongs_to__application: {
+					$count: {};
+				};
+			};
+		}
+	>;
+
+	const result: deviceOptionsNoProps = {} as any;
+
+	aNumber = result.id;
+	aNumber = result.belongs_to__application;
+}
+
+{
+	type deviceOptionsNoProps = PineClient.TypedResult<
+		BalenaSdk.Device,
+		{
+			$select: 'id';
+			$expand: {
+				device_tag: {
+					$count: {};
+				};
+			};
+		}
+	>;
+
+	const result: deviceOptionsNoProps = {} as any;
+
+	aNumber = result.id;
+	aNumber = result.device_tag;
+}

--- a/typing_tests/utils.ts
+++ b/typing_tests/utils.ts
@@ -1,4 +1,5 @@
 import { Any, Boolean } from 'ts-toolbelt';
 
+export type Compute<T> = Any.Compute<T>;
 export type Equals<T, P> = Any.Equals<T, P>;
 export let EqualsTrue: Boolean.True;

--- a/typings/balena-sdk/index.d.ts
+++ b/typings/balena-sdk/index.d.ts
@@ -141,7 +141,7 @@ export interface ReleaseWithImageDetails extends Release {
 		id: number;
 		service_name: string;
 	}>;
-	user: User;
+	user: Pick<User, 'id' | 'username'> | undefined;
 }
 
 export interface BillingAccountAddressInfo {

--- a/typings/balena-sdk/index.d.ts
+++ b/typings/balena-sdk/index.d.ts
@@ -55,6 +55,8 @@ export type {
 	ODataOptionsWithFilter as PineOptionsWithFilter,
 	SelectableProps as PineSelectableProps,
 	ExpandableProps as PineExpandableProps,
+	ExpandResultObject as PineExpandResultObject,
+	TypedResult as PineTypedResult,
 } from '../pinejs-client-core';
 export type { PineWithSelectOnGet } from '../balena-pine';
 

--- a/typings/balena-sdk/models.d.ts
+++ b/typings/balena-sdk/models.d.ts
@@ -10,6 +10,58 @@ import type {
 // TODO: Drop in the next major
 export { SocialServiceAccount } from './jwt';
 
+export interface ResourceTypeMap {
+	api_key: ApiKey;
+	application: Application;
+	application__can_use__application_as_host: ApplicationHostedOnApplication;
+	application_config_variable: ApplicationVariable;
+	application_environment_variable: ApplicationVariable;
+	application_membership_role: ApplicationMembershipRole;
+	application_tag: ApplicationTag;
+	application_type: ApplicationType;
+	build_environment_variable: BuildVariable;
+	device: Device;
+	device_config_variable: DeviceVariable;
+	device_environment_variable: DeviceVariable;
+	device_service_environment_variable: DeviceServiceEnvironmentVariable;
+	device_tag: DeviceTag;
+	device_type: DeviceType;
+	feature: Feature;
+	gateway_download: GatewayDownload;
+	image: Image;
+	image_install: ImageInstall;
+	invitee: Invitee;
+	invitee__is_invited_to__application: ApplicationInvite;
+	my_application: Application;
+	organization: Organization;
+	organization__has_private_access_to__device_type: OrganizationPrivateDeviceTypeAccess;
+	organization_membership: OrganizationMembership;
+	organization_membership_role: OrganizationMembershipRole;
+	organization_membership_tag: OrganizationMembershipTag;
+	plan: Plan;
+	plan__has__discount_code: PlanDiscountCode;
+	plan_addon: PlanAddon;
+	plan_feature: PlanFeature;
+	recovery_two_factor: RecoveryTwoFactor;
+	release: Release;
+	release_tag: ReleaseTag;
+	service: Service;
+	service_environment_variable: ServiceEnvironmentVariable;
+	service_install: ServiceInstall;
+	service_instance: ServiceInstance;
+	subscription: Subscription;
+	subscription_prepaid_addon: SubscriptionPrepaidAddon;
+	supervisor_release: SupervisorRelease;
+	support_feature: SupportFeature;
+	support_tier: SupportTier;
+	team: Team;
+	team_application_access: TeamApplicationAccess;
+	team_membership: TeamMembership;
+	user: User;
+	user__has__public_key: SSHKey;
+	user__is_member_of__application: ApplicationMembership;
+}
+
 export interface Organization {
 	id: number;
 	created_at: string;
@@ -57,7 +109,6 @@ export interface OrganizationMembershipRole {
 	name: OrganizationMembershipRoles;
 }
 
-/** organization_membership */
 export interface OrganizationMembership {
 	id: number;
 	created_at: string;
@@ -72,7 +123,6 @@ export interface OrganizationMembership {
 	>;
 }
 
-/** team_membership */
 export interface TeamMembership {
 	id: number;
 	created_at: string;
@@ -169,7 +219,6 @@ export interface ApplicationMembershipRole {
 	name: ApplicationMembershipRoles;
 }
 
-/** user__is_member_of__application */
 export interface ApplicationMembership {
 	id: number;
 	user: NavigationResource<User>;
@@ -178,7 +227,6 @@ export interface ApplicationMembership {
 	application_membership_role: NavigationResource<ApplicationMembershipRole>;
 }
 
-/** team_application_access */
 export interface TeamApplicationAccess {
 	id: number;
 	team: NavigationResource<Team>;
@@ -293,7 +341,6 @@ export interface Device {
 	gateway_download?: ReverseNavigationResource<GatewayDownload>;
 }
 
-/** device_type */
 export interface DeviceType {
 	id: number;
 	slug: string;
@@ -308,14 +355,12 @@ export interface DeviceType {
 
 export type DeviceOverallStatus = DeviceOverallStatus.DeviceOverallStatus;
 
-/** organization__has_private_access_to__device_type */
 export interface OrganizationPrivateDeviceTypeAccess {
 	id: number;
 	organization: NavigationResource<Organization>;
 	has_private_access_to__device_type: NavigationResource<DeviceType>;
 }
 
-/** @deprecated Use the Device type directly */
 export type DeviceWithImageInstalls = Device &
 	Required<Pick<Device, 'image_install' | 'gateway_download'>>;
 

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -1,4 +1,5 @@
 import type { AnyObject, PropsOfType, StringKeyof, Dictionary } from './utils';
+import type { ResourceTypeMap } from './balena-sdk/models';
 
 export interface WithId {
 	id: number;
@@ -448,10 +449,34 @@ export interface SubscribeParamsWithId<T> extends ParamsObjWithId<T> {
 
 export interface Pine {
 	delete<T>(params: ParamsObjWithId<T> | ParamsObjWithFilter<T>): Promise<'OK'>;
-	get<T>(params: ParamsObjWithCount<T>): Promise<number>;
-	get<T>(params: ParamsObjWithId<T>): Promise<T | undefined>;
-	get<T>(params: ParamsObj<T>): Promise<T[]>;
-	get<T, Result>(params: ParamsObj<T>): Promise<Result>;
+	// Fully typed result overloads
+	get<
+		R extends keyof ResourceTypeMap,
+		P extends { resource: R } & ParamsObjWithCount<
+			ResourceTypeMap[P['resource']]
+		>
+	>(
+		params: P,
+	): Promise<number>;
+	get<
+		R extends keyof ResourceTypeMap,
+		P extends { resource: R } & ParamsObjWithId<ResourceTypeMap[P['resource']]>
+	>(
+		params: P,
+	): Promise<
+		TypedResult<ResourceTypeMap[P['resource']], P['options']> | undefined
+	>;
+	get<
+		R extends keyof ResourceTypeMap,
+		P extends { resource: R } & ParamsObj<ResourceTypeMap[P['resource']]>
+	>(
+		params: P,
+	): Promise<Array<TypedResult<ResourceTypeMap[P['resource']], P['options']>>>;
+	// User provided resource type overloads
+	get<T extends {}>(params: ParamsObjWithCount<T>): Promise<number>;
+	get<T extends {}>(params: ParamsObjWithId<T>): Promise<T | undefined>;
+	get<T extends {}>(params: ParamsObj<T>): Promise<T[]>;
+	get<T extends {}, Result>(params: ParamsObj<T>): Promise<Result>;
 	post<T>(params: ParamsObj<T>): Promise<T & { id: number }>;
 	patch<T>(params: ParamsObjWithId<T> | ParamsObjWithFilter<T>): Promise<'OK'>;
 	upsert<T>(params: UpsertParams<T>): Promise<T | 'OK'>;
@@ -519,13 +544,45 @@ export type PineWithSelectOnGet = Omit<
 	Pine,
 	'get' | 'prepare' | 'subscribe'
 > & {
-	get<T>(params: ParamsObjWithCount<T>): Promise<number>;
-	get<T>(
+	// Fully typed result overloads
+	get<
+		R extends keyof ResourceTypeMap,
+		P extends { resource: R } & ParamsObjWithCount<
+			ResourceTypeMap[P['resource']]
+		> &
+			ParamsObjWithSelect<ResourceTypeMap[P['resource']]>
+	>(
+		params: P,
+	): Promise<number>;
+	get<
+		R extends keyof ResourceTypeMap,
+		P extends { resource: R } & ParamsObjWithId<
+			ResourceTypeMap[P['resource']]
+		> &
+			ParamsObjWithSelect<ResourceTypeMap[P['resource']]>
+	>(
+		params: P,
+	): Promise<
+		TypedResult<ResourceTypeMap[P['resource']], P['options']> | undefined
+	>;
+	get<
+		R extends keyof ResourceTypeMap,
+		P extends { resource: R } & ParamsObjWithSelect<
+			ResourceTypeMap[P['resource']]
+		>
+	>(
+		params: P,
+	): Promise<Array<TypedResult<ResourceTypeMap[P['resource']], P['options']>>>;
+	// User provided resource type overloads
+	get<T extends {}>(params: ParamsObjWithCount<T>): Promise<number>;
+	get<T extends {}>(
 		params: ParamsObjWithId<T> & ParamsObjWithSelect<T>,
 	): Promise<T | undefined>;
-	get<T>(params: ParamsObjWithSelect<T>): Promise<T[]>;
-	get<T, Result extends number>(params: ParamsObj<T>): Promise<Result>;
-	get<T, Result>(params: ParamsObjWithSelect<T>): Promise<Result>;
+	get<T extends {}>(params: ParamsObjWithSelect<T>): Promise<T[]>;
+	get<T extends {}, Result extends number>(
+		params: ParamsObj<T>,
+	): Promise<Result>;
+	get<T extends {}, Result>(params: ParamsObjWithSelect<T>): Promise<Result>;
 
 	prepare<T extends Dictionary<ParameterAlias>, R>(
 		params: ParamsObjWithCount<R> & {

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -16,3 +16,5 @@ export interface Dictionary<T> {
 export type Resolvable<R> = R | PromiseLike<R>;
 
 export type AtLeast<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;
+
+export type Writable<T> = { -readonly [K in keyof T]: T[K] };


### PR DESCRIPTION
I decided to only initially release this for `pine.get` calls, since
* in that case it's not a major, since the previous typed method overloads are still working
* we can give this a good try on the UI and once we are fine with how it works we can do a major and release is for all calls (dropping the old "whole resource" typings)

Connects-to: #887
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/FOa1dMbGF9pAqoaNd6vkWggxYIH
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/5woCd-4nD7q-4p_YF9OO8KHzG3F
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
