### PR TITLE
Avoid $ExpectType b/c of issues with TS 3.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "superagent": "^3.8.3",
     "tmp": "^0.0.31",
     "ts-node": "^7.0.1",
+    "ts-toolbelt": "^6.9.9",
     "typescript": "^3.9.3",
     "uglify-es": "^3.3.9",
     "vinyl-buffer": "^1.0.1",

--- a/typing_tests/pine-options.ts
+++ b/typing_tests/pine-options.ts
@@ -2,6 +2,7 @@
 import * as BalenaSdk from '../typings/balena-sdk';
 import { InferAssociatedResourceType } from '../typings/pinejs-client-core';
 import { AnyObject } from '../typings/utils';
+import { Equals, EqualsTrue } from './utils';
 
 // This file is in .prettierignore, since otherwise
 // the $ExpectError comments would move to the wrong place
@@ -497,14 +498,36 @@ export const appOptionsEValid20: BalenaSdk.PineOptions<BalenaSdk.Application> = 
 
 // valid OptionalNavigationResource $selects & $expands
 
-// $ExpectType "is_created_by__user" | "belongs_to__application" | "contains__image" | "should_be_running_on__application" | "is_running_on__device" | "should_be_running_on__device" | "release_tag"
-export type ReleaseExpandableProps = BalenaSdk.PineExpandableProps<
+type ReleaseExpandablePropsExpectation =
+	| 'is_created_by__user'
+	| 'belongs_to__application'
+	| 'contains__image'
+	| 'should_be_running_on__application'
+	| 'is_running_on__device'
+	| 'should_be_running_on__device'
+	| 'release_tag';
+
+// $ExpectError
+export const releaseExpandablePropsFailingTest1: Equals<
+	BalenaSdk.PineExpandableProps<BalenaSdk.Release>,
+	Exclude<ReleaseExpandablePropsExpectation, 'release_tag'>
+> = EqualsTrue;
+
+// $ExpectError
+export const releaseExpandablePropsFailingTest2: Equals<
+	BalenaSdk.PineExpandableProps<BalenaSdk.Release>,
+	ReleaseExpandablePropsExpectation | 'id'
+> = EqualsTrue;
+
+export const releaseExpandablePropsTest: Equals<
+	BalenaSdk.PineExpandableProps<BalenaSdk.Release>,
+	ReleaseExpandablePropsExpectation
+> = EqualsTrue;
+
+export const deviceIsRunningReleaseAssociatedResourceType: Equals<
+	InferAssociatedResourceType<BalenaSdk.Device['is_running__release']>,
 	BalenaSdk.Release
->;
-// $ExpectType Release
-export type DeviceIsRunningReleaseAssociatedResourceType = InferAssociatedResourceType<
-	BalenaSdk.Device['is_running__release']
->;
+> = EqualsTrue;
 
 export const appOptionsEValid30: BalenaSdk.PineOptions<BalenaSdk.Application> = {
 	$expand: [

--- a/typing_tests/utils.ts
+++ b/typing_tests/utils.ts
@@ -1,0 +1,4 @@
+import { Any, Boolean } from 'ts-toolbelt';
+
+export type Equals<T, P> = Any.Equals<T, P>;
+export let EqualsTrue: Boolean.True;

--- a/typings/balena-sdk/models.d.ts
+++ b/typings/balena-sdk/models.d.ts
@@ -134,9 +134,7 @@ declare module './index' {
 		application_environment_variable: ReverseNavigationResource<
 			ApplicationVariable
 		>;
-		build_environment_variable: ReverseNavigationResource<
-			BuildVariable
-		>;
+		build_environment_variable: ReverseNavigationResource<BuildVariable>;
 		application_tag: ReverseNavigationResource<ApplicationTag>;
 		owns__device: ReverseNavigationResource<Device>;
 		owns__release: ReverseNavigationResource<Release>;


### PR DESCRIPTION
Dtslint's $ExpectType on TS 3.9.6 stopped expanding
PineExpandableProps<Release> to the exact
properties, which broke the tests. Stopped using
$ExpectType in favor of using ts-toolbelt's Equals
on a plain assignment. This also makes it easier to
completely drop dtslint in a future PR, in favor of
plain tsc using @ts-expect-error.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
