### PR TITLE
application.isTrackingLatestRelease & application.trackLatestRelease: Fix using draft/invalidated releases

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2187,7 +2187,7 @@ balena.models.application.willTrackNewReleases('MyApp', function(error, isEnable
 
 ##### application.isTrackingLatestRelease(nameOrSlugOrId) ⇒ <code>Promise</code>
 **Kind**: static method of [<code>application</code>](#balena.models.application)  
-**Summary**: Get whether the application is up to date and is tracking the latest release for updates  
+**Summary**: Get whether the application is up to date and is tracking the latest finalized release for updates  
 **Access**: public  
 **Fulfil**: <code>Boolean</code> - is tracking the latest release  
 
@@ -6266,6 +6266,7 @@ generation is only supported when using a session token, not an API key.
 | options.version | <code>String</code> |  | Required: the OS version of the image. |
 | [options.network] | <code>String</code> | <code>&#x27;ethernet&#x27;</code> | The network type that the device will use, one of 'ethernet' or 'wifi'. |
 | [options.appUpdatePollInterval] | <code>Number</code> |  | How often the OS checks for updates, in minutes. |
+| [options.provisioningKeyName] | <code>String</code> |  | Name assigned to API key |
 | [options.wifiKey] | <code>String</code> |  | The key for the wifi network the device will connect to. |
 | [options.wifiSsid] | <code>String</code> |  | The ssid for the wifi network the device will connect to. |
 | [options.ip] | <code>String</code> |  | static ip address. |
@@ -6814,7 +6815,7 @@ balena.models.release.createFromUrl('MyApp', { url: 'https://github.com/balena-i
 
 ##### release.finalize(commitOrId) ⇒ <code>Promise</code>
 **Kind**: static method of [<code>release</code>](#balena.models.release)  
-**Summary**: Promotes a 'draft' release to 'final' (non-draft)  
+**Summary**: Finalizes a draft release  
 **Access**: public  
 **Fulfil**: <code>void</code>  
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2283,7 +2283,7 @@ balena.models.application.getTargetReleaseHash('MyApp', function(release) {
 The application's current release will be updated with each new successfully built release.
 
 **Kind**: static method of [<code>application</code>](#balena.models.application)  
-**Summary**: Configure a specific application to track the latest available release  
+**Summary**: Configure a specific application to track the latest finalized available release  
 **Access**: public  
 
 | Param | Type | Description |

--- a/lib/models/application.ts
+++ b/lib/models/application.ts
@@ -1287,7 +1287,7 @@ const getApplicationModel = function (
 		},
 
 		/**
-		 * @summary Configure a specific application to track the latest available release
+		 * @summary Configure a specific application to track the latest finalized available release
 		 * @name trackLatestRelease
 		 * @public
 		 * @function
@@ -1324,6 +1324,9 @@ const getApplicationModel = function (
 						$select: 'id',
 						$top: 1,
 						$filter: {
+							is_final: true,
+							is_passing_tests: true,
+							is_invalidated: false,
 							status: 'success',
 						},
 						$orderby: 'created_at desc',

--- a/lib/models/application.ts
+++ b/lib/models/application.ts
@@ -1134,7 +1134,7 @@ const getApplicationModel = function (
 		},
 
 		/**
-		 * @summary Get whether the application is up to date and is tracking the latest release for updates
+		 * @summary Get whether the application is up to date and is tracking the latest finalized release for updates
 		 * @name isTrackingLatestRelease
 		 * @public
 		 * @function
@@ -1170,6 +1170,9 @@ const getApplicationModel = function (
 						$select: 'id',
 						$top: 1,
 						$filter: {
+							is_final: true,
+							is_passing_tests: true,
+							is_invalidated: false,
 							status: 'success',
 						},
 						$orderby: 'created_at desc',

--- a/tests/integration/models/application.spec.js
+++ b/tests/integration/models/application.spec.js
@@ -1289,39 +1289,34 @@ describe('Application Model', function () {
 					});
 
 					describe('balena.models.application.trackLatestRelease()', () => {
-						it('...should re-enable latest release tracking', function () {
-							return balena.models.application
-								.isTrackingLatestRelease(this.application.id)
-								.then((result) => {
-									expect(result).to.be.false;
+						it('...should re-enable latest release tracking', async function () {
+							expect(
+								await balena.models.application.isTrackingLatestRelease(
+									this.application.id,
+								),
+							).to.be.false;
 
-									return balena.models.application.trackLatestRelease(
-										this.application.id,
-									);
-								})
-								.then(() => {
-									const promise =
-										balena.models.application.getTargetReleaseHash(
-											this.application.id,
-										);
-									return expect(promise).to.eventually.equal(
-										'new-release-commit',
-									);
-								})
-								.then(() => {
-									const promise =
-										balena.models.application.willTrackNewReleases(
-											this.application.id,
-										);
-									return expect(promise).to.eventually.be.true;
-								})
-								.then(() => {
-									const promise =
-										balena.models.application.isTrackingLatestRelease(
-											this.application.id,
-										);
-									return expect(promise).to.eventually.be.true;
-								});
+							await balena.models.application.trackLatestRelease(
+								this.application.id,
+							);
+
+							expect(
+								await balena.models.application.getTargetReleaseHash(
+									this.application.id,
+								),
+							).to.equal('new-release-commit');
+
+							expect(
+								await balena.models.application.willTrackNewReleases(
+									this.application.id,
+								),
+							).to.be.true;
+
+							expect(
+								await balena.models.application.isTrackingLatestRelease(
+									this.application.id,
+								),
+							).to.be.true;
 						});
 					});
 
@@ -1376,6 +1371,42 @@ describe('Application Model', function () {
 											this.application.id,
 										),
 									).to.equal('new-release-commit');
+
+									expect(
+										await balena.models.application.isTrackingLatestRelease(
+											this.application.id,
+										),
+									).to.be.true;
+								});
+							});
+
+							describe('balena.models.application.trackLatestRelease()', () => {
+								it(`should not use a ${releaseType} releases as the latest`, async function () {
+									await balena.models.application.pinToRelease(
+										this.application.id,
+										'old-release-commit',
+									);
+									expect(
+										await balena.models.application.isTrackingLatestRelease(
+											this.application.id,
+										),
+									).to.be.false;
+
+									await balena.models.application.trackLatestRelease(
+										this.application.id,
+									);
+
+									expect(
+										await balena.models.application.getTargetReleaseHash(
+											this.application.id,
+										),
+									).to.equal('new-release-commit');
+
+									expect(
+										await balena.models.application.willTrackNewReleases(
+											this.application.id,
+										),
+									).to.be.true;
 
 									expect(
 										await balena.models.application.isTrackingLatestRelease(


### PR DESCRIPTION
Aligns the SDK methods with what the how the API picks the latest release of an application.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
