### PR TITLE
Improve the parameter type checks for the fully typed pine.get

### DIFF
--- a/typing_tests/pine-params.ts
+++ b/typing_tests/pine-params.ts
@@ -5,6 +5,8 @@ import { Compute, Equals, EqualsTrue } from './utils';
 
 const sdk: BalenaSdk.BalenaSDK = {} as any;
 
+const strictPine = sdk.pine as BalenaSdk.PineWithSelectOnGet;
+
 let aAny: any;
 let aNumber: number;
 let aNumberOrUndefined: number | undefined;
@@ -322,4 +324,154 @@ let aString: string;
 			},
 		},
 	});
+})();
+
+// strictPine
+(async () => {
+	const result = await strictPine.get({
+		resource: 'device',
+		options: {
+			// @ts-expect-error
+			$select: ['id', 'device_name', 'belongs_to__application', 'asdf'],
+		},
+	});
+})();
+
+(async () => {
+	const result = await strictPine.get({
+		resource: 'device',
+		options: {
+			// @ts-expect-error b/c the expand doesn't have a $select, bad placing though.
+			$select: ['id', 'device_name', 'belongs_to__application'],
+			$expand: {
+				should_be_running__release: {},
+				device_tag: {
+					$count: {}
+				},
+			},
+		},
+	});
+})();
+
+(async () => {
+	const result = await strictPine.get({
+		resource: 'device',
+		options: {
+			// @ts-expect-error b/c asdf is not an expandable prop, bad placing though.
+			$select: ['id', 'device_name', 'belongs_to__application'],
+			$expand: {
+				should_be_running__release: {
+					$select: 'id'
+				},
+				asdf: {
+					$select: 'id',
+				},
+				device_tag: {
+					$count: {}
+				},
+			},
+		},
+	});
+})();
+
+(async () => {
+	const [result] = await strictPine.get({
+		resource: 'device',
+		options: {
+			$select: ['id', 'device_name', 'belongs_to__application'],
+			$expand: {
+				should_be_running__release: {
+					$select: 'id'
+				},
+				device_tag: {
+					$count: {}
+				},
+			},
+		},
+	});
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumberOrUndefined = result.should_be_running__release[0]?.id;
+	aNumber = result.device_tag;
+
+	// @ts-expect-error
+	aString = result.os_version;
+	// @ts-expect-error
+	aNumber = result.is_on__release.__id;
+})();
+
+(async () => {
+	const result = await strictPine.get({
+		resource: 'device',
+		id: 5,
+		options: {
+			$select: ['id', 'device_name', 'belongs_to__application'],
+			$expand: {
+				should_be_running__release: {
+					$select: 'id'
+				},
+				device_tag: {
+					$count: {}
+				},
+			},
+		},
+	});
+	const checkUndefined: typeof result = undefined;
+	if (result === undefined) {
+		throw 'Can be undefined';
+	}
+
+	aNumber = result.id;
+	aString = result.device_name;
+	aNumber = result.belongs_to__application.__id;
+	aNumberOrUndefined = result.should_be_running__release[0]?.id;
+	aNumber = result.device_tag;
+
+	// @ts-expect-error
+	aString = result.os_version;
+	// @ts-expect-error
+	aNumber = result.is_on__release.__id;
+})();
+
+(async () => {
+	const result = await strictPine.get({
+		resource: 'device',
+		id: 5,
+		options: {
+			$count: {
+				$filter: {
+					// TODO: this should error
+					asdf: 4,
+					belongs_to__application: {
+						organization: 1,
+						application_type: 2,
+						depends_on__application: null,
+					},
+				},
+			},
+		},
+	});
+
+	aNumber = result;
+})();
+
+(async () => {
+	const result = await strictPine.get({
+		resource: 'device',
+		id: 5,
+		options: {
+			$count: {
+				$filter: {
+					belongs_to__application: {
+						organization: 1,
+						application_type: 2,
+						depends_on__application: null,
+					},
+				},
+			},
+		},
+	});
+
+	aNumber = result;
 })();

