### PR TITLE
Alias device.getManifestBySlug as config.getDeviceTypeManifestBySlug

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -309,6 +309,7 @@ const sdk = fromSharedOptions();
         * [.config](#balena.models.config) : <code>object</code>
             * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
             * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
+            * ~~[.getDeviceTypeManifestBySlug(slugOrName)](#balena.models.config.getDeviceTypeManifestBySlug) ⇒ <code>Promise</code>~~
             * [.getDeviceOptions(deviceType)](#balena.models.config.getDeviceOptions) ⇒ <code>Promise</code>
             * [.getConfigVarSchema(deviceType)](#balena.models.config.getConfigVarSchema) ⇒ <code>Promise</code>
         * [.release](#balena.models.release) : <code>object</code>
@@ -684,6 +685,7 @@ balena.models.device.get(123).catch(function (error) {
     * [.config](#balena.models.config) : <code>object</code>
         * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
         * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
+        * ~~[.getDeviceTypeManifestBySlug(slugOrName)](#balena.models.config.getDeviceTypeManifestBySlug) ⇒ <code>Promise</code>~~
         * [.getDeviceOptions(deviceType)](#balena.models.config.getDeviceOptions) ⇒ <code>Promise</code>
         * [.getConfigVarSchema(deviceType)](#balena.models.config.getConfigVarSchema) ⇒ <code>Promise</code>
     * [.release](#balena.models.release) : <code>object</code>
@@ -3920,13 +3922,13 @@ balena.models.device.getSupervisorTargetState('7cf02a6', function(error, state) 
 ***Deprecated***
 
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
-**Summary**: Get a device manifest by slug  
+**Summary**: Get a device type manifest by slug  
 **Access**: public  
-**Fulfil**: <code>Object</code> - device manifest  
+**Fulfil**: <code>Object</code> - device type manifest  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| slugOrName | <code>String</code> | device slug |
+| slugOrName | <code>String</code> | device type slug |
 
 **Example**  
 ```js
@@ -6356,6 +6358,7 @@ console.log(result2);
 * [.config](#balena.models.config) : <code>object</code>
     * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
     * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
+    * ~~[.getDeviceTypeManifestBySlug(slugOrName)](#balena.models.config.getDeviceTypeManifestBySlug) ⇒ <code>Promise</code>~~
     * [.getDeviceOptions(deviceType)](#balena.models.config.getDeviceOptions) ⇒ <code>Promise</code>
     * [.getConfigVarSchema(deviceType)](#balena.models.config.getConfigVarSchema) ⇒ <code>Promise</code>
 
@@ -6400,6 +6403,33 @@ balena.models.config.getDeviceTypes(function(error, deviceTypes) {
 	if (error) throw error;
 	console.log(deviceTypes);
 })
+```
+<a name="balena.models.config.getDeviceTypeManifestBySlug"></a>
+
+##### ~~config.getDeviceTypeManifestBySlug(slugOrName) ⇒ <code>Promise</code>~~
+***Deprecated***
+
+**Kind**: static method of [<code>config</code>](#balena.models.config)  
+**Summary**: Get a device type manifest by slug  
+**Access**: public  
+**Fulfil**: <code>Object</code> - device type manifest  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| slugOrName | <code>String</code> | device type slug |
+
+**Example**  
+```js
+balena.models.config.getDeviceTypeManifestBySlug('raspberry-pi').then(function(manifest) {
+	console.log(manifest);
+});
+```
+**Example**  
+```js
+balena.models.config.getDeviceTypeManifestBySlug('raspberry-pi', function(error, manifest) {
+	if (error) throw error;
+	console.log(manifest);
+});
 ```
 <a name="balena.models.config.getDeviceOptions"></a>
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -216,7 +216,7 @@ const sdk = fromSharedOptions();
             * [.restartApplication(uuidOrId)](#balena.models.device.restartApplication) ⇒ <code>Promise</code>
             * [.getSupervisorTargetState(uuidOrId)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
             * ~~[.getManifestBySlug(slugOrName)](#balena.models.device.getManifestBySlug) ⇒ <code>Promise</code>~~
-            * [.getManifestByApplication(slugOrUuidOrId)](#balena.models.device.getManifestByApplication) ⇒ <code>Promise</code>
+            * ~~[.getManifestByApplication(slugOrUuidOrId)](#balena.models.device.getManifestByApplication) ⇒ <code>Promise</code>~~
             * [.generateUniqueKey()](#balena.models.device.generateUniqueKey) ⇒ <code>String</code>
             * [.register(applicationSlugOrUuidOrId, uuid)](#balena.models.device.register) ⇒ <code>Promise</code>
             * [.generateDeviceKey(uuidOrId)](#balena.models.device.generateDeviceKey) ⇒ <code>Promise</code>
@@ -591,7 +591,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.restartApplication(uuidOrId)](#balena.models.device.restartApplication) ⇒ <code>Promise</code>
         * [.getSupervisorTargetState(uuidOrId)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
         * ~~[.getManifestBySlug(slugOrName)](#balena.models.device.getManifestBySlug) ⇒ <code>Promise</code>~~
-        * [.getManifestByApplication(slugOrUuidOrId)](#balena.models.device.getManifestByApplication) ⇒ <code>Promise</code>
+        * ~~[.getManifestByApplication(slugOrUuidOrId)](#balena.models.device.getManifestByApplication) ⇒ <code>Promise</code>~~
         * [.generateUniqueKey()](#balena.models.device.generateUniqueKey) ⇒ <code>String</code>
         * [.register(applicationSlugOrUuidOrId, uuid)](#balena.models.device.register) ⇒ <code>Promise</code>
         * [.generateDeviceKey(uuidOrId)](#balena.models.device.generateDeviceKey) ⇒ <code>Promise</code>
@@ -2492,7 +2492,7 @@ balena.models.application.revokeSupportAccess('myorganization/myapp', function(e
     * [.restartApplication(uuidOrId)](#balena.models.device.restartApplication) ⇒ <code>Promise</code>
     * [.getSupervisorTargetState(uuidOrId)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
     * ~~[.getManifestBySlug(slugOrName)](#balena.models.device.getManifestBySlug) ⇒ <code>Promise</code>~~
-    * [.getManifestByApplication(slugOrUuidOrId)](#balena.models.device.getManifestByApplication) ⇒ <code>Promise</code>
+    * ~~[.getManifestByApplication(slugOrUuidOrId)](#balena.models.device.getManifestByApplication) ⇒ <code>Promise</code>~~
     * [.generateUniqueKey()](#balena.models.device.generateUniqueKey) ⇒ <code>String</code>
     * [.register(applicationSlugOrUuidOrId, uuid)](#balena.models.device.register) ⇒ <code>Promise</code>
     * [.generateDeviceKey(uuidOrId)](#balena.models.device.generateDeviceKey) ⇒ <code>Promise</code>
@@ -3943,7 +3943,9 @@ balena.models.device.getManifestBySlug('raspberry-pi', function(error, manifest)
 ```
 <a name="balena.models.device.getManifestByApplication"></a>
 
-##### device.getManifestByApplication(slugOrUuidOrId) ⇒ <code>Promise</code>
+##### ~~device.getManifestByApplication(slugOrUuidOrId) ⇒ <code>Promise</code>~~
+***Deprecated***
+
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
 **Summary**: Get a device manifest by application name  
 **Access**: public  

--- a/lib/models/application.ts
+++ b/lib/models/application.ts
@@ -58,8 +58,8 @@ const getApplicationModel = function (
 	const { request, pine } = deps;
 	const { apiUrl } = opts;
 
-	const deviceModel = once(() =>
-		(require('./device') as typeof import('./device')).default(deps, opts),
+	const configModel = once(() =>
+		(require('./config') as typeof import('./config')).default(deps, opts),
 	);
 	const releaseModel = once(() =>
 		(require('./release') as typeof import('./release')).default(deps, opts),
@@ -699,8 +699,8 @@ const getApplicationModel = function (
 				? exports.get(parent, { $select: ['id'] })
 				: undefined;
 
-			const deviceTypeIdPromise = deviceModel()
-				.getManifestBySlug(deviceType)
+			const deviceTypeIdPromise = configModel()
+				.getDeviceTypeManifestBySlug(deviceType)
 				.then(async function ({ slug: deviceTypeSlug }) {
 					if (deviceTypeSlug == null) {
 						throw new errors.BalenaInvalidDeviceType(deviceType);

--- a/lib/models/device.ts
+++ b/lib/models/device.ts
@@ -1402,6 +1402,7 @@ const getDeviceModel = function (
 			return deviceManifest;
 		},
 
+		// TODO: Drop in the next major
 		/**
 		 * @summary Get a device manifest by application name
 		 * @name getManifestByApplication
@@ -1409,6 +1410,7 @@ const getDeviceModel = function (
 		 * @function
 		 * @memberof balena.models.device
 		 *
+		 * @deprecated use balena.models.application.get & balena.models.deviceType.getBySlugOrName
 		 * @param {String|Number} slugOrUuidOrId - application slug (string), uuid (string) or id (number)
 		 * @fulfil {Object} - device manifest
 		 * @returns {Promise}

--- a/lib/models/device.ts
+++ b/lib/models/device.ts
@@ -1364,15 +1364,15 @@ const getDeviceModel = function (
 		},
 
 		/**
-		 * @summary Get a device manifest by slug
+		 * @summary Get a device type manifest by slug
 		 * @name getManifestBySlug
 		 * @public
 		 * @function
 		 * @memberof balena.models.device
 		 *
 		 * @deprecated use balena.models.deviceType.getBySlugOrName
-		 * @param {String} slugOrName - device slug
-		 * @fulfil {Object} - device manifest
+		 * @param {String} slugOrName - device type slug
+		 * @fulfil {Object} - device type manifest
 		 * @returns {Promise}
 		 *
 		 * @example
@@ -1388,19 +1388,9 @@ const getDeviceModel = function (
 		 */
 		getManifestBySlug: async (
 			slugOrName: string,
-		): Promise<DeviceTypeJson.DeviceType> => {
-			const deviceTypes = await configModel().getDeviceTypes();
-			const deviceManifest = deviceTypes.find(
-				(deviceType) =>
-					deviceType.name === slugOrName ||
-					deviceType.slug === slugOrName ||
-					deviceType.aliases?.includes(slugOrName),
-			);
-			if (deviceManifest == null) {
-				throw new errors.BalenaInvalidDeviceType(slugOrName);
-			}
-			return deviceManifest;
-		},
+		): Promise<DeviceTypeJson.DeviceType> =>
+			// TODO: Drop in the next major
+			configModel().getDeviceTypeManifestBySlug(slugOrName),
 
 		// TODO: Drop in the next major
 		/**
@@ -1443,7 +1433,9 @@ const getDeviceModel = function (
 				slugOrUuidOrId,
 				applicationOptions,
 			)) as PineTypedResult<Application, typeof applicationOptions>;
-			return await exports.getManifestBySlug(app.is_for__device_type[0].slug);
+			return await configModel().getDeviceTypeManifestBySlug(
+				app.is_for__device_type[0].slug,
+			);
 		},
 
 		/**

--- a/tests/integration/models/config.spec.ts
+++ b/tests/integration/models/config.spec.ts
@@ -127,6 +127,31 @@ describe('Config Model', function () {
 		});
 	});
 
+	parallel('balena.models.config.getDeviceTypeManifestBySlug()', function () {
+		it('should become the manifest if the slug is valid', async () => {
+			const manifest = await balena.models.config.getDeviceTypeManifestBySlug(
+				'raspberry-pi',
+			);
+			expect(_.isPlainObject(manifest)).to.be.true;
+			expect(manifest.slug).to.exist;
+			expect(manifest.name).to.exist;
+			return expect(manifest.options).to.exist;
+		});
+
+		it('should be rejected if the device slug is invalid', function () {
+			const promise =
+				balena.models.config.getDeviceTypeManifestBySlug('foobar');
+			return expect(promise).to.be.rejectedWith('Invalid device type: foobar');
+		});
+
+		it('should become the manifest given a device type alias', async () => {
+			const manifest = await balena.models.config.getDeviceTypeManifestBySlug(
+				'raspberrypi',
+			);
+			return expect(manifest.slug).to.equal('raspberry-pi');
+		});
+	});
+
 	describe('balena.models.config.getConfigVarSchema()', function () {
 		it('Fetching config var schema without deviceType', async function () {
 			const result = await balena.models.config.getConfigVarSchema();


### PR DESCRIPTION
Also deprecates device.getManifestByApplication().

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
