### PR TITLE
os.getConfig: Add typings for the provisioningKeyName option

### DIFF
--- a/lib/models/os.ts
+++ b/lib/models/os.ts
@@ -30,6 +30,7 @@ const BALENAOS_VERSION_REGEX = /v?\d+\.\d+\.\d+(\.rev\d+)?((\-|\+).+)?/;
 export interface ImgConfigOptions {
 	network?: 'ethernet' | 'wifi';
 	appUpdatePollInterval?: number;
+	provisioningKeyName?: string;
 	wifiKey?: string;
 	wifiSsid?: string;
 	ip?: string;
@@ -483,6 +484,7 @@ const getOsModel = function (
 	 * the device will use, one of 'ethernet' or 'wifi'.
 	 * @param {Number} [options.appUpdatePollInterval] - How often the OS checks
 	 * for updates, in minutes.
+	 * @param {String} [options.provisioningKeyName] - Name assigned to API key
 	 * @param {String} [options.wifiKey] - The key for the wifi network the
 	 * device will connect to.
 	 * @param {String} [options.wifiSsid] - The ssid for the wifi network the

--- a/tests/integration/models/os.spec.ts
+++ b/tests/integration/models/os.spec.ts
@@ -664,6 +664,36 @@ describe('OS model', function () {
 					});
 			});
 
+			it('should be able to configure v2 image with a provisioning key name', async function () {
+				const provisioningKeyName = `provision-key-${new Date()}`;
+				const configOptions = {
+					appUpdatePollInterval: 72,
+					network: 'wifi' as const,
+					wifiKey: 'foobar',
+					wifiSsid: 'foobarbaz',
+					ip: '1.2.3.4',
+					gateway: '5.6.7.8',
+					netmask: '9.10.11.12',
+					version: '2.11.8+rev1.prod',
+					provisioningKeyName,
+				};
+
+				await balena.models.os.getConfig(ctx.application.id, configOptions);
+
+				const provisioningKeys = _.filter(
+					await balena.models.apiKey.getProvisioningApiKeysByApplication(
+						ctx.application.id,
+					),
+					['name', provisioningKeyName],
+				);
+
+				expect(provisioningKeys).to.be.an('array');
+				expect(provisioningKeys.length).is.equal(1);
+				expect(provisioningKeys[0])
+					.to.have.property('name')
+					.to.be.equal(provisioningKeyName);
+			});
+
 			it('should be rejected if the application id does not exist', function () {
 				const promise = balena.models.os.getConfig(999999, {
 					version: DEFAULT_OS_VERSION,


### PR DESCRIPTION
Change-Type: minor
Signed-off-by: Nitish Agarwal <1592163+nitishagar@users.noreply.github.com>

HQ: https://jel.ly.fish/e450713f-001c-4470-b571-71724aeb0869
See: https://www.flowdock.com/app/rulemotion/r-product/threads/DZt_LvQvMCOoN6p2EceSu6MG4MF
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/IPdnkCLH2G0o7DSlkSS9nRetA4f
Depends-on: https://github.com/balena-io/open-balena-api/pull/716
Depends-on: https://github.com/balena-io/balena-api/pull/3298

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
