### PR TITLE
Remove unnecessary vpn address filtering when fetching local addresses

### DIFF
--- a/lib/models/device.ts
+++ b/lib/models/device.ts
@@ -916,15 +916,13 @@ const getDeviceModel = function (
 		getLocalIPAddresses: async (
 			uuidOrId: string | number,
 		): Promise<string[]> => {
-			const { is_online, ip_address, vpn_address } = await exports.get(
-				uuidOrId,
-				{ $select: ['is_online', 'ip_address', 'vpn_address'] },
-			);
+			const { is_online, ip_address } = await exports.get(uuidOrId, {
+				$select: ['is_online', 'ip_address'],
+			});
 			if (!is_online) {
 				throw new Error(`The device is offline: ${uuidOrId}`);
 			}
-			const ips = (ip_address ?? '').split(' ');
-			return ips.filter((ip) => ip !== vpn_address);
+			return (ip_address ?? '').split(' ');
 		},
 
 		/**


### PR DESCRIPTION
This has been handled by the supervisor since v2.2.0 / balenaOS v1.14
from 2016-09-23 and is not relevant for any supported devices

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
