### PR TITLE
typings: Deprecate PineWithSelectOnGet variant in favor of PineStrict

### DIFF
--- a/typing_tests/pine-params.ts
+++ b/typing_tests/pine-params.ts
@@ -5,7 +5,7 @@ import { Compute, Equals, EqualsTrue } from './utils';
 
 const sdk: BalenaSdk.BalenaSDK = {} as any;
 
-const strictPine = sdk.pine as BalenaSdk.PineWithSelectOnGet;
+const strictPine = sdk.pine as BalenaSdk.PineStrict;
 
 let aAny: any;
 let aNumber: number;

--- a/typings/balena-pine.d.ts
+++ b/typings/balena-pine.d.ts
@@ -2,7 +2,7 @@ import type * as PineClient from './pinejs-client-core';
 
 export type Pine = PineClient.Pine;
 /**
- * A variant that helps you not forget addins a $select, helping to
- * create requests explecitely fetch only what your code needs.
+ * A variant that makes $select mandatory, helping to create
+ * requests that explicitly fetch only what your code needs.
  */
-export type PineWithSelectOnGet = PineClient.PineWithSelectOnGet;
+export type PineStrict = PineClient.PineStrict;

--- a/typings/balena-sdk/index.d.ts
+++ b/typings/balena-sdk/index.d.ts
@@ -60,7 +60,12 @@ export type {
 	ExpandResultObject as PineExpandResultObject,
 	TypedResult as PineTypedResult,
 } from '../pinejs-client-core';
-export type { PineWithSelectOnGet } from '../balena-pine';
+export type { PineStrict } from '../balena-pine';
+
+// TODO: Drop in the next major
+import type { PineStrict } from '../balena-pine';
+/** @deprecated */
+export type PineWithSelectOnGet = PineStrict;
 
 export type PineOptions<T> = Pine.ODataOptions<T>;
 export type PineSubmitBody<T> = Pine.SubmitBody<T>;

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -545,15 +545,11 @@ export interface Pine {
 	): Poll<'OK'>;
 }
 
-// TODO: Rename to PineStrict on the next major
 /**
- * A variant that helps you not forget addins a $select, helping to
- * create requests explecitely fetch only what your code needs.
+ * A variant that makes $select mandatory, helping to create
+ * requests that explicitly fetch only what your code needs.
  */
-export type PineWithSelectOnGet = Omit<
-	Pine,
-	'get' | 'prepare' | 'subscribe'
-> & {
+export type PineStrict = Omit<Pine, 'get' | 'prepare' | 'subscribe'> & {
 	// Fully typed result overloads
 	get<
 		R extends keyof ResourceTypeMap,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
