### PR TITLE
Remove the workaround for failing cascade deletes on deployFromUrl tests

### DIFF
--- a/tests/integration/models/release.spec.js
+++ b/tests/integration/models/release.spec.js
@@ -1,7 +1,7 @@
 import * as m from 'mochainon';
 import * as parallel from 'mocha.parallel';
 import * as _ from 'lodash';
-import { delay, timeSuite } from '../../util';
+import { timeSuite } from '../../util';
 
 const { expect } = m.chai;
 
@@ -101,9 +101,6 @@ describe('Release Model', function () {
 				'https://github.com/balena-io-projects/simple-server-node/archive/v1.0.0.tar.gz';
 
 			after(async function () {
-				// TODO: We shouldn't need this, but the API's application->service->image delete cascade
-				// started erroring with data still referenced by image.
-				await delay(10000);
 				await balena.pine.delete({
 					resource: 'release',
 					options: {

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -65,9 +65,3 @@ export const timeSuite = function (beforeFn: Mocha.HookFunction) {
 		);
 	});
 };
-
-export async function delay(ms: number) {
-	await new Promise((resolve) => {
-		setTimeout(resolve, ms);
-	});
-}


### PR DESCRIPTION
This reverts commit
65c1da9d22d79fa377dba14a4bc75b7e3ef4426e.
I expect the tests to fail, but once they start passing we should get this in.

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-devops/threads/wOEEiorvtaeCtuGc4KVO0YpAy-f

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
