### PR TITLE
Update generateProvisioningKey to include keyName

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -153,7 +153,7 @@ const sdk = fromSharedOptions();
             * [.rename(nameOrSlugOrId, newName)](#balena.models.application.rename) ⇒ <code>Promise</code>
             * [.restart(nameOrSlugOrId)](#balena.models.application.restart) ⇒ <code>Promise</code>
             * ~~[.generateApiKey(nameOrSlugOrId)](#balena.models.application.generateApiKey) ⇒ <code>Promise</code>~~
-            * [.generateProvisioningKey(nameOrSlugOrId)](#balena.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
+            * [.generateProvisioningKey(nameOrSlugOrId, [keyName])](#balena.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
             * [.purge(appId)](#balena.models.application.purge) ⇒ <code>Promise</code>
             * [.shutdown(appId, [options])](#balena.models.application.shutdown) ⇒ <code>Promise</code>
             * [.reboot(appId, [options])](#balena.models.application.reboot) ⇒ <code>Promise</code>
@@ -524,7 +524,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.rename(nameOrSlugOrId, newName)](#balena.models.application.rename) ⇒ <code>Promise</code>
         * [.restart(nameOrSlugOrId)](#balena.models.application.restart) ⇒ <code>Promise</code>
         * ~~[.generateApiKey(nameOrSlugOrId)](#balena.models.application.generateApiKey) ⇒ <code>Promise</code>~~
-        * [.generateProvisioningKey(nameOrSlugOrId)](#balena.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
+        * [.generateProvisioningKey(nameOrSlugOrId, [keyName])](#balena.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
         * [.purge(appId)](#balena.models.application.purge) ⇒ <code>Promise</code>
         * [.shutdown(appId, [options])](#balena.models.application.shutdown) ⇒ <code>Promise</code>
         * [.reboot(appId, [options])](#balena.models.application.reboot) ⇒ <code>Promise</code>
@@ -768,7 +768,7 @@ balena.models.device.get(123).catch(function (error) {
     * [.rename(nameOrSlugOrId, newName)](#balena.models.application.rename) ⇒ <code>Promise</code>
     * [.restart(nameOrSlugOrId)](#balena.models.application.restart) ⇒ <code>Promise</code>
     * ~~[.generateApiKey(nameOrSlugOrId)](#balena.models.application.generateApiKey) ⇒ <code>Promise</code>~~
-    * [.generateProvisioningKey(nameOrSlugOrId)](#balena.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
+    * [.generateProvisioningKey(nameOrSlugOrId, [keyName])](#balena.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
     * [.purge(appId)](#balena.models.application.purge) ⇒ <code>Promise</code>
     * [.shutdown(appId, [options])](#balena.models.application.shutdown) ⇒ <code>Promise</code>
     * [.reboot(appId, [options])](#balena.models.application.reboot) ⇒ <code>Promise</code>
@@ -2052,7 +2052,7 @@ balena.models.application.generateApiKey('MyApp', function(error, apiKey) {
 ```
 <a name="balena.models.application.generateProvisioningKey"></a>
 
-##### application.generateProvisioningKey(nameOrSlugOrId) ⇒ <code>Promise</code>
+##### application.generateProvisioningKey(nameOrSlugOrId, [keyName]) ⇒ <code>Promise</code>
 **Kind**: static method of [<code>application</code>](#balena.models.application)  
 **Summary**: Generate a device provisioning key for a specific application  
 **Access**: public  
@@ -2061,6 +2061,7 @@ balena.models.application.generateApiKey('MyApp', function(error, apiKey) {
 | Param | Type | Description |
 | --- | --- | --- |
 | nameOrSlugOrId | <code>String</code> \| <code>Number</code> | application name (string) (deprecated), slug (string) or id (number) |
+| [keyName] | <code>String</code> | Provisioning key name |
 
 **Example**  
 ```js

--- a/lib/models/application.ts
+++ b/lib/models/application.ts
@@ -940,6 +940,7 @@ const getApplicationModel = function (
 		 * @memberof balena.models.application
 		 *
 		 * @param {String|Number} nameOrSlugOrId - application name (string) (deprecated), slug (string) or id (number)
+		 * @param {String} [keyName] - Provisioning key name
 		 * @fulfil {String} - device provisioning key
 		 * @returns {Promise}
 		 *
@@ -961,13 +962,20 @@ const getApplicationModel = function (
 		 */
 		generateProvisioningKey: async (
 			nameOrSlugOrId: string | number,
+			keyName?: string,
 		): Promise<string> => {
 			try {
 				const applicationId = await getId(nameOrSlugOrId);
 				const { body } = await request.send({
 					method: 'POST',
-					url: `/api-key/application/${applicationId}/provisioning`,
+					url: '/api-key/v1/',
 					baseUrl: apiUrl,
+					body: {
+						actorType: 'application',
+						actorTypeId: applicationId,
+						roles: ['provisioning-api-key'],
+						name: keyName,
+					},
 				});
 				return body;
 			} catch (err) {


### PR DESCRIPTION
Change-Type: patch
Signed-off-by: Nitish Agarwal 1592163+nitishagar@users.noreply.github.com

HQ: https://jel.ly.fish/e450713f-001c-4470-b571-71724aeb0869
See: https://www.flowdock.com/app/rulemotion/r-product/threads/DZt_LvQvMCOoN6p2EceSu6MG4MF
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/IPdnkCLH2G0o7DSlkSS9nRetA4f

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Includes tests 
- [ ] Includes typings
- [x] Includes updated documentation
- [ ] Includes updated build output

Note: The test here are not retrieving key and checking the assigned name, but checking on whether we can set a value with the new API call.