### PR TITLE
Add interface property - device.last_vpn_event

### DIFF
--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -484,6 +484,7 @@ declare namespace BalenaSdk {
 		is_active: boolean;
 		is_online: boolean;
 		last_connectivity_event: string;
+		last_vpn_event: string;
 		latitude?: string;
 		local_id?: string;
 		location: string;


### PR DESCRIPTION
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output

I'm attempting to get the last vpn and connectivity events from the API.
Namely, I'm using https://www.balena.io/docs/reference/sdk/node-sdk/#devicegetalloptions-%E2%87%92-codepromisecode and doing: 

```typescript
const balena = initBalena({myDataDir});

export const getAndSetBalenaInformation = () => {
  balenaDevices.getAll()
  .then(devices => devices.forEach(device => {
    console.log("Last connectivity event:", device.last_connectivity_event),
    console.log("Last vpn event:", device.last_vpn_event)
  }))
};
```

On V13.6.0.

While I'm seeing `last_vpn_event` in the response, the typing doesn't seem to be there. This adds the property to the `device` interface, but I did not take a close look to see whether any additional changes are needed. Let me know if any are, and I will add them.