### PR TITLE
typings: Drop the v5-model-only application_type.is_host_os

### DIFF
--- a/lib/types/models.ts
+++ b/lib/types/models.ts
@@ -259,7 +259,6 @@ export interface ApplicationType {
 	requires_payment: boolean;
 	needs__os_version_range: string | null;
 	maximum_device_count: number | null;
-	is_host_os: boolean;
 }
 
 export interface ApplicationHostedOnApplication {


### PR DESCRIPTION
This is no longer a property in the v6 model and we forgot to drop it when we upgraded the SDK to v6.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
