### PR TITLE
Add contract partial based instruction generation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -246,7 +246,7 @@ const sdk = fromSharedOptions();
             * [.getDashboardUrl(uuid)](#balena.models.device.getDashboardUrl) ⇒ <code>String</code>
             * [.getAll([options])](#balena.models.device.getAll) ⇒ <code>Promise</code>
             * [.getAllByApplication(slugOrUuidOrId, [options])](#balena.models.device.getAllByApplication) ⇒ <code>Promise</code>
-            * [.getAllByParentDevice(parentUuidOrId, [options])](#balena.models.device.getAllByParentDevice) ⇒ <code>Promise</code>
+            * ~~[.getAllByParentDevice(parentUuidOrId, [options])](#balena.models.device.getAllByParentDevice) ⇒ <code>Promise</code>~~
             * [.get(uuidOrId, [options])](#balena.models.device.get) ⇒ <code>Promise</code>
             * [.getWithServiceDetails(uuidOrId, [options])](#balena.models.device.getWithServiceDetails) ⇒ <code>Promise</code>
             * [.getByName(name)](#balena.models.device.getByName) ⇒ <code>Promise</code>
@@ -315,7 +315,7 @@ const sdk = fromSharedOptions();
             * [.getBySlugOrName(slugOrName)](#balena.models.deviceType.getBySlugOrName) ⇒ <code>Promise</code>
             * [.getName(deviceTypeSlug)](#balena.models.deviceType.getName) ⇒ <code>Promise</code>
             * [.getSlugByName(deviceTypeName)](#balena.models.deviceType.getSlugByName) ⇒ <code>Promise</code>
-            * [.getInterpolatedPartials(deviceTypeSlug, initial)](#balena.models.deviceType.getInterpolatedPartials) ⇒ <code>Promise</code>
+            * [.getInterpolatedPartials(deviceTypeSlug)](#balena.models.deviceType.getInterpolatedPartials) ⇒ <code>Promise</code>
             * [.getInstructions(deviceTypeSlug)](#balena.models.deviceType.getInstructions) ⇒ <code>Promise</code>
             * [.getInstallMethod(deviceTypeSlug)](#balena.models.deviceType.getInstallMethod) ⇒ <code>Promise</code>
         * [.apiKey](#balena.models.apiKey) : <code>object</code>
@@ -393,6 +393,9 @@ const sdk = fromSharedOptions();
         * [.image](#balena.models.image) : <code>object</code>
             * [.get(id, [options])](#balena.models.image.get) ⇒ <code>Promise</code>
             * [.getLogs(id)](#balena.models.image.getLogs) ⇒ <code>Promise</code>
+        * [.creditBundle](#balena.models.creditBundle) : <code>object</code>
+            * [.getAllByOrg(orgId, [options])](#balena.models.creditBundle.getAllByOrg) ⇒ <code>Promise</code>
+            * [.create(orgId, featureId, creditsToPurchase)](#balena.models.creditBundle.create) ⇒ <code>Promise</code>
         * [.billing](#balena.models.billing) : <code>object</code>
             * [.getAccount(organization)](#balena.models.billing.getAccount) ⇒ <code>Promise</code>
             * [.getPlan(organization)](#balena.models.billing.getPlan) ⇒ <code>Promise</code>
@@ -644,7 +647,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.getDashboardUrl(uuid)](#balena.models.device.getDashboardUrl) ⇒ <code>String</code>
         * [.getAll([options])](#balena.models.device.getAll) ⇒ <code>Promise</code>
         * [.getAllByApplication(slugOrUuidOrId, [options])](#balena.models.device.getAllByApplication) ⇒ <code>Promise</code>
-        * [.getAllByParentDevice(parentUuidOrId, [options])](#balena.models.device.getAllByParentDevice) ⇒ <code>Promise</code>
+        * ~~[.getAllByParentDevice(parentUuidOrId, [options])](#balena.models.device.getAllByParentDevice) ⇒ <code>Promise</code>~~
         * [.get(uuidOrId, [options])](#balena.models.device.get) ⇒ <code>Promise</code>
         * [.getWithServiceDetails(uuidOrId, [options])](#balena.models.device.getWithServiceDetails) ⇒ <code>Promise</code>
         * [.getByName(name)](#balena.models.device.getByName) ⇒ <code>Promise</code>
@@ -713,7 +716,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.getBySlugOrName(slugOrName)](#balena.models.deviceType.getBySlugOrName) ⇒ <code>Promise</code>
         * [.getName(deviceTypeSlug)](#balena.models.deviceType.getName) ⇒ <code>Promise</code>
         * [.getSlugByName(deviceTypeName)](#balena.models.deviceType.getSlugByName) ⇒ <code>Promise</code>
-        * [.getInterpolatedPartials(deviceTypeSlug, initial)](#balena.models.deviceType.getInterpolatedPartials) ⇒ <code>Promise</code>
+        * [.getInterpolatedPartials(deviceTypeSlug)](#balena.models.deviceType.getInterpolatedPartials) ⇒ <code>Promise</code>
         * [.getInstructions(deviceTypeSlug)](#balena.models.deviceType.getInstructions) ⇒ <code>Promise</code>
         * [.getInstallMethod(deviceTypeSlug)](#balena.models.deviceType.getInstallMethod) ⇒ <code>Promise</code>
     * [.apiKey](#balena.models.apiKey) : <code>object</code>
@@ -791,6 +794,9 @@ balena.models.device.get(123).catch(function (error) {
     * [.image](#balena.models.image) : <code>object</code>
         * [.get(id, [options])](#balena.models.image.get) ⇒ <code>Promise</code>
         * [.getLogs(id)](#balena.models.image.getLogs) ⇒ <code>Promise</code>
+    * [.creditBundle](#balena.models.creditBundle) : <code>object</code>
+        * [.getAllByOrg(orgId, [options])](#balena.models.creditBundle.getAllByOrg) ⇒ <code>Promise</code>
+        * [.create(orgId, featureId, creditsToPurchase)](#balena.models.creditBundle.create) ⇒ <code>Promise</code>
     * [.billing](#balena.models.billing) : <code>object</code>
         * [.getAccount(organization)](#balena.models.billing.getAccount) ⇒ <code>Promise</code>
         * [.getPlan(organization)](#balena.models.billing.getPlan) ⇒ <code>Promise</code>
@@ -2565,7 +2571,7 @@ balena.models.application.revokeSupportAccess('myorganization/myapp', function(e
     * [.getDashboardUrl(uuid)](#balena.models.device.getDashboardUrl) ⇒ <code>String</code>
     * [.getAll([options])](#balena.models.device.getAll) ⇒ <code>Promise</code>
     * [.getAllByApplication(slugOrUuidOrId, [options])](#balena.models.device.getAllByApplication) ⇒ <code>Promise</code>
-    * [.getAllByParentDevice(parentUuidOrId, [options])](#balena.models.device.getAllByParentDevice) ⇒ <code>Promise</code>
+    * ~~[.getAllByParentDevice(parentUuidOrId, [options])](#balena.models.device.getAllByParentDevice) ⇒ <code>Promise</code>~~
     * [.get(uuidOrId, [options])](#balena.models.device.get) ⇒ <code>Promise</code>
     * [.getWithServiceDetails(uuidOrId, [options])](#balena.models.device.getWithServiceDetails) ⇒ <code>Promise</code>
     * [.getByName(name)](#balena.models.device.getByName) ⇒ <code>Promise</code>
@@ -3396,7 +3402,9 @@ balena.models.device.getAllByApplication('myorganization/myapp', function(error,
 ```
 <a name="balena.models.device.getAllByParentDevice"></a>
 
-##### device.getAllByParentDevice(parentUuidOrId, [options]) ⇒ <code>Promise</code>
+##### ~~device.getAllByParentDevice(parentUuidOrId, [options]) ⇒ <code>Promise</code>~~
+***Deprecated***
+
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
 **Summary**: Get all devices by parent device  
 **Access**: public  
@@ -5222,7 +5230,7 @@ balena.models.device.restartService('7cf02a6', 123, function(error) {
     * [.getBySlugOrName(slugOrName)](#balena.models.deviceType.getBySlugOrName) ⇒ <code>Promise</code>
     * [.getName(deviceTypeSlug)](#balena.models.deviceType.getName) ⇒ <code>Promise</code>
     * [.getSlugByName(deviceTypeName)](#balena.models.deviceType.getSlugByName) ⇒ <code>Promise</code>
-    * [.getInterpolatedPartials(deviceTypeSlug, initial)](#balena.models.deviceType.getInterpolatedPartials) ⇒ <code>Promise</code>
+    * [.getInterpolatedPartials(deviceTypeSlug)](#balena.models.deviceType.getInterpolatedPartials) ⇒ <code>Promise</code>
     * [.getInstructions(deviceTypeSlug)](#balena.models.deviceType.getInstructions) ⇒ <code>Promise</code>
     * [.getInstallMethod(deviceTypeSlug)](#balena.models.deviceType.getInstallMethod) ⇒ <code>Promise</code>
 
@@ -5407,7 +5415,7 @@ balena.models.deviceType.getSlugByName('Raspberry Pi', function(error, deviceTyp
 ```
 <a name="balena.models.deviceType.getInterpolatedPartials"></a>
 
-##### deviceType.getInterpolatedPartials(deviceTypeSlug, initial) ⇒ <code>Promise</code>
+##### deviceType.getInterpolatedPartials(deviceTypeSlug) ⇒ <code>Promise</code>
 **Kind**: static method of [<code>deviceType</code>](#balena.models.deviceType)  
 **Summary**: Get a contract with resolved partial templates  
 **Access**: public  
@@ -5416,7 +5424,6 @@ balena.models.deviceType.getSlugByName('Raspberry Pi', function(error, deviceTyp
 | Param | Type | Description |
 | --- | --- | --- |
 | deviceTypeSlug | <code>String</code> | device type slug |
-| initial | <code>any</code> | Other contract values necessary for interpreting contracts |
 
 **Example**  
 ```js
@@ -7382,6 +7389,54 @@ balena.models.image.getLogs(123).then(function(logs) {
 balena.models.image.getLogs(123, function(error, logs) {
 	if (error) throw error;
 	console.log(logs);
+});
+```
+<a name="balena.models.creditBundle"></a>
+
+#### models.creditBundle : <code>object</code>
+**Kind**: static namespace of [<code>models</code>](#balena.models)  
+
+* [.creditBundle](#balena.models.creditBundle) : <code>object</code>
+    * [.getAllByOrg(orgId, [options])](#balena.models.creditBundle.getAllByOrg) ⇒ <code>Promise</code>
+    * [.create(orgId, featureId, creditsToPurchase)](#balena.models.creditBundle.create) ⇒ <code>Promise</code>
+
+<a name="balena.models.creditBundle.getAllByOrg"></a>
+
+##### creditBundle.getAllByOrg(orgId, [options]) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>creditBundle</code>](#balena.models.creditBundle)  
+**Summary**: Get all of the credit bundles purchased by the given org  
+**Access**: public  
+**Fulfil**: <code>Object[]</code> - credit bundles  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| orgId | <code>String</code> \| <code>Number</code> |  | handle (string) or id (number) of the target organization. |
+| [options] | <code>Object</code> | <code>{}</code> | extra pine options to use |
+
+**Example**  
+```js
+balena.models.creditBundle.getAllByOrg(orgId).then(function(creditBundles) {
+	console.log(creditBundles);
+});
+```
+<a name="balena.models.creditBundle.create"></a>
+
+##### creditBundle.create(orgId, featureId, creditsToPurchase) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>creditBundle</code>](#balena.models.creditBundle)  
+**Summary**: Purchase a credit bundle for the given feature and org of the given quantity  
+**Access**: public  
+**Fulfil**: <code>Object[]</code> - credit bundles  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| orgId | <code>String</code> \| <code>Number</code> | handle (string) or id (number) of the target organization. |
+| featureId | <code>String</code> \| <code>Number</code> | id (number) of the feature for which credits are being purchased. |
+| creditsToPurchase | <code>String</code> \| <code>Number</code> | number of credits being purchased. |
+
+**Example**  
+```js
+balena.models.creditBundle.create(orgId, featureId, creditsToPurchase).then(function(creditBundle) {
+	console.log(creditBundle);
 });
 ```
 <a name="balena.models.billing"></a>

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -315,6 +315,9 @@ const sdk = fromSharedOptions();
             * [.getBySlugOrName(slugOrName)](#balena.models.deviceType.getBySlugOrName) ⇒ <code>Promise</code>
             * [.getName(deviceTypeSlug)](#balena.models.deviceType.getName) ⇒ <code>Promise</code>
             * [.getSlugByName(deviceTypeName)](#balena.models.deviceType.getSlugByName) ⇒ <code>Promise</code>
+            * [.getInterpolatedPartials(deviceTypeSlug, initial)](#balena.models.deviceType.getInterpolatedPartials) ⇒ <code>Promise</code>
+            * [.getInstructions(deviceTypeSlug)](#balena.models.deviceType.getInstructions) ⇒ <code>Promise</code>
+            * [.getInstallMethod(deviceTypeSlug)](#balena.models.deviceType.getInstallMethod) ⇒ <code>Promise</code>
         * [.apiKey](#balena.models.apiKey) : <code>object</code>
             * [.create(name, [description])](#balena.models.apiKey.create) ⇒ <code>Promise</code>
             * [.getAll([options])](#balena.models.apiKey.getAll) ⇒ <code>Promise</code>
@@ -710,6 +713,9 @@ balena.models.device.get(123).catch(function (error) {
         * [.getBySlugOrName(slugOrName)](#balena.models.deviceType.getBySlugOrName) ⇒ <code>Promise</code>
         * [.getName(deviceTypeSlug)](#balena.models.deviceType.getName) ⇒ <code>Promise</code>
         * [.getSlugByName(deviceTypeName)](#balena.models.deviceType.getSlugByName) ⇒ <code>Promise</code>
+        * [.getInterpolatedPartials(deviceTypeSlug, initial)](#balena.models.deviceType.getInterpolatedPartials) ⇒ <code>Promise</code>
+        * [.getInstructions(deviceTypeSlug)](#balena.models.deviceType.getInstructions) ⇒ <code>Promise</code>
+        * [.getInstallMethod(deviceTypeSlug)](#balena.models.deviceType.getInstallMethod) ⇒ <code>Promise</code>
     * [.apiKey](#balena.models.apiKey) : <code>object</code>
         * [.create(name, [description])](#balena.models.apiKey.create) ⇒ <code>Promise</code>
         * [.getAll([options])](#balena.models.apiKey.getAll) ⇒ <code>Promise</code>
@@ -5216,6 +5222,9 @@ balena.models.device.restartService('7cf02a6', 123, function(error) {
     * [.getBySlugOrName(slugOrName)](#balena.models.deviceType.getBySlugOrName) ⇒ <code>Promise</code>
     * [.getName(deviceTypeSlug)](#balena.models.deviceType.getName) ⇒ <code>Promise</code>
     * [.getSlugByName(deviceTypeName)](#balena.models.deviceType.getSlugByName) ⇒ <code>Promise</code>
+    * [.getInterpolatedPartials(deviceTypeSlug, initial)](#balena.models.deviceType.getInterpolatedPartials) ⇒ <code>Promise</code>
+    * [.getInstructions(deviceTypeSlug)](#balena.models.deviceType.getInstructions) ⇒ <code>Promise</code>
+    * [.getInstallMethod(deviceTypeSlug)](#balena.models.deviceType.getInstallMethod) ⇒ <code>Promise</code>
 
 <a name="balena.models.deviceType.get"></a>
 
@@ -5394,6 +5403,73 @@ balena.models.deviceType.getSlugByName('Raspberry Pi', function(error, deviceTyp
 	if (error) throw error;
 	console.log(deviceTypeSlug);
 	// raspberry-pi
+});
+```
+<a name="balena.models.deviceType.getInterpolatedPartials"></a>
+
+##### deviceType.getInterpolatedPartials(deviceTypeSlug, initial) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>deviceType</code>](#balena.models.deviceType)  
+**Summary**: Get a contract with resolved partial templates  
+**Access**: public  
+**Fulfil**: <code>Contract</code> - device type contract with resolved partials  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| deviceTypeSlug | <code>String</code> | device type slug |
+| initial | <code>any</code> | Other contract values necessary for interpreting contracts |
+
+**Example**  
+```js
+balena.models.deviceType.getInterpolatedPartials('raspberry-pi').then(function(contract) {
+ for (const partial in contract.partials) {
+ 	console.log(`${partial}: ${contract.partials[partial]}`);
+ }
+	// bootDevice: ["Connect power to the Raspberry Pi (v1 / Zero / Zero W)"]
+});
+```
+<a name="balena.models.deviceType.getInstructions"></a>
+
+##### deviceType.getInstructions(deviceTypeSlug) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>deviceType</code>](#balena.models.deviceType)  
+**Summary**: Get instructions for installing a host OS on a given device type  
+**Access**: public  
+**Fulfil**: <code>String[]</code> - step by step instructions for installing the host OS to the device  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| deviceTypeSlug | <code>String</code> | device type slug |
+
+**Example**  
+```js
+balena.models.deviceType.getInstructions('raspberry-pi').then(function(instructions) {
+ for (let instruction of instructions.values()) {
+	 console.log(instruction);
+ }
+ // Insert the sdcard to the host machine.
+ // Write the BalenaOS file you downloaded to the sdcard. We recommend using <a href="http://www.etcher.io/">Etcher</a>.
+ // Wait for writing of BalenaOS to complete.
+ // Remove the sdcard from the host machine.
+ // Insert the freshly flashed sdcard into the Raspberry Pi (v1 / Zero / Zero W).
+ // Connect power to the Raspberry Pi (v1 / Zero / Zero W) to boot the device.
+});
+```
+<a name="balena.models.deviceType.getInstallMethod"></a>
+
+##### deviceType.getInstallMethod(deviceTypeSlug) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>deviceType</code>](#balena.models.deviceType)  
+**Summary**: Get installation method on a given device type  
+**Access**: public  
+**Fulfil**: <code>String</code> - the installation method supported for the given device type slug  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| deviceTypeSlug | <code>String</code> | device type slug |
+
+**Example**  
+```js
+balena.models.deviceType.getInstallMethod('raspberry-pi').then(function(method) {
+	console.log(method);
+ // externalBoot
 });
 ```
 <a name="balena.models.apiKey"></a>

--- a/lib/models/balenaos-contract.ts
+++ b/lib/models/balenaos-contract.ts
@@ -1,0 +1,76 @@
+import { Contract } from '../types/contract';
+
+// Hardcoded host OS contract, this should be moved to the Yocto build process with meta-balena.
+// Here for initial implementatin and testing purposes
+const BalenaOS: Contract = {
+	name: 'balenaOS',
+	slug: 'balenaos',
+	type: 'sw.os',
+	description: 'Balena OS',
+	partials: {
+		image: [`{{#each deviceType.partials.instructions}}{{{this}}} {{/each}}`],
+		internalFlash: [
+			`{{#each deviceType.partials.connectDevice}}{{{this}}} {{/each}}`,
+			`Write the {{name}} file you downloaded to the {{deviceType.name}}. We recommend using <a href="http://www.etcher.io/">Etcher</a>.`,
+			`Wait for writing of {{name}} to complete.`,
+			`{{#each deviceType.partials.disconnectDevice}}{{{this}}} {{/each}}`,
+			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
+		],
+		externalFlash: [
+			`Insert the {{deviceType.data.media.altBoot.[0]}} to the host machine.`,
+			`Write the {{name}} file you downloaded to the {{deviceType.data.media.altBoot.[0]}}. We recommend using <a href="http://www.etcher.io/">Etcher</a>.`,
+			`Wait for writing of {{name}} to complete.`,
+			`Remove the {{deviceType.data.media.altBoot.[0]}} from the host machine.`,
+			`Insert the freshly flashed {{deviceType.data.media.altBoot.[0]}} into the {{deviceType.name}}.`,
+			`<strong role="alert">Warning!</strong> This will also completely erase internal storage medium, so please make a backup first.`,
+			`{{#each deviceType.partials.bootDeviceExternal}}{{{this}}} {{/each}}`,
+			`Wait for the {{deviceType.name}} to finish flashing and shutdown. {{#if deviceType.partials.flashIndicator}}Please wait until {{deviceType.partials.flashIndicator}}.{{/if}}`,
+			`Remove the {{deviceType.data.media.altBoot.[0]}} from the {{deviceType.name}}.`,
+			`{{#each deviceType.partials.bootDeviceInternal}}{{{this}}} {{/each}}`,
+			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
+		],
+		externalBoot: [
+			`Insert the {{deviceType.data.media.defaultBoot}} to the host machine.`,
+			`Write the {{name}} file you downloaded to the {{deviceType.data.media.defaultBoot}}. We recommend using <a href="http://www.etcher.io/">Etcher</a>.`,
+			`Wait for writing of {{name}} to complete.`,
+			`Remove the {{deviceType.data.media.defaultBoot}} from the host machine.`,
+			`Insert the freshly flashed {{deviceType.data.media.defaultBoot}} into the {{deviceType.name}}.`,
+			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
+		],
+		jetsonFlash: [
+			`Put the device in recovery mode and connect to the host computer via USB`,
+			`{{#if deviceType.partials.jetsonNotes}}{{#each deviceType.partials.jetsonNotes}}{{{this}}} {{/each}}{{/if}}`,
+			`Unzip the {{name}} image and use the Jetson Flash tool to flash the {{deviceType.name}} found at <a href="https://github.com/balena-os/jetson-flash">https://github.com/balena-os/jetson-flash</a>.`,
+			`Wait for writing of {{name}} to complete.`,
+			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
+		],
+		edisonFlash: {
+			Linux: [
+				`{{#each deviceType.partials.Linux.flashDependencies}}{{{this}}} {{/each}}`,
+				`Unplug the {{deviceType.name}} from your system`,
+				`Unzip the downloaded {{name}} file`,
+				`{{#each deviceType.partials.Linux.flashInstructions}}{{{this}}} {{/each}}`,
+				`Plug the {{deviceType.name}} as per the instructions on your terminal.`,
+				`You can check the progress of the provisioning on your terminal.`,
+			],
+			MacOS: [
+				`{{#each deviceType.partials.MacOS.flashDependencies}}{{{this}}} {{/each}}`,
+				`Unplug the {{deviceType.name}} from your system`,
+				`Unzip the downloaded {{name}} file`,
+				`{{#each deviceType.partials.MacOS.flashInstructions}}{{{this}}} {{/each}}`,
+				`Plug the {{deviceType.name}} as per the instructions on your terminal.`,
+				`You can check the progress of the provisioning on your terminal.`,
+			],
+			Windows: [
+				`{{#each deviceType.partials.Windows.flashDependencies}}{{{this}}} {{/each}}`,
+				`Unplug the {{deviceType.name}} from your system`,
+				`Unzip the downloaded {{name}} file`,
+				`{{#each deviceType.partials.Windows.flashInstructions}}{{{this}}} {{/each}}`,
+				`Plug the {{deviceType.name}} as per the instructions on your terminal.`,
+				`You can check the progress of the provisioning on your terminal.`,
+			],
+		},
+	},
+};
+
+export { BalenaOS };

--- a/lib/models/device-type.ts
+++ b/lib/models/device-type.ts
@@ -16,8 +16,75 @@ limitations under the License.
 
 import type { InjectedDependenciesParam, PineOptions } from '..';
 import { DeviceType } from '../types/models';
+import { Partials, Contract } from '../types/contract';
 import { mergePineOptions } from '../util';
 import * as errors from 'balena-errors';
+import * as Handlebars from 'handlebars';
+import cloneDeep = require('lodash/cloneDeep');
+
+// REPLACE ONCE HOST OS CONTRACTS ARE GENERATED THROUGH YOCTO
+import { BalenaOS } from './balenaos-contract';
+
+const traversingCompile = (
+	partials: Partials,
+	initial: Contract,
+	path: string[],
+): Contract => {
+	let interpolated: Contract = { ...initial }
+	for (const partialKey of Object.keys(partials)) {
+		const current = partials[partialKey];
+		if (Array.isArray(current)) {
+			let location: any = interpolated;
+			for (const key of path) {
+				location = location[key];
+			}
+			// if array of partials, compile the template
+			location[partialKey] = current
+				.map((partial) => Handlebars.compile(partial)(interpolated))
+				.filter((n) => n);
+		} else {
+			// if it's another dictionary, keep traversing
+			interpolated = traversingCompile(
+				current,
+				interpolated,
+				path.concat([partialKey]),
+			);
+		}
+	}
+	return interpolated;
+}
+
+const interpolatedPartials = (contract: Contract): Contract => {
+	if (contract.partials) {
+		return traversingCompile(contract.partials, contract, ['partials']);
+	} else {
+		return contract;
+	}
+};
+
+const calculateInstallMethod = (contract: Contract): string => {
+	const flashProtocol = contract.data?.flashProtocol;
+	const defaultBoot = contract.data?.media?.defaultBoot;
+	if (flashProtocol) {
+		if (flashProtocol === 'RPIBOOT') {
+			return 'internalFlash';
+		} else {
+			return flashProtocol;
+		}
+	} else if (defaultBoot) {
+		if (defaultBoot === 'image') {
+			return 'image';
+		} else if (defaultBoot === 'internal') {
+			return 'externalFlash';
+		} else {
+			return 'externalBoot';
+		}
+	} else {
+		throw new errors.BalenaError(
+			`Unable to determine installation method for contract: ${contract.slug}`,
+		);
+	}
+};
 
 const getDeviceTypeModel = function (deps: InjectedDependenciesParam) {
 	const { pine } = deps;
@@ -322,6 +389,109 @@ const getDeviceTypeModel = function (deps: InjectedDependenciesParam) {
 			return (
 				await exports.getBySlugOrName(deviceTypeName, { $select: 'slug' })
 			).slug;
+		},
+
+		/**
+		 * @summary Get a contract with resolved partial templates
+		 * @name getInterpolatedPartials
+		 * @public
+		 * @function
+		 * @memberof balena.models.deviceType
+		 *
+		 * @param {String} deviceTypeSlug - device type slug
+		 * @fulfil {Contract} - device type contract with resolved partials
+		 * @returns {Promise}
+		 *
+		 * @example
+		 * balena.models.deviceType.getInterpolatedPartials('raspberry-pi').then(function(contract) {
+		 *  for (const partial in contract.partials) {
+		 *  	console.log(`${partial}: ${contract.partials[partial]}`);
+		 *  }
+		 * 	// bootDevice: ["Connect power to the Raspberry Pi (v1 / Zero / Zero W)"]
+		 * });
+		 */
+		getInterpolatedPartials: async (
+			deviceTypeSlug: string,
+		): Promise<Contract> => {
+			const { contract } = await exports.getBySlugOrName(deviceTypeSlug, {
+				$select: 'contract',
+			});
+			if (!contract) {
+				throw new Error(`Could not find contract for device type ${deviceTypeSlug}`);
+			}
+			return interpolatedPartials(contract);
+		},
+
+		/**
+		 * @summary Get instructions for installing a host OS on a given device type
+		 * @name getInstructions
+		 * @public
+		 * @function
+		 * @memberof balena.models.deviceType
+		 *
+		 * @param {String} deviceTypeSlug - device type slug
+		 * @fulfil {String[]} - step by step instructions for installing the host OS to the device
+		 * @returns {Promise}
+		 *
+		 * @example
+		 * balena.models.deviceType.getInstructions('raspberry-pi').then(function(instructions) {
+		 *  for (let instruction of instructions.values()) {
+		 * 	 console.log(instruction);
+		 *  }
+		 *  // Insert the sdcard to the host machine.
+		 *  // Write the BalenaOS file you downloaded to the sdcard. We recommend using <a href="http://www.etcher.io/">Etcher</a>.
+		 *  // Wait for writing of BalenaOS to complete.
+		 *  // Remove the sdcard from the host machine.
+		 *  // Insert the freshly flashed sdcard into the Raspberry Pi (v1 / Zero / Zero W).
+		 *  // Connect power to the Raspberry Pi (v1 / Zero / Zero W) to boot the device.
+		 * });
+		 */
+		getInstructions: async (
+			deviceTypeSlug: string,
+		): Promise<any | string[]> => {
+			const { contract } = await exports.getBySlugOrName(deviceTypeSlug, {
+				$select: 'contract',
+			});
+			if (!contract || !contract.partials) {
+				throw new Error(
+					`Instruction partials not defined for ${deviceTypeSlug}`,
+				);
+			}
+			const installMethod = calculateInstallMethod(contract);
+			const interpolatedDeviceType = interpolatedPartials(contract);
+			const interpolatedHostOS = interpolatedPartials({...cloneDeep(BalenaOS), ...interpolatedDeviceType});
+
+			return interpolatedHostOS.partials?.[installMethod];
+		},
+
+		/**
+		 * @summary Get installation method on a given device type
+		 * @name getInstallMethod
+		 * @public
+		 * @function
+		 * @memberof balena.models.deviceType
+		 *
+		 * @param {String} deviceTypeSlug - device type slug
+		 * @fulfil {String} - the installation method supported for the given device type slug
+		 * @returns {Promise}
+		 *
+		 * @example
+		 * balena.models.deviceType.getInstallMethod('raspberry-pi').then(function(method) {
+		 * 	console.log(method);
+		 *  // externalBoot
+		 * });
+		 */
+		getInstallMethod: async (
+			deviceTypeSlug: string,
+		): Promise<string | null> => {
+			const { contract } = await exports.getBySlugOrName(deviceTypeSlug, {
+				$select: 'contract',
+			});
+			if (contract) {
+				return calculateInstallMethod(contract);
+			} else {
+				return null;
+			}
 		},
 	};
 

--- a/lib/models/device-type.ts
+++ b/lib/models/device-type.ts
@@ -30,7 +30,7 @@ const traversingCompile = (
 	initial: Contract,
 	path: string[],
 ): Contract => {
-	let interpolated: Contract = { ...initial }
+	let interpolated: Contract = { ...initial };
 	for (const partialKey of Object.keys(partials)) {
 		const current = partials[partialKey];
 		if (Array.isArray(current)) {
@@ -52,7 +52,7 @@ const traversingCompile = (
 		}
 	}
 	return interpolated;
-}
+};
 
 const interpolatedPartials = (contract: Contract): Contract => {
 	if (contract.partials) {
@@ -417,7 +417,9 @@ const getDeviceTypeModel = function (deps: InjectedDependenciesParam) {
 				$select: 'contract',
 			});
 			if (!contract) {
-				throw new Error(`Could not find contract for device type ${deviceTypeSlug}`);
+				throw new Error(
+					`Could not find contract for device type ${deviceTypeSlug}`,
+				);
 			}
 			return interpolatedPartials(contract);
 		},
@@ -458,8 +460,13 @@ const getDeviceTypeModel = function (deps: InjectedDependenciesParam) {
 				);
 			}
 			const installMethod = calculateInstallMethod(contract);
-			const interpolatedDeviceType = interpolatedPartials(contract);
-			const interpolatedHostOS = interpolatedPartials({...cloneDeep(BalenaOS), ...interpolatedDeviceType});
+			const interpolatedDeviceType = {
+				deviceType: interpolatedPartials(contract),
+			};
+			const interpolatedHostOS = interpolatedPartials({
+				...cloneDeep(BalenaOS),
+				...interpolatedDeviceType,
+			});
 
 			return interpolatedHostOS.partials?.[installMethod];
 		},

--- a/lib/types/contract.ts
+++ b/lib/types/contract.ts
@@ -1,4 +1,6 @@
-import { AnyObject } from '../../typings/utils';
+import { AnyObject, Dictionary } from '../../typings/utils';
+
+export type Partials = Dictionary<string[] | Partials>;
 
 export interface Contract {
 	slug: string;
@@ -15,5 +17,5 @@ export interface Contract {
 	requires?: string[];
 	provides?: string[];
 	composedOf?: AnyObject;
-	partials?: AnyObject;
+	partials?: Partials;
 }

--- a/lib/types/device-type-json.ts
+++ b/lib/types/device-type-json.ts
@@ -6,7 +6,7 @@ export interface DeviceType {
 	slug: string;
 	name: string;
 	aliases: string[];
-	
+
 	arch: string;
 	state?: string;
 	community?: boolean;

--- a/lib/types/device-type-json.ts
+++ b/lib/types/device-type-json.ts
@@ -6,7 +6,7 @@ export interface DeviceType {
 	slug: string;
 	name: string;
 	aliases: string[];
-
+	
 	arch: string;
 	state?: string;
 	community?: boolean;

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "balena-semver": "^2.3.0",
     "balena-settings-client": "^4.0.6",
     "date-fns": "^2.29.3",
+    "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "memoizee": "^0.4.15",
     "ndjson": "^2.0.0",

--- a/tests/integration/models/device-type.spec.ts
+++ b/tests/integration/models/device-type.spec.ts
@@ -7,6 +7,7 @@ import type * as BalenaSdk from '../../..';
 const DEVICE_TYPE_NAME = 'Raspberry Pi 2';
 const DEVICE_TYPE_SLUG = 'raspberry-pi2';
 const DEVICE_TYPE_ALIAS = 'raspberrypi2';
+const DEVICE_TYPE_INSTALL_METHOD = 'externalBoot';
 const DEVICE_TYPE_ID = 1;
 
 describe('Device Type model', function () {
@@ -89,6 +90,35 @@ describe('Device Type model', function () {
 				DEVICE_TYPE_NAME,
 			);
 			expect(slug).to.equal(DEVICE_TYPE_SLUG);
+		});
+	});
+
+	parallel('balena.models.deviceType.getInterpolatedPartials()', function () {
+		it(`should get just the device type partials with template strings resolved`, async function () {
+			const partials = await balena.models.deviceType.getInterpolatedPartials(
+				DEVICE_TYPE_NAME,
+			);
+			expect(partials).to.be.an('object');
+			expect(Object.keys(partials)).to.not.have.length(0);
+		});
+	});
+
+	parallel('balena.models.deviceType.getInstructions()', function () {
+		it(`should get just the full instructions for installing BalenaOS on a device type with templates strings resolved`, async function () {
+			const partials = await balena.models.deviceType.getInstructions(
+				DEVICE_TYPE_NAME,
+			);
+			expect(partials).to.be.an('Array');
+			expect(partials).to.not.have.length(0);
+		});
+	});
+
+	parallel('balena.models.deviceType.getInstallMethod()', function () {
+		it(`should get device type installation method`, async function () {
+			const installMethod = await balena.models.deviceType.getInstallMethod(
+				DEVICE_TYPE_NAME,
+			);
+			expect(installMethod).to.equal(DEVICE_TYPE_INSTALL_METHOD);
 		});
 	});
 });

--- a/tests/integration/models/device-type.spec.ts
+++ b/tests/integration/models/device-type.spec.ts
@@ -100,6 +100,12 @@ describe('Device Type model', function () {
 			);
 			expect(partials).to.be.an('object');
 			expect(Object.keys(partials)).to.not.have.length(0);
+			expect(partials)
+				.to.have.property('partials')
+				.to.have.property('bootDevice');
+			expect(partials?.partials?.bootDevice[0]).to.equal(
+				'Connect power to the Raspberry Pi 2',
+			);
 		});
 	});
 
@@ -110,6 +116,14 @@ describe('Device Type model', function () {
 			);
 			expect(partials).to.be.an('Array');
 			expect(partials).to.not.have.length(0);
+			expect(partials).to.eql([
+				'Insert the sdcard to the host machine.',
+				'Write the balenaOS file you downloaded to the sdcard. We recommend using <a href="http://www.etcher.io/">Etcher</a>.',
+				'Wait for writing of balenaOS to complete.',
+				'Remove the sdcard from the host machine.',
+				'Insert the freshly flashed sdcard into the Raspberry Pi 2.',
+				'Connect power to the Raspberry Pi 2 to boot the device.',
+			]);
 		});
 	});
 


### PR DESCRIPTION
This is an initial implementation of a basic API call to interpolate partials within a contract. Discussion is needed to address the HostOS contract that is currently hard-coded (should be pulled from somewhere else). Also, this functionality applies not just to device types, but any contract could potentially have partials that need to be interpolated. There currently isn't a place to handle such abstract functionality in the SDK (to my knowledge) and it seems like this would be a good place to use Contrato as it is going to be (should be) the de facto implementation of the Contract data structure and operations surrounding them. It might be better for the partial interpolation to live there and then anything that is contract based in the SDK have the ability to use Contrato types and functionality.

This will also be able to easily fix the current issue where the instructions are not correct in BalenaHub and open fleets since new devices added do not appear in the dashboard. This will allow different interfaces and uses of the partials to provide their own overarching template (Discussion for this specific issue on Flowdock: https://www.flowdock.com/app/rulemotion/balenahub/threads/UQ29ow3_IXlkXMOnzT-ea9H6V-q).
https://balena.zulipchat.com/#narrow/stream/349104-balena-io.2Fcontracts/topic/contract.20partial.20based.20instruction.20generation

### TODO

- [x] Updating the contracts repo to have necessary partials
- [x] Improve implementation to handle the few edge cases that don't fall under the usual Etcher based install methods
  - [x] Fix cases with nested instructions like having different instructions for linux/mac/windows

Depends-on: https://github.com/balena-io/contracts/pull/236
Change-type: minor

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests
- [x] Includes typings
- [x] Includes updated documentation
- [ ] Includes updated build output
