### PR TITLE
Merge the DeviceWithImageInstalls with the Device type

### DIFF
--- a/lib/util/device-service-details.ts
+++ b/lib/util/device-service-details.ts
@@ -2,7 +2,6 @@ import type {
 	CurrentGatewayDownload,
 	CurrentService,
 	Device,
-	DeviceWithImageInstalls,
 	DeviceWithServiceDetails,
 	GatewayDownload,
 	Image,
@@ -14,7 +13,7 @@ import type {
 
 // Pine expand options necessary for getting raw service data for a device
 export const getCurrentServiceDetailsPineExpand = (expandRelease: boolean) => {
-	const pineExpand: PineExpand<DeviceWithImageInstalls> = {
+	const pineExpand: PineExpand<Device> = {
 		image_install: {
 			$select: ['id', 'download_progress', 'status', 'install_date'],
 			$filter: {
@@ -107,7 +106,7 @@ function getSingleInstallSummary(
 }
 
 export const generateCurrentServiceDetails = (
-	rawDevice: DeviceWithImageInstalls,
+	rawDevice: Device,
 ): DeviceWithServiceDetails => {
 	const installs = rawDevice.image_install!.map((ii) =>
 		getSingleInstallSummary(ii),
@@ -121,7 +120,7 @@ export const generateCurrentServiceDetails = (
 	delete rawDevice.image_install;
 	delete rawDevice.gateway_download;
 
-	const device = (rawDevice as Device) as DeviceWithServiceDetails;
+	const device = rawDevice as DeviceWithServiceDetails;
 
 	// Essentially a groupBy(installs, 'service_name')
 	// but try making it a bit faster for the sake of large fleets.

--- a/lib/util/device-service-details.ts
+++ b/lib/util/device-service-details.ts
@@ -87,22 +87,25 @@ function getSingleInstallSummary(
 		};
 	}
 
+	const result = {
+		...rawData,
+		service_id: service.id,
+		// add this extra property to make grouping the services easier
+		service_name: service.service_name,
+		image_id: image.id,
+		...releaseInfo,
+	};
+
 	// prefer over omit for performance reasons
-	delete rawData.image;
-	if ('is_provided_by__release' in rawData) {
-		delete rawData.is_provided_by__release;
+	delete result.image;
+	if ('installs__image' in result) {
+		delete result.installs__image;
+	}
+	if ('is_provided_by__release' in result) {
+		delete result.is_provided_by__release;
 	}
 
-	return Object.assign(
-		rawData,
-		{
-			service_id: service.id,
-			// add this extra property to make grouping the services easier
-			service_name: service.service_name,
-			image_id: image.id,
-		},
-		releaseInfo,
-	);
+	return result;
 }
 
 export const generateCurrentServiceDetails = (
@@ -115,12 +118,6 @@ export const generateCurrentServiceDetails = (
 	const downloads = rawDevice.gateway_download!.map((gd) =>
 		getSingleInstallSummary(gd),
 	);
-
-	// prefer over omit for performance reasons
-	delete rawDevice.image_install;
-	delete rawDevice.gateway_download;
-
-	const device = rawDevice as DeviceWithServiceDetails;
 
 	// Essentially a groupBy(installs, 'service_name')
 	// but try making it a bit faster for the sake of large fleets.
@@ -153,6 +150,7 @@ export const generateCurrentServiceDetails = (
 		}
 	}
 
+	const device = rawDevice as DeviceWithServiceDetails;
 	device.current_services = currentServicesGroupedByName;
 	device.current_gateway_downloads = downloads;
 	return device;

--- a/tests/integration/models/application.spec.js
+++ b/tests/integration/models/application.spec.js
@@ -1288,18 +1288,61 @@ describe('Application Model', function () {
 			}
 
 			expect(application.owns__device).to.have.lengthOf(1);
-			m.chai
-				.expect(application.owns__device[0])
-				.to.deep.match(deviceExpectation);
+			const [deviceDetails] = application.owns__device;
+			m.chai.expect(deviceDetails).to.deep.match(deviceExpectation);
 
+			// Should include the Device model properties
+			m.chai.expect(deviceDetails.image_install).to.have.lengthOf(3);
+
+			deviceDetails.image_install.forEach((imageInstall) => {
+				m.chai
+					.expect(imageInstall)
+					.to.have.property('id')
+					.that.is.oneOf([
+						this.oldWebInstall.id,
+						this.newWebInstall.id,
+						this.newDbInstall.id,
+					]);
+				m.chai
+					.expect(imageInstall)
+					.to.have.property('download_progress')
+					.that.is.oneOf([50, null]);
+				m.chai
+					.expect(imageInstall)
+					.to.have.property('image')
+					.that.has.length(1);
+				if (expectCommit) {
+					m.chai
+						.expect(imageInstall)
+						.to.have.property('is_provided_by__release')
+						.that.has.length(1);
+				} else {
+					m.chai
+						.expect(imageInstall)
+						.to.not.have.property('is_provided_by__release');
+				}
+				m.chai
+					.expect(imageInstall)
+					.to.have.property('install_date')
+					.that.is.a('string');
+				m.chai
+					.expect(imageInstall)
+					.to.have.property('status')
+					.that.is.a('string');
+				m.chai.expect(imageInstall).to.not.have.property('service_id');
+				m.chai.expect(imageInstall).to.not.have.property('image_id');
+				m.chai.expect(imageInstall).to.not.have.property('commit');
+			});
+
+			m.chai.expect(deviceDetails.gateway_download).to.have.lengthOf(0);
+
+			// Augmented properties
 			// Should filter out deleted image installs
-			m.chai
-				.expect(application.owns__device[0].current_services.db)
-				.to.have.lengthOf(1);
+			m.chai.expect(deviceDetails.current_services.db).to.have.lengthOf(1);
 
 			// Should have an empty list of gateway downloads
-			return m.chai
-				.expect(application.owns__device[0].current_gateway_downloads)
+			m.chai
+				.expect(deviceDetails.current_gateway_downloads)
 				.to.have.lengthOf(0);
 		};
 

--- a/tests/integration/models/device.spec.js
+++ b/tests/integration/models/device.spec.js
@@ -2160,13 +2160,55 @@ describe('Device Model', function () {
 								},
 							});
 
+							// Should include the Device model properties
+							m.chai.expect(deviceDetails.image_install).to.have.lengthOf(3);
+
+							// Just to make TS happy, since we already checked its length.
+							const imageInstalls = deviceDetails.image_install ?? [];
+							imageInstalls.forEach((imageInstall) => {
+								m.chai
+									.expect(imageInstall)
+									.to.have.property('id')
+									.that.is.oneOf([
+										this.oldWebInstall.id,
+										this.newWebInstall.id,
+										this.newDbInstall.id,
+									]);
+								m.chai
+									.expect(imageInstall)
+									.to.have.property('download_progress')
+									.that.is.oneOf([50, null]);
+								m.chai
+									.expect(imageInstall)
+									.to.have.property('image')
+									.that.has.length(1);
+								m.chai
+									.expect(imageInstall)
+									.to.have.property('is_provided_by__release')
+									.that.has.length(1);
+								m.chai
+									.expect(imageInstall)
+									.to.have.property('install_date')
+									.that.is.a('string');
+								m.chai
+									.expect(imageInstall)
+									.to.have.property('status')
+									.that.is.a('string');
+								m.chai.expect(imageInstall).to.not.have.property('service_id');
+								m.chai.expect(imageInstall).to.not.have.property('image_id');
+								m.chai.expect(imageInstall).to.not.have.property('commit');
+							});
+
+							m.chai.expect(deviceDetails.gateway_download).to.have.lengthOf(0);
+
+							// Augmented properties
 							// Should filter out deleted image installs
 							m.chai
 								.expect(deviceDetails.current_services.db)
 								.to.have.lengthOf(1);
 
 							// Should have an empty list of gateway downloads
-							return m.chai
+							m.chai
 								.expect(deviceDetails.current_gateway_downloads)
 								.to.have.lengthOf(0);
 						});

--- a/typings/balena-sdk/models.d.ts
+++ b/typings/balena-sdk/models.d.ts
@@ -416,6 +416,7 @@ declare module './index' {
 		status: string;
 
 		image: NavigationResource<Image>;
+		is_downloaded_by__device: NavigationResource<Device>;
 	}
 
 	export interface ServiceInstall {

--- a/typings/balena-sdk/models.d.ts
+++ b/typings/balena-sdk/models.d.ts
@@ -307,6 +307,8 @@ declare module './index' {
 		device_tag: ReverseNavigationResource<DeviceTag>;
 		manages__device: ReverseNavigationResource<Device>;
 		service_install: ReverseNavigationResource<ServiceInstall>;
+		image_install?: ReverseNavigationResource<ImageInstall>;
+		gateway_download?: ReverseNavigationResource<GatewayDownload>;
 	}
 
 	/** device_type */
@@ -331,10 +333,9 @@ declare module './index' {
 		has_private_access_to__device_type: NavigationResource<DeviceType>;
 	}
 
-	export interface DeviceWithImageInstalls extends Device {
-		image_install: ReverseNavigationResource<ImageInstall>;
-		gateway_download: ReverseNavigationResource<GatewayDownload>;
-	}
+	/** @deprecated Use the Device type directly */
+	export type DeviceWithImageInstalls = Device &
+		Required<Pick<Device, 'image_install' | 'gateway_download'>>;
 
 	export interface SupervisorRelease {
 		created_at: string;


### PR DESCRIPTION
In order to properly match the return type of the `...WithServiceDetails` method (which are meant to provide an easier to consume result) we were so far using a separate type.
This preserves all core model properties on the Device and only augments it with with the easier to consume ones.
This way we can stop having some explicit casting, when trying to assign the result of a `...WithServiceDetails` method to a plain Device variable.

Connects-to: #923
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
