### PR TITLE
Drop the non-populated apiUrl & actionsUrl properties from Config type

### DIFF
--- a/lib/models/config.ts
+++ b/lib/models/config.ts
@@ -24,8 +24,6 @@ export interface Config {
 	deployment: string | null;
 	deviceUrlsBase: string;
 	adminUrl: string;
-	apiUrl: string;
-	actionsUrl: string;
 	gitServerUrl: string;
 	/** @deprecated */
 	pubnub?: {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
