### PR TITLE
Update balena-pine and add custom typings for prepare/subscribe

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -310,9 +310,11 @@ export const getSdk = function ($opts?: BalenaSdk.SdkOptions) {
 	 *
 	 * @example
 	 * balena.pine.get({
-	 * 	resource: 'release/$count',
+	 * 	resource: 'release',
 	 * 	options: {
-	 * 		$filter: { belongs_to__application: applicationId }
+	 * 		$count: {
+	 * 			$filter: { belongs_to__application: applicationId }
+	 * 		}
 	 * 	}
 	 * });
 	 */

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "superagent": "^3.8.3",
     "tmp": "^0.0.31",
     "ts-node": "^7.0.1",
-    "ts-toolbelt": "^6.13.33",
+    "ts-toolbelt": "^6.15.4",
     "typescript": "^3.9.7",
     "uglify-es": "^3.3.9",
     "vinyl-buffer": "^1.0.1",
@@ -93,14 +93,14 @@
   },
   "dependencies": {
     "@balena/es-version": "^1.0.0",
-    "@types/lodash": "^4.14.158",
+    "@types/lodash": "^4.14.159",
     "@types/memoizee": "^0.4.3",
     "@types/node": "^10.17.28",
     "abortcontroller-polyfill": "^1.5.0",
     "balena-auth": "^4.0.2",
     "balena-errors": "^4.4.0",
     "balena-hup-action-utils": "~4.0.2",
-    "balena-pine": "^12.2.0",
+    "balena-pine": "^12.3.0",
     "balena-register-device": "^7.1.0",
     "balena-request": "^11.1.0",
     "balena-semver": "^2.3.0",
@@ -110,6 +110,6 @@
     "moment": "~2.24.0 || ^2.25.1",
     "ndjson": "^1.5.0",
     "semver": "^7.3.2",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.1"
   }
 }

--- a/tests/util_ts.ts
+++ b/tests/util_ts.ts
@@ -1,5 +1,4 @@
 import * as m from 'mochainon';
-import type { AnyObject } from '../typings/utils';
 import { balena } from './integration/setup';
 import type * as BalenaSdk from '..';
 const { expect } = m.chai;
@@ -17,7 +16,7 @@ export const describeExpandAssertions = async <T>(
 		Object.keys(expand).forEach((key) => {
 			describe(`to ${key}`, function () {
 				it('should succeed and include the expanded property', async function () {
-					const [result] = await balena.pine.get<AnyObject>({
+					const [result] = await balena.pine.get({
 						...params,
 						options: {
 							...params.options,
@@ -25,7 +24,7 @@ export const describeExpandAssertions = async <T>(
 								[key]: expand[key],
 							},
 						},
-					});
+					} as typeof params);
 					if (result) {
 						expect(result).to.have.property(key).that.is.an('array');
 					}

--- a/typings/balena-pine.d.ts
+++ b/typings/balena-pine.d.ts
@@ -1,30 +1,8 @@
 import type * as PineClient from './pinejs-client-core';
 
-export interface Pine {
-	delete<T>(
-		params: PineClient.ParamsObjWithId<T> | PineClient.ParamsObjWithFilter<T>,
-	): Promise<'OK'>;
-	get<T>(params: PineClient.ParamsObjWithId<T>): Promise<T | undefined>;
-	get<T>(params: PineClient.ParamsObj<T>): Promise<T[]>;
-	get<T, Result>(params: PineClient.ParamsObj<T>): Promise<Result>;
-	post<T>(params: PineClient.ParamsObj<T>): Promise<T & { id: number }>;
-	patch<T>(
-		params: PineClient.ParamsObjWithId<T> | PineClient.ParamsObjWithFilter<T>,
-	): Promise<'OK'>;
-	upsert<T>(params: PineClient.UpsertParams<T>): Promise<T | 'OK'>;
-}
-
+export type Pine = PineClient.Pine;
 /**
  * A variant that helps you not forget addins a $select, helping to
  * create requests explecitely fetch only what your code needs.
  */
-export type PineWithSelectOnGet = Omit<Pine, 'get'> & {
-	get<T>(
-		params: PineClient.ParamsObjWithId<T> & PineClient.ParamsObjWithSelect<T>,
-	): Promise<T | undefined>;
-	get<T>(params: PineClient.ParamsObjWithSelect<T>): Promise<T[]>;
-	get<T, Result extends number>(
-		params: PineClient.ParamsObj<T>,
-	): Promise<Result>;
-	get<T, Result>(params: PineClient.ParamsObjWithSelect<T>): Promise<Result>;
-};
+export type PineWithSelectOnGet = PineClient.PineWithSelectOnGet;


### PR DESCRIPTION
Update balena-pine from 12.2.0 to 12.3.0

Change-type: minor

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
