### PR TITLE
Split util function imports and lazy load them

### DIFF
--- a/lib/models/device.js
+++ b/lib/models/device.js
@@ -26,15 +26,11 @@ import {
 	isId,
 	isNoDeviceForKeyResponse,
 	isNotFoundResponse,
-	getOsUpdateHelper as _getOsUpdateHelper,
-	deviceTypes as deviceTypesUtil,
 	mergePineOptions,
 	treatAsMissingDevice,
 	LOCKED_STATUS_CODE,
-	timeSince,
 } from '../util';
 
-import { hupActionHelper } from '../util/device-actions/os-update/utils';
 import {
 	getDeviceOsSemverWithVariant,
 	normalizeDeviceOsVersion,
@@ -89,6 +85,11 @@ const getDeviceModel = function (deps, opts) {
 	const { addCallbackSupportToModule } = require('../util/callbacks');
 
 	const { buildDependentResource } = require('../util/dependent-resource');
+	const hupActionHelper = once(
+		() => require('../util/device-actions/os-update/utils').hupActionHelper,
+	);
+	const deviceTypesUtils = once(() => require('../util/device-types'));
+	const dateUtils = once(() => require('../util/date'));
 
 	const tagsModel = buildDependentResource(
 		{ pine },
@@ -140,11 +141,14 @@ const getDeviceModel = function (deps, opts) {
 		}),
 	);
 
-	const getOsUpdateHelper = once(() =>
-		getDeviceUrlsBase().then(($deviceUrlsBase) =>
-			_getOsUpdateHelper($deviceUrlsBase, request),
-		),
-	);
+	const getOsUpdateHelper = once(() => {
+		return getDeviceUrlsBase().then(($deviceUrlsBase) => {
+			const {
+				getOsUpdateHelper: _getOsUpdateHelper,
+			} = require('../util/device-actions/os-update');
+			return _getOsUpdateHelper($deviceUrlsBase, request);
+		});
+	});
 
 	// Internal method for uuid/id disambiguation
 	// Note that this throws an exception for missing uuids, but not missing ids
@@ -1021,15 +1025,15 @@ const getDeviceModel = function (deps, opts) {
 					$select: ['id', 'device_type'],
 				}),
 			}).then(function ({ application, device, deviceTypes }) {
-				const osDeviceType = deviceTypesUtil.getBySlug(
+				const osDeviceType = deviceTypesUtils().getBySlug(
 					deviceTypes,
 					device.device_type,
 				);
-				const targetAppDeviceType = deviceTypesUtil.getBySlug(
+				const targetAppDeviceType = deviceTypesUtils().getBySlug(
 					deviceTypes,
 					application.device_type,
 				);
-				const isCompatibleMove = deviceTypesUtil.isDeviceTypeCompatibleWith(
+				const isCompatibleMove = deviceTypesUtils().isDeviceTypeCompatibleWith(
 					osDeviceType,
 					targetAppDeviceType,
 				);
@@ -2517,6 +2521,7 @@ const getDeviceModel = function (deps, opts) {
 		 */
 		lastOnline(device) {
 			const lce = device.last_connectivity_event;
+			const { timeSince } = dateUtils();
 
 			if (!lce) {
 				return 'Connecting...';
@@ -2787,7 +2792,7 @@ const getDeviceModel = function (deps, opts) {
 			// rely on getHUPActionType to throw an error
 
 			// this will throw an error if the action isn't available
-			hupActionHelper.getHUPActionType(
+			hupActionHelper().getHUPActionType(
 				device_type,
 				currentOsVersion,
 				targetOsVersion,

--- a/lib/util/date.ts
+++ b/lib/util/date.ts
@@ -1,0 +1,21 @@
+import throttle = require('lodash/throttle');
+import * as memoizee from 'memoizee';
+import * as moment from 'moment';
+
+const now = throttle(() => moment(), 1000, { leading: true });
+
+const dateToMoment = memoizee((date: Date) => moment(date), {
+	max: 1000,
+	primitive: true,
+});
+
+export const timeSince = (input: Date, suffix = true) => {
+	const date = dateToMoment(input);
+
+	// We do this to avoid out-of-sync times causing this to return
+	// e.g. 'in a few seconds'.
+	// if the date is in the future .min will make it at maximum, the time since now
+	// which results in 'a few seconds ago'.
+	const time = now();
+	return moment.min(time, date).from(time, !suffix);
+};

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -1,20 +1,12 @@
 import * as errors from 'balena-errors';
 import cloneDeep = require('lodash/cloneDeep');
-import throttle = require('lodash/throttle');
-import * as memoizee from 'memoizee';
-import * as moment from 'moment';
 import * as Pine from '../../typings/pinejs-client-core';
-import { getOsUpdateHelper as updateHelper } from './device-actions/os-update';
-import * as dt from './device-types';
 
 export interface ErrorResponse {
 	code: string;
 	statusCode?: number;
 	body?: string;
 }
-
-export const getOsUpdateHelper = updateHelper;
-export const deviceTypes = dt;
 
 export const notImplemented = () => {
 	throw new Error('The method is not implemented.');
@@ -28,24 +20,6 @@ export const onlyIf = <T extends (...args: any[]) => any>(
 	} else {
 		return notImplemented;
 	}
-};
-
-export const now = throttle(() => moment(), 1000, { leading: true });
-
-export const dateToMoment = memoizee((date: Date) => moment(date), {
-	max: 1000,
-	primitive: true,
-});
-
-export const timeSince = (input: Date, suffix = true) => {
-	const date = dateToMoment(input);
-
-	// We do this to avoid out-of-sync times causing this to return
-	// e.g. 'in a few seconds'.
-	// if the date is in the future .min will make it at maximum, the time since now
-	// which results in 'a few seconds ago'.
-	const time = now();
-	return moment.min(time, date).from(time, !suffix);
 };
 
 export const isId = (v?: any): v is number => typeof v === 'number';
@@ -95,9 +69,6 @@ export const treatAsMissingDevice = (uuidOrId: string | number) => (
 	replacementErr.stack = err.stack || '';
 	throw replacementErr;
 };
-
-export const isDevelopmentVersion = (version: string) =>
-	/(\.|\+|-)dev/.test(version);
 
 // Merging two sets of pine options sensibly is more complicated than it sounds.
 //
@@ -251,26 +222,4 @@ const convertExpandToObject = <T extends {}>(
 	}
 
 	return cloneDeep(expandOption);
-};
-
-// In order not to introduce a breaking change, we export each element independently and all together as a default export.
-export default {
-	getOsUpdateHelper,
-	deviceTypes,
-	notImplemented,
-	onlyIf,
-	now,
-	dateToMoment,
-	timeSince,
-	isId,
-	LOCKED_STATUS_CODE,
-	isUnauthorizedResponse,
-	isNotFoundResponse,
-	isNoDeviceForKeyResponse,
-	isNoApplicationForKeyResponse,
-	isUniqueKeyViolationResponse,
-	treatAsMissingApplication,
-	treatAsMissingDevice,
-	isDevelopmentVersion,
-	mergePineOptions,
 };


### PR DESCRIPTION
This allows us to avoid loading:
* lodash/throttle
* memoizee
* moment
* balena-hup-action-utils

in all files that import from the util.ts
and also adds lazy loading when possible.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
