### PR TITLE
tests: Workaround the failing  cascade deletes for release.deployFromUrl

### DIFF
--- a/tests/integration/models/release.spec.js
+++ b/tests/integration/models/release.spec.js
@@ -1,7 +1,7 @@
 import * as m from 'mochainon';
 import * as parallel from 'mocha.parallel';
 import * as _ from 'lodash';
-import { timeSuite } from '../../util';
+import { delay, timeSuite } from '../../util';
 
 const { expect } = m.chai;
 
@@ -100,8 +100,11 @@ describe('Release Model', function () {
 			const TEST_SOURCE_URL =
 				'https://github.com/balena-io-projects/simple-server-node/archive/v1.0.0.tar.gz';
 
-			after(function () {
-				return balena.pine.delete({
+			after(async function () {
+				// TODO: We shouldn't need this, but the API's application->service->image delete cascade
+				// started erroring with data still referenced by image.
+				await delay(10000);
+				await balena.pine.delete({
 					resource: 'release',
 					options: {
 						$filter: {

--- a/tests/integration/models/release.spec.js
+++ b/tests/integration/models/release.spec.js
@@ -114,8 +114,7 @@ describe('Release Model', function () {
 				});
 			});
 
-			parallel('', function () {
-				// [read operations]
+			parallel('[read operations]', function () {
 				it('should be rejected if the application name does not exist', function () {
 					const promise = balena.models.release.createFromUrl('HelloWorldApp', {
 						url: TEST_SOURCE_URL,
@@ -167,8 +166,9 @@ describe('Release Model', function () {
 							);
 					});
 				});
+			});
 
-				// [mutating operations]
+			describe('[mutating operations]', function () {
 				['id', 'app_name', 'slug'].forEach((prop) => {
 					it(`should be able to create a release using a tarball url given an application ${prop}`, function () {
 						return balena.models.release

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -65,3 +65,9 @@ export const timeSuite = function (beforeFn: Mocha.HookFunction) {
 		);
 	});
 };
+
+export async function delay(ms: number) {
+	await new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}


### PR DESCRIPTION
Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-devops/threads/wOEEiorvtaeCtuGc4KVO0YpAy-f
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
