### PR TITLE
application.getAppByName: Add 'directly_accessible' convenience filter

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -145,7 +145,7 @@ const sdk = fromSharedOptions();
             * [.get(slugOrId, [options], [context])](#balena.models.application.get) ⇒ <code>Promise</code>
             * [.getDirectlyAccessible(slugOrId, [options])](#balena.models.application.getDirectlyAccessible) ⇒ <code>Promise</code>
             * [.getWithDeviceServiceDetails(slugOrId, [options])](#balena.models.application.getWithDeviceServiceDetails) ⇒ <code>Promise</code>
-            * [.getAppByName(appName, [options])](#balena.models.application.getAppByName) ⇒ <code>Promise</code>
+            * [.getAppByName(appName, [options], [context])](#balena.models.application.getAppByName) ⇒ <code>Promise</code>
             * [.getAppByOwner(appName, owner, [options])](#balena.models.application.getAppByOwner) ⇒ <code>Promise</code>
             * [.has(slugOrId)](#balena.models.application.has) ⇒ <code>Promise</code>
             * [.hasAny()](#balena.models.application.hasAny) ⇒ <code>Promise</code>
@@ -520,7 +520,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.get(slugOrId, [options], [context])](#balena.models.application.get) ⇒ <code>Promise</code>
         * [.getDirectlyAccessible(slugOrId, [options])](#balena.models.application.getDirectlyAccessible) ⇒ <code>Promise</code>
         * [.getWithDeviceServiceDetails(slugOrId, [options])](#balena.models.application.getWithDeviceServiceDetails) ⇒ <code>Promise</code>
-        * [.getAppByName(appName, [options])](#balena.models.application.getAppByName) ⇒ <code>Promise</code>
+        * [.getAppByName(appName, [options], [context])](#balena.models.application.getAppByName) ⇒ <code>Promise</code>
         * [.getAppByOwner(appName, owner, [options])](#balena.models.application.getAppByOwner) ⇒ <code>Promise</code>
         * [.has(slugOrId)](#balena.models.application.has) ⇒ <code>Promise</code>
         * [.hasAny()](#balena.models.application.hasAny) ⇒ <code>Promise</code>
@@ -766,7 +766,7 @@ balena.models.device.get(123).catch(function (error) {
     * [.get(slugOrId, [options], [context])](#balena.models.application.get) ⇒ <code>Promise</code>
     * [.getDirectlyAccessible(slugOrId, [options])](#balena.models.application.getDirectlyAccessible) ⇒ <code>Promise</code>
     * [.getWithDeviceServiceDetails(slugOrId, [options])](#balena.models.application.getWithDeviceServiceDetails) ⇒ <code>Promise</code>
-    * [.getAppByName(appName, [options])](#balena.models.application.getAppByName) ⇒ <code>Promise</code>
+    * [.getAppByName(appName, [options], [context])](#balena.models.application.getAppByName) ⇒ <code>Promise</code>
     * [.getAppByOwner(appName, owner, [options])](#balena.models.application.getAppByOwner) ⇒ <code>Promise</code>
     * [.has(slugOrId)](#balena.models.application.has) ⇒ <code>Promise</code>
     * [.hasAny()](#balena.models.application.hasAny) ⇒ <code>Promise</code>
@@ -1837,7 +1837,7 @@ balena.models.application.getWithDeviceServiceDetails('myorganization/myapp', fu
 ```
 <a name="balena.models.application.getAppByName"></a>
 
-##### application.getAppByName(appName, [options]) ⇒ <code>Promise</code>
+##### application.getAppByName(appName, [options], [context]) ⇒ <code>Promise</code>
 **Kind**: static method of [<code>application</code>](#balena.models.application)  
 **Summary**: Get a single application using the appname and the handle of the owning organization  
 **Access**: public  
@@ -1847,6 +1847,7 @@ balena.models.application.getWithDeviceServiceDetails('myorganization/myapp', fu
 | --- | --- | --- | --- |
 | appName | <code>String</code> |  | application name |
 | [options] | <code>Object</code> | <code>{}</code> | extra pine options to use |
+| [context] | <code>String</code> |  | extra access filters, undefined or 'directly_accessible' |
 
 **Example**  
 ```js

--- a/lib/models/application.ts
+++ b/lib/models/application.ts
@@ -467,6 +467,7 @@ const getApplicationModel = function (
 		 *
 		 * @param {String} appName - application name
 		 * @param {Object} [options={}] - extra pine options to use
+		 * @param {String} [context] - extra access filters, undefined or 'directly_accessible'
 		 * @fulfil {Object} - application
 		 * @returns {Promise}
 		 *
@@ -478,16 +479,23 @@ const getApplicationModel = function (
 		async getAppByName(
 			appName: string,
 			options?: PineOptions<Application>,
+			context?: 'directly_accessible',
 		): Promise<Application> {
 			if (options == null) {
 				options = {};
 			}
+
+			const accessFilter =
+				context === 'directly_accessible'
+					? isDirectlyAccessibleByUserFilter
+					: null;
 
 			const applications = await pine.get({
 				resource: 'application',
 				options: mergePineOptions(
 					{
 						$filter: {
+							...accessFilter,
 							app_name: appName,
 						},
 					},

--- a/tests/integration/models/application.spec.ts
+++ b/tests/integration/models/application.spec.ts
@@ -497,6 +497,15 @@ describe('Application Model', function () {
 						const app = await balena.models.application.getAppByName('FooBar');
 						expect(app.id).to.equal(ctx.application.id);
 					});
+
+					it('should find the created application [directly_accessible]', async function () {
+						const app = await balena.models.application.getAppByName(
+							'FooBar',
+							{},
+							'directly_accessible',
+						);
+						expect(app.id).to.equal(ctx.application.id);
+					});
 				});
 
 				parallel('balena.models.application.getAppByOwner()', function () {
@@ -1792,7 +1801,7 @@ describe('Application Model', function () {
 				function () {
 					applicationRetrievalFields.forEach((prop) =>
 						$it(
-							`should be able to get the public application by ${prop}`,
+							`should not return the public application by ${prop}`,
 							async function () {
 								const promise = balena.models.application.get(
 									publicApp[prop],
@@ -1826,6 +1835,28 @@ describe('Application Model', function () {
 					);
 				},
 			);
+
+			describe('balena.models.application.getAppByName()', function () {
+				$it(`should be able to get the public application`, async function () {
+					const app = await balena.models.application.getAppByName(
+						publicApp.app_name,
+					);
+					expect(app.id).to.equal(publicApp.id);
+				});
+			});
+
+			describe('balena.models.application.getAppByName() [directly_accessible]', function () {
+				$it(`should not return the public application`, async function () {
+					const promise = balena.models.application.getAppByName(
+						publicApp.app_name,
+						{},
+						'directly_accessible',
+					);
+					await expect(promise).to.eventually.be.rejectedWith(
+						`Application not found: ${publicApp.app_name}`,
+					);
+				});
+			});
 
 			describe('balena.models.application.getAll()', function () {
 				$it('should be able to get the public application', async function () {


### PR DESCRIPTION
Resolves: #1163
See: https://www.flowdock.com/app/rulemotion/i-cli/threads/VnT1qqVb13PkQO_GnPsKZB1l_fZ
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
