### PR TITLE
apiKey.getAll: Return only NamedUserApiKeys for backwards compatibility

### DIFF
--- a/lib/models/api-key.ts
+++ b/lib/models/api-key.ts
@@ -110,26 +110,10 @@ const getApiKeysModel = function (
 		 * 	console.log(apiKeys);
 		 * });
 		 */
-		getAll(
+		async getAll(
 			options: BalenaSdk.PineOptions<BalenaSdk.ApiKey> = {},
 		): Promise<BalenaSdk.ApiKey[]> {
-			return pine.get({
-				resource: 'api_key',
-				options: mergePineOptions(
-					{
-						// the only way to reason whether
-						// it's a named user api key is whether
-						// it has a name
-						$filter: {
-							name: {
-								$ne: null,
-							},
-						},
-						$orderby: 'name asc',
-					},
-					options,
-				),
-			});
+			return await exports.getAllNamedUserApiKeys(options);
 		},
 
 		/**


### PR DESCRIPTION
So far `getAll()` was only returning named user api keys. With the current code, once we add support for naming provisioning api keys as well, `getAll()` will start returning those as well. but not the non-named ones, which would lead to confusion.
Changing it to return all apiKeys should better be in the next major, so the safest thing to do for users of the current major is probably to change it so that it will only be returning named user api keys, like it always did.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
