### PR TITLE
Add missing balena-request typings for the refreshToken method

### DIFF
--- a/typings/balena-request.d.ts
+++ b/typings/balena-request.d.ts
@@ -38,4 +38,5 @@ interface BalenaRequest {
 	send: BalenaRequestSend;
 	stream: (options: BalenaRequestOptions) => Promise<BalenaRequestStreamResult>;
 	interceptors: Interceptor[];
+	refreshToken(options: { baseUrl: string }): Promise<string>;
 }


### PR DESCRIPTION
Even though balena-request v12 will start generating its own typings.

Change-type: patch
See: https://github.com/balena-io-modules/balena-request/pull/151
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
