### PR TITLE
config.getAll: Deprecate the pubnub property and mark as optional

### DIFF
--- a/lib/models/config.ts
+++ b/lib/models/config.ts
@@ -27,7 +27,8 @@ export interface Config {
 	apiUrl: string;
 	actionsUrl: string;
 	gitServerUrl: string;
-	pubnub: {
+	/** @deprecated */
+	pubnub?: {
 		subscribe_key: string;
 		publish_key: string;
 	};

--- a/tests/integration/models/config.spec.ts
+++ b/tests/integration/models/config.spec.ts
@@ -80,12 +80,6 @@ describe('Config Model', function () {
 					expect(_.isEmpty(config)).to.be.false;
 				}));
 
-			it('should include the pubnub keys', () =>
-				balena.models.config.getAll().then(function ({ pubnub }) {
-					expect(pubnub.publish_key).to.be.a('string').that.has.length(0);
-					expect(pubnub.subscribe_key).to.be.a('string').that.has.length(0);
-				}));
-
 			it('should include the mixpanel token', () =>
 				balena.models.config.getAll().then(function ({ mixpanelToken }) {
 					expect(mixpanelToken).to.be.a('string');


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-io/balena-api/pull/3646
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
