### PR TITLE
Improve $orderby typing to allow `[{a: 'desc'}, {b: 'asc'}]`

### DIFF
--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -70,7 +70,7 @@ interface Lambda<T> {
 }
 
 type OrderByValues = 'asc' | 'desc';
-type OrderBy = string | string[] | { [index: string]: OrderByValues };
+type OrderBy = string | OrderBy[] | { [index: string]: OrderByValues };
 
 type AssociatedResourceFilter<T> = T extends NonNullable<
 	ReverseNavigationResource


### PR DESCRIPTION
Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
