### PR TITLE
**BREAKING** Include invalidated versions in hostapp.getAllOsVersions()

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -307,6 +307,7 @@ const sdk = fromSharedOptions();
             * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
         * [.hostapp](#balena.models.hostapp) : <code>object</code>
             * [.getAllOsVersions(deviceTypes, [options])](#balena.models.hostapp.getAllOsVersions) ⇒ <code>Promise</code>
+            * [.getAvailableOsVersions(deviceTypes)](#balena.models.hostapp.getAvailableOsVersions) ⇒ <code>Promise</code>
         * [.config](#balena.models.config) : <code>object</code>
             * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
             * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
@@ -681,6 +682,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
     * [.hostapp](#balena.models.hostapp) : <code>object</code>
         * [.getAllOsVersions(deviceTypes, [options])](#balena.models.hostapp.getAllOsVersions) ⇒ <code>Promise</code>
+        * [.getAvailableOsVersions(deviceTypes)](#balena.models.hostapp.getAvailableOsVersions) ⇒ <code>Promise</code>
     * [.config](#balena.models.config) : <code>object</code>
         * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
         * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
@@ -6325,6 +6327,11 @@ console.log(result2);
 **Beta** The hostapp methods are still in beta and might change in a non-major release.
 
 **Kind**: static namespace of [<code>models</code>](#balena.models)  
+
+* [.hostapp](#balena.models.hostapp) : <code>object</code>
+    * [.getAllOsVersions(deviceTypes, [options])](#balena.models.hostapp.getAllOsVersions) ⇒ <code>Promise</code>
+    * [.getAvailableOsVersions(deviceTypes)](#balena.models.hostapp.getAvailableOsVersions) ⇒ <code>Promise</code>
+
 <a name="balena.models.hostapp.getAllOsVersions"></a>
 
 ##### hostapp.getAllOsVersions(deviceTypes, [options]) ⇒ <code>Promise</code>
@@ -6344,6 +6351,21 @@ balena.models.hostapp.getAllOsVersions(['fincm3', 'raspberrypi3']);
 **Example**  
 ```js
 balena.models.hostapp.getAllOsVersions(['fincm3', 'raspberrypi3'], { $filter: { is_invalidated: false } });
+```
+<a name="balena.models.hostapp.getAvailableOsVersions"></a>
+
+##### hostapp.getAvailableOsVersions(deviceTypes) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>hostapp</code>](#balena.models.hostapp)  
+**Summary**: Get all non-invalidated OS versions for the passed device types  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| deviceTypes | <code>Array.&lt;String&gt;</code> | device type slugs |
+
+**Example**  
+```js
+balena.models.hostapp.getAvailableOsVersions(['fincm3', 'raspberrypi3']);
 ```
 <a name="balena.models.config"></a>
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -306,7 +306,7 @@ const sdk = fromSharedOptions();
             * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
             * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
         * [.hostapp](#balena.models.hostapp) : <code>object</code>
-            * [.getAllOsVersions(deviceTypes)](#balena.models.hostapp.getAllOsVersions) ⇒ <code>Promise</code>
+            * [.getAllOsVersions(deviceTypes, [options])](#balena.models.hostapp.getAllOsVersions) ⇒ <code>Promise</code>
         * [.config](#balena.models.config) : <code>object</code>
             * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
             * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
@@ -680,7 +680,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
         * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
     * [.hostapp](#balena.models.hostapp) : <code>object</code>
-        * [.getAllOsVersions(deviceTypes)](#balena.models.hostapp.getAllOsVersions) ⇒ <code>Promise</code>
+        * [.getAllOsVersions(deviceTypes, [options])](#balena.models.hostapp.getAllOsVersions) ⇒ <code>Promise</code>
     * [.config](#balena.models.config) : <code>object</code>
         * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
         * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
@@ -6327,18 +6327,23 @@ console.log(result2);
 **Kind**: static namespace of [<code>models</code>](#balena.models)  
 <a name="balena.models.hostapp.getAllOsVersions"></a>
 
-##### hostapp.getAllOsVersions(deviceTypes) ⇒ <code>Promise</code>
+##### hostapp.getAllOsVersions(deviceTypes, [options]) ⇒ <code>Promise</code>
 **Kind**: static method of [<code>hostapp</code>](#balena.models.hostapp)  
 **Summary**: Get all OS versions for the passed device types  
 **Access**: public  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| deviceTypes | <code>Array.&lt;String&gt;</code> | device type slugs |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| deviceTypes | <code>Array.&lt;String&gt;</code> |  | device type slugs |
+| [options] | <code>Object</code> | <code>{}</code> | extra pine options to use |
 
 **Example**  
 ```js
 balena.models.hostapp.getAllOsVersions(['fincm3', 'raspberrypi3']);
+```
+**Example**  
+```js
+balena.models.hostapp.getAllOsVersions(['fincm3', 'raspberrypi3'], { $filter: { is_invalidated: false } });
 ```
 <a name="balena.models.config"></a>
 

--- a/lib/models/device.ts
+++ b/lib/models/device.ts
@@ -2525,7 +2525,7 @@ const getDeviceModel = function (
 			exports._checkOsUpdateTarget(device, targetOsVersion);
 
 			const osVersions = (
-				await hostappModel().getAllOsVersions([
+				await hostappModel().getAvailableOsVersions([
 					device.is_of__device_type[0].slug,
 				])
 			)[device.is_of__device_type[0].slug];

--- a/lib/models/hostapp.ts
+++ b/lib/models/hostapp.ts
@@ -195,9 +195,6 @@ const getHostappModel = function (deps: InjectedDependenciesParam) {
 								$select: ['tag_key', 'value'],
 							},
 						},
-						$filter: {
-							is_invalidated: false,
-						},
 					},
 				},
 				$filter: {

--- a/lib/models/hostapp.ts
+++ b/lib/models/hostapp.ts
@@ -236,6 +236,14 @@ const getHostappModel = function (deps: InjectedDependenciesParam) {
 		},
 	);
 
+	const memoizedGetAllValidOsVersions = authDependentMemoizer(
+		async (deviceTypes: string[]) => {
+			return await getAllOsVersionsBase(deviceTypes, {
+				$filter: { is_invalidated: false },
+			});
+		},
+	);
+
 	/**
 	 * @summary Get all OS versions for the passed device types
 	 * @name getAllOsVersions
@@ -264,11 +272,28 @@ const getHostappModel = function (deps: InjectedDependenciesParam) {
 		return await getAllOsVersionsBase(deviceTypes, options);
 	};
 
+	/**
+	 * @summary Get all non-invalidated OS versions for the passed device types
+	 * @name getAvailableOsVersions
+	 * @public
+	 * @function
+	 * @memberof balena.models.hostapp
+	 *
+	 * @param {String[]} deviceTypes - device type slugs
+	 * @returns {Promise}
+	 *
+	 * @example
+	 * balena.models.hostapp.getAvailableOsVersions(['fincm3', 'raspberrypi3']);
+	 */
+	const getAvailableOsVersions = async (deviceTypes: string[]) => {
+		const sortedDeviceTypes = deviceTypes.sort();
+		return await memoizedGetAllValidOsVersions(sortedDeviceTypes);
+	};
+
 	return {
 		OsTypes,
 		getAllOsVersions,
-		// TODO: The current implementation will be available as getAvailableOsVersions in the next major
-		getAvailableOsVersions: getAllOsVersions,
+		getAvailableOsVersions,
 	};
 };
 

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -74,6 +74,14 @@ export const treatAsMissingDevice = (uuidOrId: string | number, err: Error) => {
 	throw replacementErr;
 };
 
+// TODO: Make it so that it also infers the extras param
+export function mergePineOptionsTyped<
+	R,
+	P extends Pine.ODataOptionsWithSelect<R>,
+>(defaults: P, extras: Pine.ODataOptions<R> | undefined): P {
+	return mergePineOptions(defaults, extras) as P;
+}
+
 // Merging two sets of pine options sensibly is more complicated than it sounds.
 //
 // The general rules are:

--- a/tests/integration/models/hostapp.spec.ts
+++ b/tests/integration/models/hostapp.spec.ts
@@ -62,10 +62,10 @@ describe('Hostapp model', function () {
 		it('should return an empty object for non-existent DTs', async () => {
 			const res = await balena.models.hostapp.getAllOsVersions(['blahbleh']);
 
-			return expect(res).to.deep.equal({});
+			expect(res).to.deep.equal({});
 		});
 
-		it('should cache the results', async () => {
+		it('should cache the results when not providing extra options', async () => {
 			const firstRes = await balena.models.hostapp.getAllOsVersions([
 				'raspberrypi3',
 			]);
@@ -73,6 +73,18 @@ describe('Hostapp model', function () {
 				'raspberrypi3',
 			]);
 			expect(firstRes).to.equal(secondRes);
+		});
+
+		it('should cache the results when providing extra options', async () => {
+			const firstRes = await balena.models.hostapp.getAllOsVersions(
+				['raspberrypi3'],
+				{ $filter: { is_invalidated: false } },
+			);
+			const secondRes = await balena.models.hostapp.getAllOsVersions(
+				['raspberrypi3'],
+				{ $filter: { is_invalidated: false } },
+			);
+			expect(firstRes).to.not.equal(secondRes);
 		});
 	});
 });

--- a/tests/integration/models/hostapp.spec.ts
+++ b/tests/integration/models/hostapp.spec.ts
@@ -75,7 +75,7 @@ describe('Hostapp model', function () {
 			expect(firstRes).to.equal(secondRes);
 		});
 
-		it('should cache the results when providing extra options', async () => {
+		it('should not cache the results when providing extra options', async () => {
 			const firstRes = await balena.models.hostapp.getAllOsVersions(
 				['raspberrypi3'],
 				{ $filter: { is_invalidated: false } },
@@ -85,6 +85,67 @@ describe('Hostapp model', function () {
 				{ $filter: { is_invalidated: false } },
 			);
 			expect(firstRes).to.not.equal(secondRes);
+		});
+	});
+
+	parallel('balena.models.hostapp.getAvailableOsVersions()', function () {
+		it("should contain both balenaOS and balenaOS ESR OS types'", async () => {
+			const res = await balena.models.hostapp.getAvailableOsVersions([
+				'fincm3',
+				'raspberrypi3',
+			]);
+
+			containsVersion(res['fincm3'], {
+				strippedVersion: '2.29.0+rev1',
+				variant: 'dev',
+			});
+			containsVersion(res['fincm3'], {
+				strippedVersion: '2.29.0+rev1',
+				variant: 'prod',
+			});
+			containsVersion(res['fincm3'], {
+				strippedVersion: '2020.04.0',
+				variant: 'dev',
+			});
+			containsVersion(res['fincm3'], {
+				strippedVersion: '2020.04.0',
+				variant: 'prod',
+			});
+
+			containsVersion(res['raspberrypi3'], {
+				strippedVersion: '2.29.0+rev1',
+				variant: 'dev',
+			});
+			containsVersion(res['raspberrypi3'], {
+				strippedVersion: '2.29.0+rev1',
+				variant: 'prod',
+			});
+			containsVersion(res['raspberrypi3'], {
+				strippedVersion: '2020.04.0',
+				variant: 'dev',
+			});
+			containsVersion(res['raspberrypi3'], {
+				strippedVersion: '2020.04.0',
+				variant: 'prod',
+			});
+		});
+
+		it('should return an empty object for non-existent DTs', async () => {
+			const res = await balena.models.hostapp.getAvailableOsVersions([
+				'blahbleh',
+			]);
+
+			expect(res).to.deep.equal({});
+		});
+
+		it('should cache the results', async () => {
+			const firstRes = await balena.models.hostapp.getAvailableOsVersions([
+				'raspberrypi3',
+			]);
+			const secondRes = await balena.models.hostapp.getAvailableOsVersions([
+				'raspberrypi3',
+			]);
+			expect(firstRes).to.equal(secondRes);
 		});
 	});
 });


### PR DESCRIPTION
Required for the release invalidation & feed spec, according to which the UI will offer an option to show invalidated releases as well.

Change-type: major
See: https://jel.ly.fish/1c3fbd90-422e-48b5-8679-ab205c33d6b5
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
