### PR TITLE
Switch to generating es2015 as that is already the minimum we support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "preserveConstEnums": true,
         "strictNullChecks": true,
         "sourceMap": false,
-        "target": "es5",
+        "target": "es2015",
         "noUnusedParameters": true,
         "noUnusedLocals": true,
         "moduleResolution": "node",


### PR DESCRIPTION
Due to modules we depend on we're already generating es2015 bundles so
updating our target allows for generating smaller, more modern output

Change-type: minor

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
