### PR TITLE
typings: Export pine variant w/ a mandatory $select on get requests

### DIFF
--- a/typings/balena-pine.d.ts
+++ b/typings/balena-pine.d.ts
@@ -14,3 +14,14 @@ export interface Pine {
 	): Bluebird<'OK'>;
 	upsert<T>(params: PineClient.UpsertParams<T>): Bluebird<T | 'OK'>;
 }
+
+export type PineWithSelectOnGet = Omit<Pine, 'get'> & {
+	get<T>(
+		params: PineClient.ParamsObjWithId<T> & PineClient.ParamsObjWithSelect<T>,
+	): Bluebird<T>;
+	get<T>(params: PineClient.ParamsObjWithSelect<T>): Bluebird<T[]>;
+	get<T, Result extends number>(
+		params: PineClient.ParamsObj<T>,
+	): Bluebird<Result>;
+	get<T, Result>(params: PineClient.ParamsObjWithSelect<T>): Bluebird<Result>;
+};

--- a/typings/balena-sdk/index.d.ts
+++ b/typings/balena-sdk/index.d.ts
@@ -45,6 +45,12 @@ declare namespace BalenaSdk {
 	type PineSelectableProps<T> = Pine.SelectableProps<T>;
 	type PineExpandableProps<T> = Pine.ExpandableProps<T>;
 
+	/**
+	 * A variant that helps you not forget addins a $select, helping to
+	 * create requests explecitely fetch only what your code needs.
+	 */
+	type PineWithSelectOnGet = BalenaPine.PineWithSelectOnGet;
+
 	interface Interceptor {
 		request?(response: any): Bluebird<any>;
 		response?(response: any): Bluebird<any>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -269,6 +269,10 @@ export interface ParamsObjWithId<T> extends ParamsObj<T> {
 	id: number;
 }
 
+export type ParamsObjWithSelect<T> = ParamsObj<T> & {
+	options: ODataOptionsWithSelect<T>;
+};
+
 export interface ParamsObjWithFilter<T> extends ParamsObj<T> {
 	options: ODataOptionsWithFilter<T>;
 }


### PR DESCRIPTION
This allows at least balena modules to opt-in type checking that enforces `$select`s, while not hurting the development & discoverability of properties for other consumers.

Change-type: minor
See: https://github.com/balena-io/balena-ui/pull/3829/files#r450310702
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
