### PR TITLE
Properly document the exported factory function, setSharedOptions & fromSharedOptions

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -22,6 +22,12 @@ If you feel something is missing, not clear or could be improved, please don't h
 <a name="module_balena-sdk"></a>
 
 ## balena-sdk
+
+* [balena-sdk](#module_balena-sdk)
+    * [getSdk()](#exp_module_balena-sdk--getSdk) ⏏
+        * [~setSharedOptions(options)](#module_balena-sdk--getSdk..setSharedOptions)
+        * [~fromSharedOptions()](#module_balena-sdk--getSdk..fromSharedOptions)
+
 <a name="exp_module_balena-sdk--getSdk"></a>
 
 ### getSdk() ⏏
@@ -36,6 +42,52 @@ const balena = getSdk({
 	apiUrl: "https://api.balena-cloud.com/",
 	dataDirectory: "/opt/local/balena"
 });
+```
+<a name="module_balena-sdk--getSdk..setSharedOptions"></a>
+
+#### getSdk~setSharedOptions(options)
+Set options that are used by calls to `getSdk.fromSharedOptions()`.
+The options accepted are the same as those used in the main SDK factory function.
+If you use this method, it should be called as soon as possible during app
+startup and before any calls to `fromSharedOptions()` are made.
+
+**Kind**: inner method of [<code>getSdk</code>](#exp_module_balena-sdk--getSdk)  
+**Summary**: Set shared default options  
+**Access**: public  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| options | <code>Object</code> |  | The shared default options |
+| [options.apiUrl] | <code>String</code> | <code>&#x27;https://api.balena-cloud.com/&#x27;</code> | the balena API url to use. |
+| [options.builderUrl] | <code>String</code> | <code>&#x27;https://builder.balena-cloud.com/&#x27;</code> | the balena builder url to use. |
+| [options.deviceUrlsBase] | <code>String</code> | <code>&#x27;balena-devices.com&#x27;</code> | the base balena device API url to use. |
+| [options.dataDirectory] | <code>String</code> | <code>&#x27;$HOME/.balena&#x27;</code> | *ignored in the browser*, the directory where the user settings are stored, normally retrieved like `require('balena-settings-client').get('dataDirectory')`. |
+| [options.isBrowser] | <code>Boolean</code> |  | the flag to tell if the module works in the browser. If not set will be computed based on the presence of the global `window` value. |
+| [options.debug] | <code>Boolean</code> |  | when set will print some extra debug information. |
+
+**Example**  
+```js
+const getSdk = require('balena-sdk');
+getSdk.setSharedOptions({
+	apiUrl: 'https://api.balena-cloud.com/',
+	builderUrl: 'https://builder.balena-cloud.com/',
+	isBrowser: true,
+});
+```
+<a name="module_balena-sdk--getSdk..fromSharedOptions"></a>
+
+#### getSdk~fromSharedOptions()
+Create an SDK instance using shared default options set using the `setSharedOptions()` method.
+If options have not been set using this method, then this method will use the
+same defaults as the main SDK factory function.
+
+**Kind**: inner method of [<code>getSdk</code>](#exp_module_balena-sdk--getSdk)  
+**Summary**: Create an SDK instance using shared default options  
+**Access**: public  
+**Example**  
+```js
+const getSdk = require('balena-sdk');
+const sdk = getSdk.fromSharedOptions();
 ```
 <a name="balena"></a>
 
@@ -258,8 +310,6 @@ const balena = getSdk({
     * [.settings](#balena.settings) : <code>object</code>
         * [.get([key])](#balena.settings.get) ⇒ <code>Promise</code>
         * [.getAll()](#balena.settings.getAll) ⇒ <code>Promise</code>
-    * [.setSharedOptions(options)](#balena.setSharedOptions)
-    * [.fromSharedOptions()](#balena.fromSharedOptions)
 
 <a name="balena.interceptors"></a>
 
@@ -6166,48 +6216,4 @@ balena.settings.getAll(function(error, settings) {
 	if (error) throw error;
 	console.log(settings);
 });
-```
-<a name="balena.setSharedOptions"></a>
-
-### balena.setSharedOptions(options)
-Set options that are used by calls to `balena.fromSharedOptions()`.
-The options accepted are the same as those used in the main SDK factory function.
-If you use this method, it should be called as soon as possible during app
-startup and before any calls to `fromSharedOptions()` are made.
-
-**Kind**: static method of [<code>balena</code>](#balena)  
-**Summary**: Set shared default options  
-**Access**: public  
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| options | <code>Object</code> |  | The shared default options |
-| [options.apiUrl] | <code>String</code> | <code>&#x27;https://api.balena-cloud.com/&#x27;</code> | the balena API url to use. |
-| [options.builderUrl] | <code>String</code> | <code>&#x27;https://builder.balena-cloud.com/&#x27;</code> | the balena builder url to use. |
-| [options.deviceUrlsBase] | <code>String</code> | <code>&#x27;balena-devices.com&#x27;</code> | the base balena device API url to use. |
-| [options.dataDirectory] | <code>String</code> | <code>&#x27;$HOME/.balena&#x27;</code> | *ignored in the browser*, the directory where the user settings are stored, normally retrieved like `require('balena-settings-client').get('dataDirectory')`. |
-| [options.isBrowser] | <code>Boolean</code> |  | the flag to tell if the module works in the browser. If not set will be computed based on the presence of the global `window` value. |
-| [options.debug] | <code>Boolean</code> |  | when set will print some extra debug information. |
-
-**Example**  
-```js
-balena.setSharedOptions({
-	apiUrl: 'https://api.balena-cloud.com/',
-	builderUrl: 'https://builder.balena-cloud.com/',
-	isBrowser: true,
-});
-```
-<a name="balena.fromSharedOptions"></a>
-
-### balena.fromSharedOptions()
-Create an SDK instance using shared default options set using the `setSharedOptions()` method.
-If options have not been set using this method, then this method will use the
-same defaults as the main SDK factory function.
-
-**Kind**: static method of [<code>balena</code>](#balena)  
-**Summary**: Create an SDK instance using shared default options  
-**Access**: public  
-**Example**  
-```js
-const sdk = balena.fromSharedOptions();
 ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,6 +1,3 @@
-<a name="balena"></a>
-
-## balena : <code>object</code>
 Welcome to the Balena SDK documentation.
 
 This document aims to describe all the functions supported by the SDK, as well as showing examples of their expected usage.
@@ -8,6 +5,41 @@ This document aims to describe all the functions supported by the SDK, as well a
 If you feel something is missing, not clear or could be improved, please don't hesitate to open an
 [issue in GitHub](https://github.com/balena-io/balena-sdk/issues/new), we'll be happy to help.
 
+## Modules
+
+<dl>
+<dt><a href="#module_balena-sdk">balena-sdk</a></dt>
+<dd></dd>
+</dl>
+
+## Objects
+
+<dl>
+<dt><a href="#balena">balena</a> : <code>object</code></dt>
+<dd></dd>
+</dl>
+
+<a name="module_balena-sdk"></a>
+
+## balena-sdk
+<a name="exp_module_balena-sdk--getSdk"></a>
+
+### getSdk() ⏏
+The module exports a single factory function.
+
+**Kind**: Exported function  
+**Summary**: Creates a new SDK instance using the default or the provided options.  
+**Example**  
+```js
+const getSdk = require('balena-sdk');
+const balena = getSdk({
+	apiUrl: "https://api.balena-cloud.com/",
+	dataDirectory: "/opt/local/balena"
+});
+```
+<a name="balena"></a>
+
+## balena : <code>object</code>
 **Kind**: global namespace  
 
 * [balena](#balena) : <code>object</code>

--- a/doc/DOCUMENTATION.hbs
+++ b/doc/DOCUMENTATION.hbs
@@ -1,0 +1,8 @@
+Welcome to the Balena SDK documentation.
+
+This document aims to describe all the functions supported by the SDK, as well as showing examples of their expected usage.
+
+If you feel something is missing, not clear or could be improved, please don't hesitate to open an
+[issue in GitHub](https://github.com/balena-io/balena-sdk/issues/new), we'll be happy to help.
+
+{{>main}}

--- a/lib/balena.js
+++ b/lib/balena.js
@@ -303,10 +303,9 @@ const getSdk = function (opts) {
  * @name setSharedOptions
  * @public
  * @function
- * @memberof balena
  *
  * @description
- * Set options that are used by calls to `balena.fromSharedOptions()`.
+ * Set options that are used by calls to `getSdk.fromSharedOptions()`.
  * The options accepted are the same as those used in the main SDK factory function.
  * If you use this method, it should be called as soon as possible during app
  * startup and before any calls to `fromSharedOptions()` are made.
@@ -320,7 +319,8 @@ const getSdk = function (opts) {
  * @param {Boolean} [options.debug] - when set will print some extra debug information.
  *
  * @example
- * balena.setSharedOptions({
+ * const getSdk = require('balena-sdk');
+ * getSdk.setSharedOptions({
  * 	apiUrl: 'https://api.balena-cloud.com/',
  * 	builderUrl: 'https://builder.balena-cloud.com/',
  * 	isBrowser: true,
@@ -348,7 +348,6 @@ getSdk.setSharedOptions = function (options) {
  * @name fromSharedOptions
  * @public
  * @function
- * @memberof balena
  *
  * @description
  * Create an SDK instance using shared default options set using the `setSharedOptions()` method.
@@ -356,7 +355,8 @@ getSdk.setSharedOptions = function (options) {
  * same defaults as the main SDK factory function.
  *
  * @example
- * const sdk = balena.fromSharedOptions();
+ * const getSdk = require('balena-sdk');
+ * const sdk = getSdk.fromSharedOptions();
  */
 getSdk.fromSharedOptions = function () {
 	const sharedOpts = globalEnv[BALENA_SDK_SHARED_OPTIONS];

--- a/lib/balena.js
+++ b/lib/balena.js
@@ -25,15 +25,26 @@ const BALENA_SDK_HAS_SET_SHARED_OPTIONS = 'BALENA_SDK_HAS_SET_SHARED_OPTIONS';
 
 /**
  * @namespace balena
- * @description
- * Welcome to the Balena SDK documentation.
- *
- * This document aims to describe all the functions supported by the SDK, as well as showing examples of their expected usage.
- *
- * If you feel something is missing, not clear or could be improved, please don't hesitate to open an
- * [issue in GitHub](https://github.com/balena-io/balena-sdk/issues/new), we'll be happy to help.
  */
 
+/**
+ * @module balena-sdk
+ */
+
+/**
+ * @alias module:balena-sdk
+ * @summary Creates a new SDK instance using the default or the provided options.
+ *
+ * @description
+ * The module exports a single factory function.
+ *
+ * @example
+ * const getSdk = require('balena-sdk');
+ * const balena = getSdk({
+ * 	apiUrl: "https://api.balena-cloud.com/",
+ * 	dataDirectory: "/opt/local/balena"
+ * });
+ */
 const getSdk = function (opts) {
 	let settings;
 	if (opts == null) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:typings": "dtslint --localTs node_modules/typescript/lib --expectOnly typing_tests",
     "build:ts": "tsc && gulp inject-version",
     "build": "npm run lint && npm run clean && npm run build:ts && gulp build && npm run docs",
-    "docs": "jsdoc2md \"build/**/!(balena-browser*.js)\" > DOCUMENTATION.md",
+    "docs": "jsdoc2md --template doc/DOCUMENTATION.hbs \"build/**/!(balena-browser*.js)\" > DOCUMENTATION.md",
     "ci": "npm test && catch-uncommitted",
     "coffeelint": "balena-lint tests gulpfile.coffee",
     "tslint": "balena-lint -e js -e ts --typescript --fix typings lib tests",


### PR DESCRIPTION
The only thing that I don't like is the `⏏` symbol that jsdoc2md uses for cmnjs default exports:
```
[getSdk()](#exp_module_balena-sdk--getSdk) ⏏
```
But that seems to be added by one of the jsdoc nested dependencies & will be gone once we start exporting modules.

Change-type: patch

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
