### PR TITLE
typings: Add the release versioning properties

### DIFF
--- a/lib/types/models.ts
+++ b/lib/types/models.ts
@@ -302,6 +302,16 @@ export type ReleaseStatus =
 	| 'timeout'
 	| null;
 
+export interface ReleaseVersion {
+	raw: string;
+	major: number;
+	minor: number;
+	patch: number;
+	version: string;
+	build: ReadonlyArray<string>;
+	prerelease: ReadonlyArray<string | number>;
+}
+
 export interface Release {
 	id: number;
 	created_at: string;
@@ -316,6 +326,13 @@ export interface Release {
 	update_timestamp: string | null;
 	end_timestamp: string;
 	release_version: string | null;
+	semver: string;
+	semver_major: number;
+	semver_minor: number;
+	semver_patch: number;
+	revision: number | null;
+	/** This is a computed term */
+	version: ReleaseVersion;
 	is_final: boolean;
 	is_finalized_at__date: string | null;
 

--- a/lib/types/models.ts
+++ b/lib/types/models.ts
@@ -325,6 +325,7 @@ export interface Release {
 	start_timestamp: string;
 	update_timestamp: string | null;
 	end_timestamp: string;
+	/** @deprecated */
 	release_version: string | null;
 	semver: string;
 	semver_major: number;


### PR DESCRIPTION
Setting a 3-digit semver to the release.semver field
is the suggested approach, instead of setting the
release.release_version field. This fixes the unique
constraint issue that release_version was often
causing to users, since in case a duplicate semver is
provided, the backend will auto-increment the
revision field of the release. A composite
release.version field is also added, which has a raw
field with the complete unique version of the release.
Also deprecates the release.release_version property.

Change-type: minor
Depends-on: https://github.com/balena-io/balena-api/pull/3249
See: https://www.flowdock.com/app/rulemotion/r-supervisor/threads/JN2-gnspQ-v6WaeWCvm9T8NYDY1
HQ: https://jel.ly.fish/8ea1c390-9a85-402d-978c-4d31dcb0d235
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
