### PR TITLE
**BREAKING** Change apiKey.getAll() to return all keys w/o any filter & add apiKey.getAllNamedUserApiKeys()

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -265,6 +265,7 @@ const sdk = fromSharedOptions();
         * [.apiKey](#balena.models.apiKey) : <code>object</code>
             * [.create(name, [description])](#balena.models.apiKey.create) ⇒ <code>Promise</code>
             * [.getAll([options])](#balena.models.apiKey.getAll) ⇒ <code>Promise</code>
+            * [.getAllNamedUserApiKeys([options])](#balena.models.apiKey.getAllNamedUserApiKeys) ⇒ <code>Promise</code>
             * [.update(id, apiKeyInfo)](#balena.models.apiKey.update) ⇒ <code>Promise</code>
             * [.revoke(id)](#balena.models.apiKey.revoke) ⇒ <code>Promise</code>
         * [.key](#balena.models.key) : <code>object</code>
@@ -629,6 +630,7 @@ balena.models.device.get(123).catch(function (error) {
     * [.apiKey](#balena.models.apiKey) : <code>object</code>
         * [.create(name, [description])](#balena.models.apiKey.create) ⇒ <code>Promise</code>
         * [.getAll([options])](#balena.models.apiKey.getAll) ⇒ <code>Promise</code>
+        * [.getAllNamedUserApiKeys([options])](#balena.models.apiKey.getAllNamedUserApiKeys) ⇒ <code>Promise</code>
         * [.update(id, apiKeyInfo)](#balena.models.apiKey.update) ⇒ <code>Promise</code>
         * [.revoke(id)](#balena.models.apiKey.revoke) ⇒ <code>Promise</code>
     * [.key](#balena.models.key) : <code>object</code>
@@ -5221,6 +5223,7 @@ balena.models.deviceType.getSlugByName('Raspberry Pi', function(error, deviceTyp
 * [.apiKey](#balena.models.apiKey) : <code>object</code>
     * [.create(name, [description])](#balena.models.apiKey.create) ⇒ <code>Promise</code>
     * [.getAll([options])](#balena.models.apiKey.getAll) ⇒ <code>Promise</code>
+    * [.getAllNamedUserApiKeys([options])](#balena.models.apiKey.getAllNamedUserApiKeys) ⇒ <code>Promise</code>
     * [.update(id, apiKeyInfo)](#balena.models.apiKey.update) ⇒ <code>Promise</code>
     * [.revoke(id)](#balena.models.apiKey.revoke) ⇒ <code>Promise</code>
 
@@ -5279,6 +5282,31 @@ balena.models.apiKey.getAll().then(function(apiKeys) {
 **Example**  
 ```js
 balena.models.apiKey.getAll(function(error, apiKeys) {
+	if (error) throw error;
+	console.log(apiKeys);
+});
+```
+<a name="balena.models.apiKey.getAllNamedUserApiKeys"></a>
+
+##### apiKey.getAllNamedUserApiKeys([options]) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>apiKey</code>](#balena.models.apiKey)  
+**Summary**: Get all named user API keys of the current user  
+**Access**: public  
+**Fulfil**: <code>Object[]</code> - apiKeys  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> | <code>{}</code> | extra pine options to use |
+
+**Example**  
+```js
+balena.models.apiKey.getAllNamedUserApiKeys().then(function(apiKeys) {
+	console.log(apiKeys);
+});
+```
+**Example**  
+```js
+balena.models.apiKey.getAllNamedUserApiKeys(function(error, apiKeys) {
 	if (error) throw error;
 	console.log(apiKeys);
 });

--- a/lib/models/api-key.ts
+++ b/lib/models/api-key.ts
@@ -24,7 +24,7 @@ const getApiKeysModel = function (
 	deps: InjectedDependenciesParam,
 	opts: InjectedOptionsParam,
 ) {
-	const { pine, request } = deps;
+	const { pine, request, sdkInstance } = deps;
 	const { apiUrl } = opts;
 	const exports = {
 		/**
@@ -110,6 +110,51 @@ const getApiKeysModel = function (
 				resource: 'api_key',
 				options: mergePineOptions(
 					{
+						$orderby: 'name asc',
+					},
+					options,
+				),
+			});
+		},
+
+		/**
+		 * @summary Get all named user API keys of the current user
+		 * @name getAllNamedUserApiKeys
+		 * @public
+		 * @function
+		 * @memberof balena.models.apiKey
+		 *
+		 * @param {Object} [options={}] - extra pine options to use
+		 * @fulfil {Object[]} - apiKeys
+		 * @returns {Promise}
+		 *
+		 * @example
+		 * balena.models.apiKey.getAllNamedUserApiKeys().then(function(apiKeys) {
+		 * 	console.log(apiKeys);
+		 * });
+		 *
+		 * @example
+		 * balena.models.apiKey.getAllNamedUserApiKeys(function(error, apiKeys) {
+		 * 	if (error) throw error;
+		 * 	console.log(apiKeys);
+		 * });
+		 */
+		async getAllNamedUserApiKeys(
+			options: BalenaSdk.PineOptions<BalenaSdk.ApiKey> = {},
+		): Promise<BalenaSdk.ApiKey[]> {
+			return await pine.get({
+				resource: 'api_key',
+				options: mergePineOptions(
+					{
+						$filter: {
+							is_of__actor: await sdkInstance.auth.getUserActorId(),
+							// the only way to reason whether it's
+							// a named user api key vs a deprecated user api key
+							// is whether it has a name.
+							name: {
+								$ne: null,
+							},
+						},
 						$orderby: 'name asc',
 					},
 					options,

--- a/lib/models/api-key.ts
+++ b/lib/models/api-key.ts
@@ -110,14 +110,6 @@ const getApiKeysModel = function (
 				resource: 'api_key',
 				options: mergePineOptions(
 					{
-						// the only way to reason whether
-						// it's a named user api key is whether
-						// it has a name
-						$filter: {
-							name: {
-								$ne: null,
-							},
-						},
 						$orderby: 'name asc',
 					},
 					options,

--- a/tests/integration/models/api-key.spec.ts
+++ b/tests/integration/models/api-key.spec.ts
@@ -91,6 +91,47 @@ describe('API Key model', function () {
 		});
 	});
 
+	describe('balena.models.apiKey.getAllNamed()', function () {
+		givenLoggedInUser(before);
+
+		describe('given no named api keys', () => {
+			it('should retrieve an empty array', async function () {
+				const apiKeys = await balena.models.apiKey.getAllNamedUserApiKeys();
+				expect(apiKeys).to.be.an('array');
+				expect(apiKeys).to.have.lengthOf(0);
+			});
+		});
+
+		describe('given two named api keys', function () {
+			before(() =>
+				Promise.all([
+					balena.models.apiKey.create('apiKey1'),
+					balena.models.apiKey.create('apiKey2', 'apiKey2Description'),
+				]),
+			);
+
+			it('should be able to retrieve all api keys created', async function () {
+				const apiKeys = await balena.models.apiKey.getAllNamedUserApiKeys();
+				expect(apiKeys).to.be.an('array');
+				expect(apiKeys).to.have.lengthOf(2);
+				expect(apiKeys).to.deep.match([
+					{
+						name: 'apiKey1',
+						description: null,
+					},
+					{
+						name: 'apiKey2',
+						description: 'apiKey2Description',
+					},
+				]);
+				apiKeys.forEach(function (apiKey) {
+					expect(apiKey).to.have.property('id').that.is.a('number');
+					expect(apiKey).to.have.property('created_at').that.is.a('string');
+				});
+			});
+		});
+	});
+
 	describe('given a named api key [contained scenario]', function () {
 		givenLoggedInUser(before);
 

--- a/tests/integration/models/api-key.spec.ts
+++ b/tests/integration/models/api-key.spec.ts
@@ -44,11 +44,15 @@ describe('API Key model', function () {
 		givenLoggedInUser(before);
 
 		describe('given no named api keys', () => {
-			it('should retrieve an empty array', () => {
-				return balena.models.apiKey.getAll().then(function (apiKeys) {
-					expect(apiKeys).to.be.an('array');
-					expect(apiKeys).to.have.lengthOf(0);
+			it('should retrieve an empty array', async function () {
+				const apiKeys = await balena.models.apiKey.getAll({
+					$filter: {
+						is_of__actor: await balena.auth.getUserActorId(),
+						name: { $ne: null },
+					},
 				});
+				expect(apiKeys).to.be.an('array');
+				expect(apiKeys).to.have.lengthOf(0);
 			});
 		});
 
@@ -60,24 +64,28 @@ describe('API Key model', function () {
 				]),
 			);
 
-			it('should be able to retrieve all api keys created', () => {
-				return balena.models.apiKey.getAll().then(function (apiKeys) {
-					expect(apiKeys).to.be.an('array');
-					expect(apiKeys).to.have.lengthOf(2);
-					expect(apiKeys).to.deep.match([
-						{
-							name: 'apiKey1',
-							description: null,
-						},
-						{
-							name: 'apiKey2',
-							description: 'apiKey2Description',
-						},
-					]);
-					_.forEach(apiKeys, function (apiKey) {
-						expect(apiKey).to.have.property('id').that.is.a('number');
-						expect(apiKey).to.have.property('created_at').that.is.a('string');
-					});
+			it('should be able to retrieve all api keys created', async function () {
+				const apiKeys = await balena.models.apiKey.getAll({
+					$filter: {
+						is_of__actor: await balena.auth.getUserActorId(),
+						name: { $ne: null },
+					},
+				});
+				expect(apiKeys).to.be.an('array');
+				expect(apiKeys).to.have.lengthOf(2);
+				expect(apiKeys).to.deep.match([
+					{
+						name: 'apiKey1',
+						description: null,
+					},
+					{
+						name: 'apiKey2',
+						description: 'apiKey2Description',
+					},
+				]);
+				apiKeys.forEach(function (apiKey) {
+					expect(apiKey).to.have.property('id').that.is.a('number');
+					expect(apiKey).to.have.property('created_at').that.is.a('string');
 				});
 			});
 		});
@@ -196,13 +204,17 @@ describe('API Key model', function () {
 		});
 
 		describe('balena.models.apiKey.revoke()', () => {
-			it('should be able to revoke an exising api key', function () {
-				return expect(balena.models.apiKey.revoke(this.apiKey.id))
-					.to.not.be.rejected.then(() => balena.models.apiKey.getAll())
-					.then(function (apiKeys) {
-						expect(apiKeys).to.be.an('array');
-						expect(apiKeys).to.have.lengthOf(0);
-					});
+			it('should be able to revoke an exising api key', async function () {
+				await expect(balena.models.apiKey.revoke(this.apiKey.id)).to.not.be
+					.rejected;
+				const apiKeys = await balena.models.apiKey.getAll({
+					$filter: {
+						is_of__actor: await balena.auth.getUserActorId(),
+						name: { $ne: null },
+					},
+				});
+				expect(apiKeys).to.be.an('array');
+				expect(apiKeys).to.have.lengthOf(0);
 			});
 		});
 	});

--- a/tests/integration/models/api-key.spec.ts
+++ b/tests/integration/models/api-key.spec.ts
@@ -91,7 +91,7 @@ describe('API Key model', function () {
 		});
 	});
 
-	describe('balena.models.apiKey.getAllNamed()', function () {
+	describe('balena.models.apiKey.getAllNamedUserApiKeys()', function () {
 		givenLoggedInUser(before);
 
 		describe('given no named api keys', () => {
@@ -132,7 +132,7 @@ describe('API Key model', function () {
 		});
 	});
 
-	describe('given a named api key [contained scenario]', function () {
+	describe('given a named user api key [contained scenario]', function () {
 		givenLoggedInUser(before);
 
 		before(function () {
@@ -248,12 +248,7 @@ describe('API Key model', function () {
 			it('should be able to revoke an exising api key', async function () {
 				await expect(balena.models.apiKey.revoke(this.apiKey.id)).to.not.be
 					.rejected;
-				const apiKeys = await balena.models.apiKey.getAll({
-					$filter: {
-						is_of__actor: await balena.auth.getUserActorId(),
-						name: { $ne: null },
-					},
-				});
+				const apiKeys = await balena.models.apiKey.getAllNamedUserApiKeys();
 				expect(apiKeys).to.be.an('array');
 				expect(apiKeys).to.have.lengthOf(0);
 			});


### PR DESCRIPTION
The apiKeys.getAllNamedUserApiKeys will be offering
the same behavior.

Change-type: major
See: https://jel.ly.fish/287934d0-6fb2-4af2-888a-47966b9393f0
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/aLBhe-Vfl7EBsb-oNp71Mm_TTUv
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
