### PR TITLE
Add typings for provisioningKeyExpiryDate to os.getConfig and expiryDate to model.apiKey

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -5514,7 +5514,7 @@ balena.models.apiKey.getDeviceApiKeysByDevice(123, function(error, apiKeys) {
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>Number</code> | API key id |
-| apiKeyInfo | <code>Object</code> | an object with the updated name or description |
+| apiKeyInfo | <code>Object</code> | an object with the updated name|description|expiryDate |
 
 **Example**  
 ```js
@@ -5523,6 +5523,10 @@ balena.models.apiKey.update(123, { name: 'updatedName' });
 **Example**  
 ```js
 balena.models.apiKey.update(123, { description: 'updated description' });
+```
+**Example**  
+```js
+balena.models.apiKey.update(123, { expiryDate: '2022-04-29' });
 ```
 **Example**  
 ```js
@@ -6319,6 +6323,7 @@ generation is only supported when using a session token, not an API key.
 | [options.network] | <code>String</code> | <code>&#x27;ethernet&#x27;</code> | The network type that the device will use, one of 'ethernet' or 'wifi'. |
 | [options.appUpdatePollInterval] | <code>Number</code> |  | How often the OS checks for updates, in minutes. |
 | [options.provisioningKeyName] | <code>String</code> |  | Name assigned to API key |
+| [options.provisioningKeyExpiryDate] | <code>String</code> |  | Expiry Date assigned to API key |
 | [options.developmentMode] | <code>Boolean</code> |  | Controls delopment mode for unified balenaOS releases. |
 | [options.wifiKey] | <code>String</code> |  | The key for the wifi network the device will connect to. |
 | [options.wifiSsid] | <code>String</code> |  | The ssid for the wifi network the device will connect to. |

--- a/lib/models/api-key.ts
+++ b/lib/models/api-key.ts
@@ -266,7 +266,7 @@ const getApiKeysModel = function (
 		 * @memberof balena.models.apiKey
 		 *
 		 * @param {Number} id - API key id
-		 * @param {Object} apiKeyInfo - an object with the updated name or description
+		 * @param {Object} apiKeyInfo - an object with the updated name|description|expiryDate
 		 * @returns {Promise}
 		 *
 		 * @example
@@ -274,6 +274,9 @@ const getApiKeysModel = function (
 		 *
 		 * @example
 		 * balena.models.apiKey.update(123, { description: 'updated description' });
+		 *
+		 * @example
+		 * balena.models.apiKey.update(123, { expiryDate: '2022-04-29' });
 		 *
 		 * @example
 		 * balena.models.apiKey.update(123, { name: 'updatedName', description: 'updated description' });
@@ -286,7 +289,11 @@ const getApiKeysModel = function (
 		 */
 		async update(
 			id: number,
-			apiKeyInfo: { name?: string; description?: string | null },
+			apiKeyInfo: {
+				name?: string;
+				description?: string | null;
+				expiryDate?: string | null;
+			},
 		): Promise<void> {
 			if (!apiKeyInfo) {
 				throw new errors.BalenaInvalidParameterError('apiKeyInfo', apiKeyInfo);
@@ -300,6 +307,7 @@ const getApiKeysModel = function (
 			const body = {
 				name: apiKeyInfo.name,
 				description: apiKeyInfo.description,
+				expiry_date: apiKeyInfo.expiryDate,
 			};
 			await pine.patch<BalenaSdk.ApiKey>({
 				resource: 'api_key',

--- a/lib/models/os.ts
+++ b/lib/models/os.ts
@@ -84,6 +84,7 @@ export interface ImgConfigOptions {
 	network?: 'ethernet' | 'wifi';
 	appUpdatePollInterval?: number;
 	provisioningKeyName?: string;
+	provisioningKeyExpiryDate?: string;
 	wifiKey?: string;
 	wifiSsid?: string;
 	ip?: string;
@@ -757,6 +758,7 @@ const getOsModel = function (
 	 * @param {Number} [options.appUpdatePollInterval] - How often the OS checks
 	 * for updates, in minutes.
 	 * @param {String} [options.provisioningKeyName] - Name assigned to API key
+	 * @param {String} [options.provisioningKeyExpiryDate] - Expiry Date assigned to API key
 	 * @param {Boolean} [options.developmentMode] - Controls delopment mode for unified balenaOS releases.
 	 * @param {String} [options.wifiKey] - The key for the wifi network the
 	 * device will connect to.

--- a/lib/types/models.ts
+++ b/lib/types/models.ts
@@ -150,6 +150,7 @@ export interface ApiKey {
 	created_at: string;
 	name: string;
 	description: string | null;
+	expiryDate: string | null;
 
 	is_of__actor: PineDeferred;
 }

--- a/lib/types/models.ts
+++ b/lib/types/models.ts
@@ -150,7 +150,7 @@ export interface ApiKey {
 	created_at: string;
 	name: string;
 	description: string | null;
-	expiryDate: string | null;
+	expiry_date: string | null;
 
 	is_of__actor: PineDeferred;
 }

--- a/tests/integration/models/api-key.spec.ts
+++ b/tests/integration/models/api-key.spec.ts
@@ -266,6 +266,42 @@ describe('API Key model', function () {
 				});
 			});
 
+			it('should not be able to update the expiryDate of an api key to a in-valid date string', async function () {
+				await expect(
+					balena.models.apiKey.update(ctx.namedUserApiKey!.id, {
+						expiryDate: 'in-valid date',
+					}),
+				).to.be.rejected;
+			});
+
+			it('should be able to update the expiryDate of an api key to a valid date string', async function () {
+				const validDate = new Date().toISOString();
+				await balena.models.apiKey.update(ctx.namedUserApiKey!.id, {
+					expiryDate: validDate,
+				});
+
+				const [apiKey] = await balena.models.apiKey.getAll({
+					$filter: { id: ctx.namedUserApiKey!.id },
+				});
+				expect(apiKey).to.deep.match({
+					name: 'updatedApiKeyName',
+					expiry_date: validDate,
+				});
+			});
+
+			it('should be able to update the expiryDate of an api key to null', async function () {
+				await balena.models.apiKey.update(ctx.namedUserApiKey!.id, {
+					expiryDate: null,
+				});
+				const [apiKey] = await balena.models.apiKey.getAll({
+					$filter: { id: ctx.namedUserApiKey!.id },
+				});
+				expect(apiKey).to.deep.match({
+					name: 'updatedApiKeyName',
+					expiry_date: null,
+				});
+			});
+
 			testSet.forEach(([title, ctxPropName]) => {
 				it(`should be able to update the name & description of a(n) ${title} api key`, async function () {
 					await balena.models.apiKey.update(ctx[ctxPropName]!.id, {

--- a/tests/integration/models/os.spec.ts
+++ b/tests/integration/models/os.spec.ts
@@ -999,13 +999,13 @@ describe('OS model', function () {
 				const provisioningKeys =
 					await balena.models.apiKey.getProvisioningApiKeysByApplication(
 						ctx.application.id,
-						{ $filter: { expiryDate: provisioningKeyExpiryDate } },
+						{ $filter: { expiry_date: provisioningKeyExpiryDate } },
 					);
 
 				expect(provisioningKeys).to.be.an('array');
 				expect(provisioningKeys.length).is.equal(1);
 				expect(provisioningKeys[0])
-					.to.have.property('name')
+					.to.have.property('expiry_date')
 					.to.be.equal(provisioningKeyExpiryDate);
 			});
 


### PR DESCRIPTION
Change-Type: minor
Signed-off-by: Nitish Agarwal <1592163+nitishagar@users.noreply.github.com>

HQ: https://jel.ly.fish/e450713f-001c-4470-b571-71724aeb0869
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/vx-rBrpDBqXtkdtMmSU5MmPYSlb
Depends-on: https://github.com/balena-io/open-balena-api/pull/814