### PR TITLE
auth.isLoggedIn: Change to always confirm with the API

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import * as errors from 'balena-errors';
 import * as Promise from 'bluebird';
+import * as memoizee from 'memoizee';
 // TODO: change to type-only import when we bump TS to 3.8
 import _get2faModel from './2fa';
 import { InjectedDependenciesParam, InjectedOptionsParam } from './balena';
@@ -71,25 +72,26 @@ const getAuth = function (
 		email: string;
 	}
 
-	let userDetailsCache: WhoamiResult | null = null;
+	const userWhoami = () => {
+		return request
+			.send<WhoamiResult>({
+				method: 'GET',
+				url: '/user/v1/whoami',
+				baseUrl: apiUrl,
+			})
+			.then(({ body }) => body);
+	};
+
+	const memoizedUserWhoami = memoizee(userWhoami, {
+		primitive: true,
+		promise: true,
+	});
 
 	const getUserDetails = () =>
 		Promise.try(() => {
-			if (userDetailsCache) {
-				return userDetailsCache;
-			}
-			return request
-				.send<WhoamiResult>({
-					method: 'GET',
-					url: '/user/v1/whoami',
-					baseUrl: apiUrl,
-				})
-				.then(({ body }) => {
-					return (userDetailsCache = body);
-				})
-				.catch(function (err) {
-					throw normalizeAuthError(err);
-				});
+			return memoizedUserWhoami().catch(function (err) {
+				throw normalizeAuthError(err);
+			});
 		});
 
 	/**
@@ -206,7 +208,7 @@ const getAuth = function (
 		email: string;
 		password: string;
 	}): Promise<void> {
-		userDetailsCache = null;
+		memoizedUserWhoami.clear();
 		return authenticate(credentials).then(auth.setKey);
 	}
 
@@ -231,7 +233,7 @@ const getAuth = function (
 	 * });
 	 */
 	function loginWithToken(authToken: string): Promise<void> {
-		userDetailsCache = null;
+		memoizedUserWhoami.clear();
 		return auth.setKey(authToken);
 	}
 
@@ -372,7 +374,7 @@ const getAuth = function (
 	 * });
 	 */
 	function logout(): Promise<void> {
-		userDetailsCache = null;
+		memoizedUserWhoami.clear();
 		return auth.removeKey();
 	}
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -87,8 +87,11 @@ const getAuth = function (
 		promise: true,
 	});
 
-	const getUserDetails = () =>
+	const getUserDetails = (noCache = false) =>
 		Promise.try(() => {
+			if (noCache) {
+				memoizedUserWhoami.clear();
+			}
 			return memoizedUserWhoami().catch(function (err) {
 				throw normalizeAuthError(err);
 			});
@@ -268,7 +271,7 @@ const getAuth = function (
 	 * });
 	 */
 	function isLoggedIn(): Promise<boolean> {
-		return getUserDetails()
+		return getUserDetails(true)
 			.return(true)
 			.catchReturn(errors.BalenaNotLoggedIn, false);
 	}


### PR DESCRIPTION
We do need a way to check with the API's `/user/v1/whoami` endpoint for the cases like when the "logout other sessions" was used.

Based on the history it looks like the caching was adding so that the CLI doesn't do tons of separate requests for each action. B/c of the approach atm of caching only the result, the CLI atm does 2 requests even just for the `balena whoami` action, one of which is for event reporting and the other to confirm that the user is logged in.

In an effort to not increase the amount of requests that the CLI does, I didn't completely drop the caching but decided to only drop it in the `auth.isLoggedIn()` method. An alt choice was the `auth.whoami()`, but given the docs for the two methods:
> isLoggedIn: Check if you're logged in
> whoami: Return current logged in username

going with the `auth.isLoggedIn()` felt a bit more like a bugfix rather than a "big" change, which also doesn't affect the number of requests that the CLI is doing atm.

As an extra note, this is actually how the `auth.isLoggedIn()` worked on v7 (it always did an API request).
See: https://github.com/balena-io/balena-sdk/pull/449/commits/f1369f0ca3353d044c429efe0d021488480298d7?file-filters%5B%5D=.coffee&file-filters%5B%5D=.json&file-filters%5B%5D=.lock&file-filters%5B%5D=.ts#diff-f1ecd54135ef0d1ecf8300a80f5ac38aL191-L195

Resolves: #905
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
