### PR TITLE
types/models: Add `subscription_addon_discount` to the Subscription

### DIFF
--- a/lib/types/models.ts
+++ b/lib/types/models.ts
@@ -55,6 +55,7 @@ export interface ResourceTypeMap {
 	service_install: ServiceInstall;
 	service_instance: ServiceInstance;
 	subscription: Subscription;
+	subscription_addon_discount: SubscriptionAddonDiscount;
 	subscription_prepaid_addon: SubscriptionPrepaidAddon;
 	supervisor_release: SupervisorRelease;
 	support_feature: SupportFeature;
@@ -635,6 +636,7 @@ export interface Subscription {
 
 	is_for__organization: NavigationResource<Organization>;
 	is_for__plan: NavigationResource<Plan>;
+	subscription_addon_discount: ReverseNavigationResource<SubscriptionAddonDiscount>;
 	discounts__plan_addon: ReverseNavigationResource<SubscriptionAddonDiscount>;
 	subscription_prepaid_addon: ReverseNavigationResource<SubscriptionPrepaidAddon>;
 }
@@ -651,6 +653,7 @@ export interface SubscriptionPrepaidAddon {
 }
 
 export interface SubscriptionAddonDiscount {
+	id: number;
 	discount_percentage: number;
 	discounts__plan_addon: NavigationResource<PlanAddon>;
 }

--- a/lib/types/models.ts
+++ b/lib/types/models.ts
@@ -637,6 +637,7 @@ export interface Subscription {
 	is_for__organization: NavigationResource<Organization>;
 	is_for__plan: NavigationResource<Plan>;
 	subscription_addon_discount: ReverseNavigationResource<SubscriptionAddonDiscount>;
+	/** @deprecated */
 	discounts__plan_addon: ReverseNavigationResource<SubscriptionAddonDiscount>;
 	subscription_prepaid_addon: ReverseNavigationResource<SubscriptionPrepaidAddon>;
 }


### PR DESCRIPTION
Also deprecates the Subscription's discounts__plan_addon property.

See: https://github.com/balena-io/balena-api/pull/3083
See: https://github.com/balena-io/balena-api/pull/3085
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
