### PR TITLE
Support filtered $count operations inside $filter & $orderby

### DIFF
--- a/lib/util/dependent-resource.ts
+++ b/lib/util/dependent-resource.ts
@@ -50,7 +50,11 @@ export function buildDependentResource<T extends DependentResource>(
 			return pine.get<T>({
 				resource: resourceName,
 				options: mergePineOptions(
-					{ $orderby: { [resourceKeyField]: 'asc' } },
+					{
+						$orderby: {
+							[resourceKeyField]: 'asc',
+						} as PineOptions<T>['$orderby'],
+					},
 					options,
 				),
 			});

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "lodash": "^4.17.21",
     "memoizee": "^0.4.15",
     "ndjson": "^2.0.0",
-    "pinejs-client-core": "^6.9.6",
+    "pinejs-client-core": "^6.12.0",
     "tslib": "^2.1.0"
   },
   "versionist": {

--- a/tests/util.spec.ts
+++ b/tests/util.spec.ts
@@ -2,6 +2,7 @@
 import * as _ from 'lodash';
 import { expect } from 'chai';
 import * as bSemver from 'balena-semver';
+import { Application } from '../lib';
 
 // HACK: Avoid typescript trying to resolve built es2015 files
 const nodeRequire = require;
@@ -39,7 +40,7 @@ describe('Pine option merging', function () {
 	});
 
 	it('overrides top, skip and orderby options', function () {
-		const result = mergePineOptions(
+		const result = mergePineOptions<Application>(
 			{
 				$top: 1,
 				$skip: 2,


### PR DESCRIPTION
Update pinejs-client-core from 6.9.6 to 6.12.0

Change-type: minor

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
