### PR TITLE
typings: Drop the app_name & has_dependent fields from the Device

### DIFF
--- a/typings/balena-sdk.d.ts
+++ b/typings/balena-sdk.d.ts
@@ -551,14 +551,13 @@ declare namespace BalenaSdk {
 	}
 
 	interface Device {
-		app_name: string;
+		id: number;
 		created_at: string;
 		custom_latitude?: string;
 		custom_longitude?: string;
 		device_name: string;
 		download_progress?: number;
 		has_dependent: boolean;
-		id: number;
 		ip_address: string | null;
 		is_accessible_by_support_until__date: string;
 		is_connected_to_vpn: boolean;


### PR DESCRIPTION
They are not part of the model and we primarily have them by accident, while we moved the typings from the dashboard.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
