### PR TITLE
Deprecate the supportsBlink field of the DeviceTypeJson.DeviceType type

### DIFF
--- a/lib/types/device-type-json.ts
+++ b/lib/types/device-type-json.ts
@@ -24,6 +24,7 @@ export interface DeviceType {
 			command: string;
 		}>;
 	};
+	/** @deprecated Use the DeviceType.contract.data.led */
 	supportsBlink?: boolean;
 	yocto: {
 		fstype?: string;


### PR DESCRIPTION
Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-devices/threads/mIiQILpWO_W_GtNgKf0CKoQkL-z
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
