### PR TITLE
Manage lock overrides using the config variables instead of the endpoint

### DIFF
--- a/tests/integration/models/device.spec.js
+++ b/tests/integration/models/device.spec.js
@@ -1438,38 +1438,29 @@ describe('Device Model', function () {
 			describe('balena.models.device.hasLockOverride()', function () {
 				givenADevice(before);
 
-				it('should be false by default for a device retrieved by uuid', async function () {
-					const hasLockOverride = await balena.models.device.hasLockOverride(
-						this.device.uuid,
-					);
-					return expect(hasLockOverride).to.be.false;
-				});
-
-				it('should be false by default for a device retrieved by id', async function () {
-					const hasLockOverride = await balena.models.device.hasLockOverride(
-						this.device.id,
-					);
-					return expect(hasLockOverride).to.be.false;
+				['id', 'uuid'].forEach(function (deviceParam) {
+					it(`should be false by default for a device retrieved by ${deviceParam}`, async function () {
+						const hasLockOverride = await balena.models.device.hasLockOverride(
+							this.device[deviceParam],
+						);
+						return expect(hasLockOverride).to.be.false;
+					});
 				});
 			});
 
 			describe('balena.models.device.enableLockOverride()', function () {
 				givenADevice(beforeEach);
 
-				it('should be able to enable lock override by uuid', async function () {
-					await balena.models.device.enableLockOverride(this.device.uuid);
-					const hasLockOverride = await balena.models.device.hasLockOverride(
-						this.device.uuid,
-					);
-					return expect(hasLockOverride).to.be.true;
-				});
-
-				it('should be able to enable lock override by id', async function () {
-					await balena.models.device.enableLockOverride(this.device.id);
-					const hasLockOverride = await balena.models.device.hasLockOverride(
-						this.device.id,
-					);
-					return expect(hasLockOverride).to.be.true;
+				['id', 'uuid'].forEach(function (deviceParam) {
+					it(`should be able to enable lock override by ${deviceParam}`, async function () {
+						await balena.models.device.enableLockOverride(
+							this.device[deviceParam],
+						);
+						const hasLockOverride = await balena.models.device.hasLockOverride(
+							this.device[deviceParam],
+						);
+						return expect(hasLockOverride).to.be.true;
+					});
 				});
 			});
 
@@ -1484,20 +1475,16 @@ describe('Device Model', function () {
 					expect(hasLockOverride).to.be.true;
 				});
 
-				it('should be able to disable lock override by uuid', async function () {
-					await balena.models.device.disableLockOverride(this.device.uuid);
-					const hasLockOverride = await balena.models.device.hasLockOverride(
-						this.device.uuid,
-					);
-					return expect(hasLockOverride).to.be.false;
-				});
-
-				it('should be able to disable lock override by id', async function () {
-					await balena.models.device.disableLockOverride(this.device.id);
-					const hasLockOverride = await balena.models.device.hasLockOverride(
-						this.device.id,
-					);
-					return expect(hasLockOverride).to.be.false;
+				['id', 'uuid'].forEach(function (deviceParam) {
+					it(`should be able to disable lock override by ${deviceParam}`, async function () {
+						await balena.models.device.disableLockOverride(
+							this.device[deviceParam],
+						);
+						const hasLockOverride = await balena.models.device.hasLockOverride(
+							this.device[deviceParam],
+						);
+						return expect(hasLockOverride).to.be.false;
+					});
 				});
 			});
 

--- a/tests/integration/models/device.spec.js
+++ b/tests/integration/models/device.spec.js
@@ -1446,6 +1446,98 @@ describe('Device Model', function () {
 						return expect(hasLockOverride).to.be.false;
 					});
 				});
+
+				const OVERRIDE_LOCK_ENV_VAR = 'RESIN_OVERRIDE_LOCK';
+
+				it('should be true for a device that has the device config var set to 0 and no app config var', async function () {
+					await balena.models.device.configVar.set(
+						this.device.uuid,
+						OVERRIDE_LOCK_ENV_VAR,
+						'0',
+					);
+					const hasLockOverride = await balena.models.device.hasLockOverride(
+						this.device.uuid,
+					);
+					return expect(hasLockOverride).to.be.false;
+				});
+
+				it('should be true for a device that has the device config var set to 1 and no app config var', async function () {
+					await balena.models.device.configVar.set(
+						this.device.uuid,
+						OVERRIDE_LOCK_ENV_VAR,
+						'1',
+					);
+					const hasLockOverride = await balena.models.device.hasLockOverride(
+						this.device.uuid,
+					);
+					return expect(hasLockOverride).to.be.true;
+				});
+
+				it('should be true for a device that has the app config var set to 0 and no device config var', async function () {
+					await balena.models.application.configVar.set(
+						this.application.id,
+						OVERRIDE_LOCK_ENV_VAR,
+						'0',
+					);
+					await balena.models.device.configVar.remove(
+						this.device.uuid,
+						OVERRIDE_LOCK_ENV_VAR,
+					);
+					const hasLockOverride = await balena.models.device.hasLockOverride(
+						this.device.uuid,
+					);
+					return expect(hasLockOverride).to.be.false;
+				});
+
+				it('should be true for a device that has the app config var set to 1 and no device config var', async function () {
+					await balena.models.application.configVar.set(
+						this.application.id,
+						OVERRIDE_LOCK_ENV_VAR,
+						'1',
+					);
+					await balena.models.device.configVar.remove(
+						this.device.uuid,
+						OVERRIDE_LOCK_ENV_VAR,
+					);
+					const hasLockOverride = await balena.models.device.hasLockOverride(
+						this.device.uuid,
+					);
+					return expect(hasLockOverride).to.be.true;
+				});
+
+				it('should be false for a device that has the app config var set to 1 and the device config var set to 0', async function () {
+					await balena.models.application.configVar.set(
+						this.application.id,
+						OVERRIDE_LOCK_ENV_VAR,
+						'1',
+					);
+					await balena.models.device.configVar.set(
+						this.device.uuid,
+						OVERRIDE_LOCK_ENV_VAR,
+						'0',
+					);
+					const hasLockOverride = await balena.models.device.hasLockOverride(
+						this.device.uuid,
+					);
+					return expect(hasLockOverride).to.be.false;
+				});
+
+				it('should be true for a device that has the app config var set to 0 and the device config var set to 1', async function () {
+					await balena.models.application.configVar.set(
+						this.application.id,
+						OVERRIDE_LOCK_ENV_VAR,
+						'0',
+					);
+					await balena.models.device.configVar.set(
+						this.device.uuid,
+						OVERRIDE_LOCK_ENV_VAR,
+						'1',
+					);
+					const hasLockOverride = await balena.models.device.hasLockOverride(
+						this.device.uuid,
+					);
+					return expect(hasLockOverride).to.be.true;
+				});
 			});
 
 			describe('balena.models.device.enableLockOverride()', function () {


### PR DESCRIPTION
This also allows the device lock override methods to
work on open-balena.

Resolves: #1071
Change-type: minor
See: https://github.com/balena-io/open-balena-api/issues/632
See: https://github.com/balena-io/balena-api/issues/3076
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
