### PR TITLE
typings: Fix the PineWithSelect & related type helpers

### DIFF
--- a/typings/balena-request.d.ts
+++ b/typings/balena-request.d.ts
@@ -1,5 +1,4 @@
 import type { Readable } from 'stream';
-import type { Omit } from './utils';
 
 interface BalenaRequestOptions {
 	method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -239,10 +239,11 @@ export interface ODataOptions<T> {
 	$skip?: number;
 }
 
-export type ODataOptionsWithSelect<T> = Omit<ODataOptions<T>, '$expand'> &
-	Required<Pick<ODataOptions<T>, '$select'>> & {
-		$expand?: ExpandWithSelect<T>;
-	};
+export interface ODataOptionsWithSelect<T>
+	extends Omit<ODataOptions<T>, '$select' | '$expand'> {
+	$select: ODataOptions<T>['$select'];
+	$expand?: ExpandWithSelect<T>;
+}
 
 export type ODataOptionsWithFilter<T> = ODataOptions<T> &
 	Required<Pick<ODataOptions<T>, '$filter'>>;
@@ -269,7 +270,7 @@ export interface ParamsObjWithId<T> extends ParamsObj<T> {
 	id: number;
 }
 
-export type ParamsObjWithSelect<T> = ParamsObj<T> & {
+export type ParamsObjWithSelect<T> = Omit<ParamsObj<T>, 'options'> & {
 	options: ODataOptionsWithSelect<T>;
 };
 

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -1,4 +1,4 @@
-import type { AnyObject, Omit, PropsOfType, StringKeyof } from './utils';
+import type { AnyObject, PropsOfType, StringKeyof } from './utils';
 
 export interface WithId {
 	id: number;

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -9,8 +9,6 @@ export type PropsOfType<T, P> = {
 // backwards compatible alternative for: Extract<keyof T, string>
 export type StringKeyof<T> = keyof T & string;
 
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
 export interface Dictionary<T> {
 	[key: string]: T;
 }


### PR DESCRIPTION
Fixes a bug that I spotted at
See: https://github.com/balena-io/balena-ui/pull/3907

where the typings do not complain.

Also drops the custom Omit in favor of the built in one.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