--- a/typing_tests/pine-params.ts
+++ b/typing_tests/pine-params.ts
@@ -265,6 +265,31 @@ let aString: string;
 	aNumber = result.is_on__release.__id;
 })();
 
+// Exceeding properties
+(async () => {
+	const result = await sdk.pine.get({
+		resource: 'device',
+		// @ts-expect-error
+		missplaced$filter: {},
+		options: {
+			$select: ['id', 'device_name', 'belongs_to__application'],
+		},
+	});
+})();
+
+
+(async () => {
+	const result = await sdk.pine.get({
+		resource: 'device',
+		options: {
+			$select: ['id', 'device_name', 'belongs_to__application'],
+			// @ts-expect-error
+			$asdf: {},
+		},
+	});
+})();
+
+// Incorrect properties
 (async () => {
 	const result = await sdk.pine.get({
 		resource: 'device',
@@ -288,6 +313,7 @@ let aString: string;
 		options: {
 			$select: ['id', 'device_name', 'belongs_to__application'],
 			$expand: {
+				// @ts-expect-error
 				should_be_running__release: {},
 				asdf: {},
 				device_tag: {
@@ -296,5 +322,4 @@ let aString: string;
 			},
 		},
 	});
-	const test: Equals<typeof result, never[]> = EqualsTrue;
 })();

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -1,4 +1,10 @@
-import type { AnyObject, PropsOfType, StringKeyof, Dictionary } from './utils';
+import type {
+	AnyObject,
+	PropsOfType,
+	StringKeyof,
+	Dictionary,
+	ExactlyExtends,
+} from './utils';
 import type { ResourceTypeMap } from './balena-sdk/models';
 
 export interface WithId {
@@ -456,13 +462,16 @@ export interface Pine {
 			ResourceTypeMap[P['resource']]
 		>
 	>(
-		params: P,
+		params: ExactlyExtends<
+			P,
+			ParamsObjWithCount<ResourceTypeMap[P['resource']]>
+		>,
 	): Promise<number>;
 	get<
 		R extends keyof ResourceTypeMap,
 		P extends { resource: R } & ParamsObjWithId<ResourceTypeMap[P['resource']]>
 	>(
-		params: P,
+		params: ExactlyExtends<P, ParamsObjWithId<ResourceTypeMap[P['resource']]>>,
 	): Promise<
 		TypedResult<ResourceTypeMap[P['resource']], P['options']> | undefined
 	>;
@@ -470,7 +479,7 @@ export interface Pine {
 		R extends keyof ResourceTypeMap,
 		P extends { resource: R } & ParamsObj<ResourceTypeMap[P['resource']]>
 	>(
-		params: P,
+		params: ExactlyExtends<P, ParamsObj<ResourceTypeMap[P['resource']]>>,
 	): Promise<Array<TypedResult<ResourceTypeMap[P['resource']], P['options']>>>;
 	// User provided resource type overloads
 	get<T extends {}>(params: ParamsObjWithCount<T>): Promise<number>;
@@ -549,10 +558,12 @@ export type PineWithSelectOnGet = Omit<
 		R extends keyof ResourceTypeMap,
 		P extends { resource: R } & ParamsObjWithCount<
 			ResourceTypeMap[P['resource']]
-		> &
-			ParamsObjWithSelect<ResourceTypeMap[P['resource']]>
+		>
 	>(
-		params: P,
+		params: ExactlyExtends<
+			P,
+			ParamsObjWithCount<ResourceTypeMap[P['resource']]>
+		>,
 	): Promise<number>;
 	get<
 		R extends keyof ResourceTypeMap,
@@ -561,7 +572,11 @@ export type PineWithSelectOnGet = Omit<
 		> &
 			ParamsObjWithSelect<ResourceTypeMap[P['resource']]>
 	>(
-		params: P,
+		params: ExactlyExtends<
+			P,
+			ParamsObjWithId<ResourceTypeMap[P['resource']]> &
+				ParamsObjWithSelect<ResourceTypeMap[P['resource']]>
+		>,
 	): Promise<
 		TypedResult<ResourceTypeMap[P['resource']], P['options']> | undefined
 	>;
@@ -571,7 +586,10 @@ export type PineWithSelectOnGet = Omit<
 			ResourceTypeMap[P['resource']]
 		>
 	>(
-		params: P,
+		params: ExactlyExtends<
+			P,
+			ParamsObjWithSelect<ResourceTypeMap[P['resource']]>
+		>,
 	): Promise<Array<TypedResult<ResourceTypeMap[P['resource']], P['options']>>>;
 	// User provided resource type overloads
 	get<T extends {}>(params: ParamsObjWithCount<T>): Promise<number>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -4,6 +4,7 @@ import type {
 	StringKeyof,
 	Dictionary,
 	ExactlyExtends,
+	NoInfer,
 } from './utils';
 import type { ResourceTypeMap } from './balena-sdk/models';
 
@@ -592,15 +593,17 @@ export type PineWithSelectOnGet = Omit<
 		>,
 	): Promise<Array<TypedResult<ResourceTypeMap[P['resource']], P['options']>>>;
 	// User provided resource type overloads
-	get<T extends {}>(params: ParamsObjWithCount<T>): Promise<number>;
+	get<T extends {}>(params: ParamsObjWithCount<NoInfer<T>>): Promise<number>;
 	get<T extends {}>(
-		params: ParamsObjWithId<T> & ParamsObjWithSelect<T>,
+		params: ParamsObjWithId<NoInfer<T>> & ParamsObjWithSelect<NoInfer<T>>,
 	): Promise<T | undefined>;
-	get<T extends {}>(params: ParamsObjWithSelect<T>): Promise<T[]>;
+	get<T extends {}>(params: ParamsObjWithSelect<NoInfer<T>>): Promise<T[]>;
 	get<T extends {}, Result extends number>(
-		params: ParamsObj<T>,
+		params: ParamsObj<NoInfer<T>>,
 	): Promise<Result>;
-	get<T extends {}, Result>(params: ParamsObjWithSelect<T>): Promise<Result>;
+	get<T extends {}, Result>(
+		params: ParamsObjWithSelect<NoInfer<T>>,
+	): Promise<Result>;
 
 	prepare<T extends Dictionary<ParameterAlias>, R>(
 		params: ParamsObjWithCount<R> & {

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -24,3 +24,8 @@ export type Writable<T> = { -readonly [K in keyof T]: T[K] };
 export type ExactlyExtends<T, ExtendsBase> = ExtendsBase extends T
 	? T
 	: ExtendsBase;
+
+// TODO: Replace this workaround once TS adds support for this use case.
+// See: https://github.com/microsoft/TypeScript/issues/14829#issuecomment-322267089
+// See: https://github.com/millsp/ts-toolbelt/blob/3859d1819021800b96ed815abf5c300eb7b8f926/src/Function/NoInfer.ts#L27
+export type NoInfer<A extends any> = [A][A extends any ? 0 : never];

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -18,3 +18,9 @@ export type Resolvable<R> = R | PromiseLike<R>;
 export type AtLeast<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;
 
 export type Writable<T> = { -readonly [K in keyof T]: T[K] };
+
+// TODO: Change this approximation once TS properly supports Exact Types for generics.
+// See: https://github.com/microsoft/TypeScript/issues/12936#issuecomment-711172739
+export type ExactlyExtends<T, ExtendsBase> = ExtendsBase extends T
+	? T
+	: ExtendsBase;


### PR DESCRIPTION
Used the NoInfer helper to prevent TS from using the old pine.get overloads, unless the generic parameters are explicitely provided. This way when no generic arguments are provided TS will try to match only the fully typed variants and in case of an error it will output the reason from those overloads. Previously it would fallback to the old pine.get variants and try to infer a loose generic type, which wasn't correct and silenced some errors This is a bit aggressive change and as a result I decided to limit this change for the strict pine variant, which is opt-in, and hold it back from the main typings until the next major.

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
