### PR TITLE
tests/device: Use mocha.parallel for read-only test cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "karma-env-preprocessor": "^0.1.1",
     "lint-staged": "^10.1.6",
     "mocha": "^3.5.3",
+    "mocha.parallel": "^0.15.6",
     "mochainon": "^2.0.0",
     "require-npm4-to-publish": "^1.0.0",
     "rimraf": "^3.0.2",

--- a/tests/integration/models/api-key.spec.ts
+++ b/tests/integration/models/api-key.spec.ts
@@ -1,35 +1,40 @@
 // tslint:disable-next-line:import-blacklist
 import * as _ from 'lodash';
 import * as m from 'mochainon';
+import * as parallel from 'mocha.parallel';
 import { balena, givenLoggedInUser } from '../setup';
 const { expect } = m.chai;
 
 describe('API Key model', function () {
 	describe('balena.models.apiKey.create()', function () {
-		givenLoggedInUser(beforeEach);
+		givenLoggedInUser(before);
 
-		it('should be able to create a new api key', () =>
-			balena.models.apiKey
-				.create('apiKey')
-				.then((key) => expect(key).to.be.a('string')));
+		parallel('', function () {
+			it('should be able to create a new api key', function () {
+				balena.models.apiKey
+					.create('apiKey')
+					.then((key) => expect(key).to.be.a('string'));
+			});
 
-		it('should be able to create a new api key with description', () =>
-			balena.models.apiKey
-				.create('apiKey', 'apiKeyDescription')
-				.then(function (key) {
-					expect(key).to.be.a('string');
-					return balena.models.apiKey.getAll();
-				})
-				.then(function (apiKeys) {
-					expect(apiKeys).to.be.an('array');
-					expect(apiKeys).to.have.lengthOf(1);
-					expect(apiKeys).to.deep.match([
-						{
-							name: 'apiKey',
-							description: 'apiKeyDescription',
-						},
-					]);
-				}));
+			it('should be able to create a new api key with description', function () {
+				balena.models.apiKey
+					.create('apiKey2', 'apiKeyDescription')
+					.then(function (key) {
+						expect(key).to.be.a('string');
+						return balena.models.apiKey.getAll();
+					})
+					.then(function (apiKeys) {
+						expect(apiKeys).to.be.an('array');
+						expect(apiKeys).to.have.lengthOf(1);
+						expect(apiKeys).to.deep.match([
+							{
+								name: 'apiKey2',
+								description: 'apiKeyDescription',
+							},
+						]);
+					});
+			});
+		});
 	});
 
 	describe('balena.models.apiKey.getAll()', function () {

--- a/tests/integration/models/config.spec.ts
+++ b/tests/integration/models/config.spec.ts
@@ -1,6 +1,7 @@
 // tslint:disable-next-line:import-blacklist
 import * as _ from 'lodash';
 import * as m from 'mochainon';
+import * as parallel from 'mocha.parallel';
 import { balena } from '../setup';
 import type * as BalenaSdk from '../../..';
 const { expect } = m.chai;
@@ -71,28 +72,30 @@ describe('Config Model', function () {
 	});
 
 	describe('balena.models.config.getAll()', function () {
-		it('should return all the configuration', () =>
-			balena.models.config.getAll().then(function (config) {
-				expect(_.isPlainObject(config)).to.be.true;
-				expect(_.isEmpty(config)).to.be.false;
-			}));
+		parallel('', function () {
+			it('should return all the configuration', () =>
+				balena.models.config.getAll().then(function (config) {
+					expect(_.isPlainObject(config)).to.be.true;
+					expect(_.isEmpty(config)).to.be.false;
+				}));
 
-		it('should include the pubnub keys', () =>
-			balena.models.config.getAll().then(function ({ pubnub }) {
-				expect(pubnub.publish_key).to.be.a('string').that.has.length(0);
-				expect(pubnub.subscribe_key).to.be.a('string').that.has.length(0);
-			}));
+			it('should include the pubnub keys', () =>
+				balena.models.config.getAll().then(function ({ pubnub }) {
+					expect(pubnub.publish_key).to.be.a('string').that.has.length(0);
+					expect(pubnub.subscribe_key).to.be.a('string').that.has.length(0);
+				}));
 
-		it('should include the mixpanel token', () =>
-			balena.models.config.getAll().then(function ({ mixpanelToken }) {
-				expect(mixpanelToken).to.be.a('string');
-				expect(mixpanelToken).to.equal('balena-main');
-			}));
+			it('should include the mixpanel token', () =>
+				balena.models.config.getAll().then(function ({ mixpanelToken }) {
+					expect(mixpanelToken).to.be.a('string');
+					expect(mixpanelToken).to.equal('balena-main');
+				}));
 
-		it('should include the deviceTypes', () =>
-			balena.models.config
-				.getAll()
-				.then(({ deviceTypes }) => expectDeviceTypeArray(deviceTypes)));
+			it('should include the deviceTypes', () =>
+				balena.models.config
+					.getAll()
+					.then(({ deviceTypes }) => expectDeviceTypeArray(deviceTypes)));
+		});
 
 		describe('device type normalization', function () {
 			before(function () {
@@ -123,7 +126,7 @@ describe('Config Model', function () {
 		});
 	});
 
-	describe('balena.models.config.getDeviceOptions()', function () {
+	parallel('balena.models.config.getDeviceOptions()', function () {
 		it('should become the device options', () =>
 			balena.models.config
 				.getDeviceOptions('raspberry-pi')

--- a/tests/integration/models/hostapp.spec.ts
+++ b/tests/integration/models/hostapp.spec.ts
@@ -1,6 +1,7 @@
 // tslint:disable-next-line:import-blacklist
 import * as _ from 'lodash';
 import * as m from 'mochainon';
+import * as parallel from 'mocha.parallel';
 import { balena } from '../setup';
 import type * as BalenaSdk from '../../..';
 const { expect } = m.chai;
@@ -14,7 +15,7 @@ const containsVersion = (
 };
 
 describe('Hostapp model', function () {
-	describe('balena.models.hostapp.getAllOsVersions()', function () {
+	parallel('balena.models.hostapp.getAllOsVersions()', function () {
 		it("should contain both balenaOS and balenaOS ESR OS types'", async () => {
 			const res = await balena.models.hostapp.getAllOsVersions([
 				'fincm3',

--- a/tests/integration/models/keys.spec.ts
+++ b/tests/integration/models/keys.spec.ts
@@ -1,47 +1,50 @@
 // tslint:disable-next-line:import-blacklist
 import * as _ from 'lodash';
 import * as m from 'mochainon';
+import * as parallel from 'mocha.parallel';
 import PUBLIC_KEY from '../../data/public-key';
 import { balena, givenLoggedInUser } from '../setup';
 import type * as BalenaSdk from '../../..';
 const { expect } = m.chai;
 
 describe('Key Model', function () {
-	givenLoggedInUser(beforeEach);
-
 	describe('given no keys', function () {
 		describe('balena.models.key.getAll()', function () {
-			it('should become an empty array', function () {
-				const promise = balena.models.key.getAll();
-				return expect(promise).to.become([]);
-			});
+			givenLoggedInUser(before);
 
-			it('should support arbitrary pinejs options', () =>
-				balena.models.key
-					.create('MyKey', PUBLIC_KEY)
-					.then(() => balena.models.key.getAll({ $select: ['public_key'] }))
-					.then(function (keys) {
-						const key = keys[0];
-						expect(key.public_key).to.equal(PUBLIC_KEY);
-						expect(key.title).to.be.undefined;
-					}));
+			parallel('', function () {
+				it('should become an empty array', function () {
+					const promise = balena.models.key.getAll();
+					return expect(promise).to.become([]);
+				});
 
-			it('should support a callback with no options', function (done) {
-				(balena.models.key.getAll as (...args: any[]) => any)(function (
-					_err: Error,
-					keys: BalenaSdk.SSHKey[],
-				) {
-					try {
-						expect(keys).to.deep.equal([]);
-						done();
-					} catch (err) {
-						done(err);
-					}
+				it('should support arbitrary pinejs options', () =>
+					balena.models.key
+						.create('MyKey', PUBLIC_KEY)
+						.then(() => balena.models.key.getAll({ $select: ['public_key'] }))
+						.then(function (keys) {
+							const key = keys[0];
+							expect(key.public_key).to.equal(PUBLIC_KEY);
+							expect(key.title).to.be.undefined;
+						}));
+
+				it('should support a callback with no options', function (done) {
+					(balena
+						.models.key.getAll as (...args: any[]) => any)(function (_err: Error, keys: BalenaSdk.SSHKey[]) {
+						try {
+							expect(keys).to.deep.equal([]);
+							done();
+						} catch (err) {
+							done(err);
+						}
+					});
 				});
 			});
 		});
 
 		describe('balena.models.key.create()', function () {
+			givenLoggedInUser(beforeEach);
+
 			it('should be able to create a key', function () {
 				const key = PUBLIC_KEY;
 				return balena.models.key
@@ -57,26 +60,30 @@ describe('Key Model', function () {
 			it('should be able to create a key from a non trimmed string', function () {
 				const key = PUBLIC_KEY;
 				return balena.models.key
-					.create('MyKey', `    ${key}    `)
+					.create('MyOtherKey', `    ${key}    `)
 					.then(() => balena.models.key.getAll())
 					.then(function (keys) {
 						expect(keys).to.have.length(1);
 						expect(keys[0].public_key).to.equal(key.replace(/\n/g, ''));
-						expect(keys[0].title).to.equal('MyKey');
+						expect(keys[0].title).to.equal('MyOtherKey');
 					});
 			});
 		});
 	});
 
 	describe('given a single key', function () {
-		beforeEach(function () {
+		givenLoggedInUser(before);
+
+		let ctx: Mocha.Context;
+		before(function () {
+			ctx = this;
 			const publicKey = PUBLIC_KEY;
 			return balena.models.key.create('MyKey', publicKey).then((key) => {
 				return (this.key = key);
 			});
 		});
 
-		describe('balena.models.key.getAll()', () =>
+		describe('balena.models.key.getAll()', () => {
 			it('should become the list of keys', function () {
 				return balena.models.key.getAll().then((keys) => {
 					expect(keys).to.have.length(1);
@@ -85,13 +92,14 @@ describe('Key Model', function () {
 					);
 					expect(keys[0].title).to.equal('MyKey');
 				});
-			}));
+			});
+		});
 
-		describe('balena.models.key.get()', function () {
+		parallel('balena.models.key.get()', function () {
 			it('should be able to get a key', function () {
-				return balena.models.key.get(this.key.id).then((key) => {
+				return balena.models.key.get(ctx.key.id).then((key) => {
 					expect(key.public_key).to.equal(
-						this.key.public_key.replace(/\n/g, ''),
+						ctx.key.public_key.replace(/\n/g, ''),
 					);
 					expect(key.title).to.equal('MyKey');
 				});
@@ -103,12 +111,13 @@ describe('Key Model', function () {
 			});
 		});
 
-		describe('balena.models.key.remove()', () =>
+		describe('balena.models.key.remove()', () => {
 			it('should be able to remove the key', function () {
 				return balena.models.key.remove(this.key.id).then(function () {
 					const promise = balena.models.key.getAll();
 					return expect(promise).to.eventually.have.length(0);
 				});
-			}));
+			});
+		});
 	});
 });

--- a/tests/integration/models/organization-membership.spec.ts
+++ b/tests/integration/models/organization-membership.spec.ts
@@ -1,5 +1,6 @@
 // tslint:disable-next-line:import-blacklist
 import * as m from 'mochainon';
+import * as parallel from 'mocha.parallel';
 import { balena, givenInitialOrganization, givenLoggedInUser } from '../setup';
 import type * as BalenaSdk from '../../..';
 const { expect } = m.chai;
@@ -14,7 +15,9 @@ describe('Organization Membership Model', function () {
 	givenLoggedInUser(before);
 	givenInitialOrganization(before);
 
+	let ctx: Mocha.Context;
 	before(async function () {
+		ctx = this;
 		this.userId = await balena.auth.getUserId();
 		this.orgAdminRole = await balena.pine.get({
 			resource: 'organization_membership_role',
@@ -25,15 +28,15 @@ describe('Organization Membership Model', function () {
 		expect(this.orgAdminRole).to.have.property('id').that.is.a('number');
 	});
 
-	describe('balena.models.organization.membership.getAll()', function () {
+	parallel('balena.models.organization.membership.getAll()', function () {
 		it(`shoud return only the user's own membership [Promise]`, async function () {
 			const memberships = await balena.models.organization.membership.getAll();
 
 			assertDeepMatchAndLength(memberships, [
 				{
-					user: { __id: this.userId },
-					is_member_of__organization: { __id: this.initialOrg.id },
-					organization_membership_role: { __id: this.orgAdminRole.id },
+					user: { __id: ctx.userId },
+					is_member_of__organization: { __id: ctx.initialOrg.id },
+					organization_membership_role: { __id: ctx.orgAdminRole.id },
 				},
 			]);
 		});
@@ -45,9 +48,9 @@ describe('Organization Membership Model', function () {
 					try {
 						assertDeepMatchAndLength(memberships, [
 							{
-								user: { __id: this.userId },
-								is_member_of__organization: { __id: this.initialOrg.id },
-								organization_membership_role: { __id: this.orgAdminRole.id },
+								user: { __id: ctx.userId },
+								is_member_of__organization: { __id: ctx.initialOrg.id },
+								organization_membership_role: { __id: ctx.orgAdminRole.id },
 							},
 						]);
 						done();
@@ -121,11 +124,13 @@ describe('Organization Membership Model', function () {
 
 			itShouldSetGetAndRemoveTags(orgMembershipTagTestOptions);
 
-			describe('balena.models.organization.membership.tags.getAllByOrganization()', () =>
-				itShouldGetAllTagsByResource(orgTagTestOptions));
+			describe('balena.models.organization.membership.tags.getAllByOrganization()', function () {
+				itShouldGetAllTagsByResource(orgTagTestOptions);
+			});
 
-			describe('balena.models.organization.membership.tags.getAllByOrganizationMembership()', () =>
-				itShouldGetAllTagsByResource(orgMembershipTagTestOptions));
+			describe('balena.models.organization.membership.tags.getAllByOrganizationMembership()', function () {
+				itShouldGetAllTagsByResource(orgMembershipTagTestOptions);
+			});
 		});
 	});
 });

--- a/tests/integration/models/organization.spec.ts
+++ b/tests/integration/models/organization.spec.ts
@@ -1,6 +1,7 @@
 // tslint:disable-next-line:import-blacklist
 import * as _ from 'lodash';
 import * as m from 'mochainon';
+import * as parallel from 'mocha.parallel';
 import { balena, credentials, givenLoggedInUser } from '../setup';
 const { expect } = m.chai;
 
@@ -26,7 +27,7 @@ describe('Organization model', function () {
 			});
 		});
 
-		describe('balena.models.organization.get()', function () {
+		parallel('balena.models.organization.get()', function () {
 			it('should be rejected if the organization handle does not exist', function () {
 				const randomTestOrgHandle = `testOrgRandom_${Date.now()}`;
 				const promise = balena.models.organization.get(randomTestOrgHandle);
@@ -55,7 +56,7 @@ describe('Organization model', function () {
 			});
 		});
 
-		describe('balena.models.organization.remove()', function () {
+		parallel('balena.models.organization.remove()', function () {
 			it('should be rejected if the organization handle does not exist', function () {
 				const randomTestOrgHandle = `testOrgRandom_${Date.now()}`;
 				const promise = balena.models.organization.get(randomTestOrgHandle);
@@ -111,7 +112,7 @@ describe('Organization model', function () {
 			});
 		});
 
-		describe('balena.models.organization.get()', function () {
+		parallel('balena.models.organization.get()', function () {
 			['id', 'handle'].forEach((prop) => {
 				it(`should retrieve an organization by ${prop}`, async function () {
 					const orgs = await balena.models.organization.get(ctx.newOrg1[prop]);
@@ -120,7 +121,7 @@ describe('Organization model', function () {
 			});
 		});
 
-		describe('balena.models.organization.remove()', function () {
+		parallel('balena.models.organization.remove()', function () {
 			[
 				{ prop: 'id', getOrg: () => ctx.newOrg1 },
 				{ prop: 'handle', getOrg: () => ctx.newOrg2 },

--- a/tests/integration/models/os.spec.ts
+++ b/tests/integration/models/os.spec.ts
@@ -2,6 +2,7 @@ import * as bSemver from 'balena-semver';
 // tslint:disable-next-line:import-blacklist
 import * as _ from 'lodash';
 import * as m from 'mochainon';
+import * as parallel from 'mocha.parallel';
 import {
 	balena,
 	credentials,
@@ -196,7 +197,7 @@ describe('OS model', function () {
 	});
 
 	describe('balena.models.os.getSupportedVersions()', function () {
-		describe('given a valid device slug', function () {
+		parallel('given a valid device slug', function () {
 			const expectSorted = (
 				array: string[],
 				comparator: <T extends string | null | undefined>(a: T, b: T) => number, // re-sorting could fail when the system is not using a stable
@@ -293,7 +294,7 @@ describe('OS model', function () {
 	});
 
 	describe('balena.models.os.getDownloadSize()', function () {
-		describe('given a valid device slug', function () {
+		parallel('given a valid device slug', function () {
 			it('should eventually be a valid number', function () {
 				const promise = balena.models.os.getDownloadSize('raspberry-pi');
 				return expect(promise).to.eventually.be.a('number');
@@ -305,7 +306,7 @@ describe('OS model', function () {
 			});
 		});
 
-		describe('given a specific OS version', function () {
+		parallel('given a specific OS version', function () {
 			it('should get a result for ResinOS v1', function () {
 				const promise = balena.models.os.getDownloadSize(
 					'raspberry-pi',
@@ -371,7 +372,7 @@ describe('OS model', function () {
 	});
 
 	describe('balena.models.os.getLastModified()', function () {
-		describe('given a valid device slug', function () {
+		parallel('given a valid device slug', function () {
 			it('should eventually be a valid Date instance', function () {
 				const promise = balena.models.os.getLastModified('raspberry-pi');
 				return expect(promise).to.eventually.be.an.instanceof(Date);
@@ -547,12 +548,17 @@ describe('OS model', function () {
 		givenLoggedInUser(before);
 		givenAnApplication(before);
 
-		describe('balena.models.os.getConfig()', function () {
+		let ctx: Mocha.Context;
+		before(function () {
+			ctx = this;
+		});
+
+		parallel('balena.models.os.getConfig()', function () {
 			const DEFAULT_OS_VERSION = '2.12.7+rev1.prod';
 
 			it('should fail if no version option is provided', function () {
 				return expect(
-					(balena.models.os.getConfig as any)(this.application.id),
+					(balena.models.os.getConfig as any)(ctx.application.id),
 				).to.be.rejectedWith(
 					'An OS version is required when calling os.getConfig',
 				);
@@ -560,7 +566,7 @@ describe('OS model', function () {
 
 			['id', 'app_name', 'slug'].forEach((prop) => {
 				it(`should be able to get an application config by ${prop}`, function () {
-					const promise = balena.models.os.getConfig(this.application[prop], {
+					const promise = balena.models.os.getConfig(ctx.application[prop], {
 						version: DEFAULT_OS_VERSION,
 					});
 					return Promise.all([
@@ -577,7 +583,7 @@ describe('OS model', function () {
 			});
 
 			it('should be rejected if the version is invalid', function () {
-				const promise = balena.models.os.getConfig(this.application.id, {
+				const promise = balena.models.os.getConfig(ctx.application.id, {
 					version: 'v1+foo',
 				});
 				return expect(promise).to.be.rejected.then((error) => {
@@ -591,7 +597,7 @@ describe('OS model', function () {
 			});
 
 			it('should be rejected if the version is <= 1.2.0', function () {
-				const promise = balena.models.os.getConfig(this.application.id, {
+				const promise = balena.models.os.getConfig(ctx.application.id, {
 					version: '1.2.0',
 				});
 				return expect(promise).to.be.rejected.then((error) => {
@@ -616,7 +622,7 @@ describe('OS model', function () {
 					version: '1.26.1',
 				};
 				return balena.models.os
-					.getConfig(this.application.id, configOptions)
+					.getConfig(ctx.application.id, configOptions)
 					.then(function (config) {
 						expect(config).to.deep.match({
 							// NOTE: the interval is converted to ms in the config object
@@ -646,7 +652,7 @@ describe('OS model', function () {
 					version: '2.0.8+rev1.prod',
 				};
 				return balena.models.os
-					.getConfig(this.application.id, configOptions)
+					.getConfig(ctx.application.id, configOptions)
 					.then(function (config) {
 						expect(config).to.deep.match({
 							// NOTE: the interval is converted to ms in the config object

--- a/tests/integration/models/service.spec.ts
+++ b/tests/integration/models/service.spec.ts
@@ -1,6 +1,7 @@
 // tslint:disable-next-line:import-blacklist
 import * as _ from 'lodash';
 import * as m from 'mochainon';
+import * as parallel from 'mocha.parallel';
 import {
 	balena,
 	givenAnApplication,
@@ -15,11 +16,16 @@ describe('Service Model', function () {
 	describe('given an application with no services', function () {
 		givenAnApplication(before);
 
-		describe('balena.models.service.getAllByApplication()', function () {
+		let ctx: Mocha.Context;
+		before(function () {
+			ctx = this;
+		});
+
+		parallel('balena.models.service.getAllByApplication()', function () {
 			['id', 'app_name', 'slug'].forEach((prop) => {
 				it(`should eventually become an empty array given an application ${prop}`, function () {
 					const promise = balena.models.service.getAllByApplication(
-						this.application[prop],
+						ctx.application[prop],
 					);
 					return expect(promise).to.become([]);
 				});
@@ -46,7 +52,7 @@ describe('Service Model', function () {
 	describe('given a multicontainer application with two services', function () {
 		givenMulticontainerApplication(before);
 
-		describe('balena.models.service.getAllByApplication()', () =>
+		describe('balena.models.service.getAllByApplication()', () => {
 			it('should load both services', function () {
 				return balena.models.service
 					.getAllByApplication(this.application.id)
@@ -68,7 +74,8 @@ describe('Service Model', function () {
 							},
 						]);
 					});
-			}));
+			});
+		});
 
 		describe('balena.models.service.var', function () {
 			const varModel = balena.models.service.var;

--- a/tests/typings/mocha.parallel.d.ts
+++ b/tests/typings/mocha.parallel.d.ts
@@ -1,0 +1,6 @@
+declare module 'mocha.parallel' {
+	import * as mocha from 'mocha';
+
+	const parallel: typeof mocha.describe;
+	export = parallel;
+}

--- a/tests/util_ts.ts
+++ b/tests/util_ts.ts
@@ -1,4 +1,5 @@
 import * as m from 'mochainon';
+import * as parallel from 'mocha.parallel';
 import { balena } from './integration/setup';
 import type * as BalenaSdk from '..';
 const { expect } = m.chai;
@@ -12,23 +13,21 @@ export const describeExpandAssertions = async <T>(
 			`Params object passed to 'describeExpandAssertions' must include a $expand`,
 		);
 	}
-	describe(`expanding from ${params.resource}`, function () {
+	parallel(`expanding from ${params.resource}`, function () {
 		Object.keys(expand).forEach((key) => {
-			describe(`to ${key}`, function () {
-				it('should succeed and include the expanded property', async function () {
-					const [result] = await balena.pine.get<T>({
-						...params,
-						options: {
-							...params.options,
-							$expand: {
-								[key]: expand[key],
-							},
+			it(`should succeed to expand property ${key}`, async function () {
+				const [result] = await balena.pine.get<T>({
+					...params,
+					options: {
+						...params.options,
+						$expand: {
+							[key]: expand[key],
 						},
-					} as typeof params);
-					if (result) {
-						expect(result).to.have.property(key).that.is.an('array');
-					}
-				});
+					},
+				} as typeof params);
+				if (result) {
+					expect(result).to.have.property(key).that.is.an('array');
+				}
 			});
 		});
 	});


### PR DESCRIPTION
Unfortunately mocha.parallel doesn't have proper support for the `this` context of tests.

Change-type: patch
Depends-on: https://github.com/balena-io/balena-sdk/pull/997
See: https://github.com/danielstjules/mocha.parallel/issues/16
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
