### PR TITLE
add methods necessary for preloading

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -69,6 +69,13 @@ If you feel something is missing, not clear or could be improved, please don't h
 <dd></dd>
 </dl>
 
+## Functions
+
+<dl>
+<dt><a href="#listImagesFromTargetState">listImagesFromTargetState(targetState)</a> ⇒</dt>
+<dd></dd>
+</dl>
+
 <a name="module_balena-sdk"></a>
 
 ## balena-sdk
@@ -265,6 +272,11 @@ const sdk = fromSharedOptions();
             * [.unsetCustomLocation(uuidOrIdOrIds)](#balena.models.device.unsetCustomLocation) ⇒ <code>Promise</code>
             * [.move(uuidOrIdOrIds, applicationSlugOrUuidOrId)](#balena.models.device.move) ⇒ <code>Promise</code>
             * [.getSupervisorTargetState(uuidOrId)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
+            * [.restartApplication(uuidOrId)](#balena.models.device.restartApplication) ⇒ <code>Promise</code>
+            * [.getSupervisorTargetState(uuidOrId, version)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
+            * [.getSupervisorTargetStateForApp(uuidOrId, release)](#balena.models.device.getSupervisorTargetStateForApp) ⇒ <code>Promise</code>
+            * ~~[.getManifestBySlug(slugOrName)](#balena.models.device.getManifestBySlug) ⇒ <code>Promise</code>~~
+            * ~~[.getManifestByApplication(slugOrUuidOrId)](#balena.models.device.getManifestByApplication) ⇒ <code>Promise</code>~~
             * [.generateUniqueKey()](#balena.models.device.generateUniqueKey) ⇒ <code>String</code>
             * [.register(applicationSlugOrUuidOrId, uuid, [deviceTypeSlug])](#balena.models.device.register) ⇒ <code>Promise</code>
             * [.generateDeviceKey(uuidOrId, [keyName], [keyDescription])](#balena.models.device.generateDeviceKey) ⇒ <code>Promise</code>
@@ -358,6 +370,7 @@ const sdk = fromSharedOptions();
             * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
             * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
             * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
+            * [.getSupervisorImageForDT(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDT) ⇒ <code>Promise.&lt;String&gt;</code>
         * [.config](#balena.models.config) : <code>object</code>
             * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
             * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
@@ -663,6 +676,11 @@ balena.models.device.get(123).catch(function (error) {
         * [.unsetCustomLocation(uuidOrIdOrIds)](#balena.models.device.unsetCustomLocation) ⇒ <code>Promise</code>
         * [.move(uuidOrIdOrIds, applicationSlugOrUuidOrId)](#balena.models.device.move) ⇒ <code>Promise</code>
         * [.getSupervisorTargetState(uuidOrId)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
+        * [.restartApplication(uuidOrId)](#balena.models.device.restartApplication) ⇒ <code>Promise</code>
+        * [.getSupervisorTargetState(uuidOrId, version)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
+        * [.getSupervisorTargetStateForApp(uuidOrId, release)](#balena.models.device.getSupervisorTargetStateForApp) ⇒ <code>Promise</code>
+        * ~~[.getManifestBySlug(slugOrName)](#balena.models.device.getManifestBySlug) ⇒ <code>Promise</code>~~
+        * ~~[.getManifestByApplication(slugOrUuidOrId)](#balena.models.device.getManifestByApplication) ⇒ <code>Promise</code>~~
         * [.generateUniqueKey()](#balena.models.device.generateUniqueKey) ⇒ <code>String</code>
         * [.register(applicationSlugOrUuidOrId, uuid, [deviceTypeSlug])](#balena.models.device.register) ⇒ <code>Promise</code>
         * [.generateDeviceKey(uuidOrId, [keyName], [keyDescription])](#balena.models.device.generateDeviceKey) ⇒ <code>Promise</code>
@@ -756,6 +774,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
         * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
         * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
+        * [.getSupervisorImageForDT(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDT) ⇒ <code>Promise.&lt;String&gt;</code>
     * [.config](#balena.models.config) : <code>object</code>
         * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
         * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
@@ -2554,6 +2573,11 @@ balena.models.application.revokeSupportAccess('myorganization/myapp', function(e
     * [.unsetCustomLocation(uuidOrIdOrIds)](#balena.models.device.unsetCustomLocation) ⇒ <code>Promise</code>
     * [.move(uuidOrIdOrIds, applicationSlugOrUuidOrId)](#balena.models.device.move) ⇒ <code>Promise</code>
     * [.getSupervisorTargetState(uuidOrId)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
+    * [.restartApplication(uuidOrId)](#balena.models.device.restartApplication) ⇒ <code>Promise</code>
+    * [.getSupervisorTargetState(uuidOrId, version)](#balena.models.device.getSupervisorTargetState) ⇒ <code>Promise</code>
+    * [.getSupervisorTargetStateForApp(uuidOrId, release)](#balena.models.device.getSupervisorTargetStateForApp) ⇒ <code>Promise</code>
+    * ~~[.getManifestBySlug(slugOrName)](#balena.models.device.getManifestBySlug) ⇒ <code>Promise</code>~~
+    * ~~[.getManifestByApplication(slugOrUuidOrId)](#balena.models.device.getManifestByApplication) ⇒ <code>Promise</code>~~
     * [.generateUniqueKey()](#balena.models.device.generateUniqueKey) ⇒ <code>String</code>
     * [.register(applicationSlugOrUuidOrId, uuid, [deviceTypeSlug])](#balena.models.device.register) ⇒ <code>Promise</code>
     * [.generateDeviceKey(uuidOrId, [keyName], [keyDescription])](#balena.models.device.generateDeviceKey) ⇒ <code>Promise</code>
@@ -3943,7 +3967,7 @@ balena.models.device.move('7cf02a6', 'myorganization/myapp', function(error) {
 ```
 <a name="balena.models.device.getSupervisorTargetState"></a>
 
-##### device.getSupervisorTargetState(uuidOrId) ⇒ <code>Promise</code>
+##### device.getSupervisorTargetState(uuidOrId, version) ⇒ <code>Promise</code>
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
 **Summary**: Get the target supervisor state on a device  
 **Access**: public  
@@ -3951,6 +3975,7 @@ balena.models.device.move('7cf02a6', 'myorganization/myapp', function(error) {
 | Param | Type | Description |
 | --- | --- | --- |
 | uuidOrId | <code>String</code> \| <code>Number</code> | device uuid (string) or id (number) |
+| version | <code>Number</code> | (optional) target state version (2 or 3), default to 2 |
 
 **Example**  
 ```js
@@ -3966,9 +3991,105 @@ balena.models.device.getSupervisorTargetState(123).then(function(state) {
 ```
 **Example**  
 ```js
+balena.models.device.getSupervisorTargetState(123, 3).then(function(state) {
+	console.log(state);
+});
+```
+**Example**  
+```js
 balena.models.device.getSupervisorTargetState('7cf02a6', function(error, state) {
 	if (error) throw error;
 	console.log(state);
+});
+```
+<a name="balena.models.device.getSupervisorTargetStateForApp"></a>
+
+##### device.getSupervisorTargetStateForApp(uuidOrId, release) ⇒ <code>Promise</code>
+**Kind**: static method of [<code>device</code>](#balena.models.device)  
+**Summary**: Get the target supervisor state on a "generic" device on a fleet  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| uuidOrId | <code>String</code> \| <code>Number</code> | fleet uuid (string) or id (number) |
+| release | <code>String</code> | (optional) release uuid (default tracked) |
+
+**Example**  
+```js
+balena.models.device.getSupervisorTargetStateForApp('7cf02a6').then(function(state) {
+	console.log(state);
+});
+```
+**Example**  
+```js
+balena.models.device.getSupervisorTargetStateForApp(123).then(function(state) {
+	console.log(state);
+});
+```
+**Example**  
+```js
+balena.models.device.getSupervisorTargetStateForApp(123, '7cf02a6').then(function(state) {
+	console.log(state);
+});
+```
+<a name="balena.models.device.getManifestBySlug"></a>
+
+##### ~~device.getManifestBySlug(slugOrName) ⇒ <code>Promise</code>~~
+***Deprecated***
+
+**Kind**: static method of [<code>device</code>](#balena.models.device)  
+**Summary**: Get a device type manifest by slug  
+**Access**: public  
+**Fulfil**: <code>Object</code> - device type manifest  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| slugOrName | <code>String</code> | device type slug |
+
+**Example**  
+```js
+balena.models.device.getManifestBySlug('raspberry-pi').then(function(manifest) {
+	console.log(manifest);
+});
+```
+**Example**  
+```js
+balena.models.device.getManifestBySlug('raspberry-pi', function(error, manifest) {
+	if (error) throw error;
+	console.log(manifest);
+});
+```
+<a name="balena.models.device.getManifestByApplication"></a>
+
+##### ~~device.getManifestByApplication(slugOrUuidOrId) ⇒ <code>Promise</code>~~
+***Deprecated***
+
+**Kind**: static method of [<code>device</code>](#balena.models.device)  
+**Summary**: Get a device manifest by application name  
+**Access**: public  
+**Fulfil**: <code>Object</code> - device manifest  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| slugOrUuidOrId | <code>String</code> \| <code>Number</code> | application slug (string), uuid (string) or id (number) |
+
+**Example**  
+```js
+balena.models.device.getManifestByApplication('myorganization/myapp').then(function(manifest) {
+	console.log(manifest);
+});
+```
+**Example**  
+```js
+balena.models.device.getManifestByApplication(123).then(function(manifest) {
+	console.log(manifest);
+});
+```
+**Example**  
+```js
+balena.models.device.getManifestByApplication('myorganization/myapp', function(error, manifest) {
+	if (error) throw error;
+	console.log(manifest);
 });
 ```
 <a name="balena.models.device.generateUniqueKey"></a>
@@ -6211,6 +6332,7 @@ balena.models.organization.remove(123, function(error) {
     * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
     * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
     * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
+    * [.getSupervisorImageForDT(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDT) ⇒ <code>Promise.&lt;String&gt;</code>
 
 <a name="balena.models.os.getAvailableOsVersions"></a>
 
@@ -6486,6 +6608,24 @@ console.log(result1);
 
 const result2 = balena.models.os.isArchitectureCompatibleWith('armv7hf', 'amd64');
 console.log(result2);
+```
+<a name="balena.models.os.getSupervisorImageForDT"></a>
+
+##### os.getSupervisorImageForDT(deviceTypeId, version) ⇒ <code>Promise.&lt;String&gt;</code>
+**Kind**: static method of [<code>os</code>](#balena.models.os)  
+**Summary**: Returns image name for a specific supervisor version for a Device Type  
+**Returns**: <code>Promise.&lt;String&gt;</code> - - Docker image name for the Supervisor version and arch  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| deviceTypeId | <code>Number</code> | The Id for the Device Type |
+| version | <code>String</code> | The semver version string for the supervisor |
+
+**Example**  
+```js
+const result = balena.models.os.getSupervisorImageForDT(60, 'v12.11.0').then(result => console.log(result))
+// 60 would be raspberrypi4-64 on balena-cloud
 ```
 <a name="balena.models.config"></a>
 
@@ -8338,3 +8478,13 @@ balena.settings.getAll(function(error, settings) {
 
 ### balena.utils : <code>object</code>
 **Kind**: static namespace of [<code>balena</code>](#balena)  
+<a name="listImagesFromTargetState"></a>
+
+## listImagesFromTargetState(targetState) ⇒
+**Kind**: global function  
+**Returns**: array containing all images for all services for all releases for all apps for the device  
+
+| Param |
+| --- |
+| targetState | 
+

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -370,7 +370,7 @@ const sdk = fromSharedOptions();
             * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
             * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
             * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
-            * [.getSupervisorImageForDT(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDT) ⇒ <code>Promise.&lt;String&gt;</code>
+            * [.getSupervisorImageForDeviceType(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDeviceType) ⇒ <code>Promise.&lt;String&gt;</code>
         * [.config](#balena.models.config) : <code>object</code>
             * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
             * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
@@ -774,7 +774,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
         * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
         * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
-        * [.getSupervisorImageForDT(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDT) ⇒ <code>Promise.&lt;String&gt;</code>
+        * [.getSupervisorImageForDeviceType(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDeviceType) ⇒ <code>Promise.&lt;String&gt;</code>
     * [.config](#balena.models.config) : <code>object</code>
         * [.getAll()](#balena.models.config.getAll) ⇒ <code>Promise</code>
         * ~~[.getDeviceTypes()](#balena.models.config.getDeviceTypes) ⇒ <code>Promise</code>~~
@@ -6332,7 +6332,7 @@ balena.models.organization.remove(123, function(error) {
     * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
     * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
     * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
-    * [.getSupervisorImageForDT(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDT) ⇒ <code>Promise.&lt;String&gt;</code>
+    * [.getSupervisorImageForDeviceType(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDeviceType) ⇒ <code>Promise.&lt;String&gt;</code>
 
 <a name="balena.models.os.getAvailableOsVersions"></a>
 
@@ -6609,9 +6609,9 @@ console.log(result1);
 const result2 = balena.models.os.isArchitectureCompatibleWith('armv7hf', 'amd64');
 console.log(result2);
 ```
-<a name="balena.models.os.getSupervisorImageForDT"></a>
+<a name="balena.models.os.getSupervisorImageForDeviceType"></a>
 
-##### os.getSupervisorImageForDT(deviceTypeId, version) ⇒ <code>Promise.&lt;String&gt;</code>
+##### os.getSupervisorImageForDeviceType(deviceTypeId, version) ⇒ <code>Promise.&lt;String&gt;</code>
 **Kind**: static method of [<code>os</code>](#balena.models.os)  
 **Summary**: Returns image name for a specific supervisor version for a Device Type  
 **Returns**: <code>Promise.&lt;String&gt;</code> - - Docker image name for the Supervisor version and arch  

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -1248,6 +1248,7 @@ const getDeviceModel = function (
 		 * @memberof balena.models.device
 		 *
 		 * @param {String|Number} uuidOrId - device uuid (string) or id (number)
+		 * @param {Number} version - (optional) target state version (2 or 3), default to 2
 		 * @returns {Promise}
 		 *
 		 * @example
@@ -1261,6 +1262,11 @@ const getDeviceModel = function (
 		 * });
 		 *
 		 * @example
+		 * balena.models.device.getSupervisorTargetState(123, 3).then(function(state) {
+		 * 	console.log(state);
+		 * });
+		 *
+		 * @example
 		 * balena.models.device.getSupervisorTargetState('7cf02a6', function(error, state) {
 		 * 	if (error) throw error;
 		 * 	console.log(state);
@@ -1268,10 +1274,52 @@ const getDeviceModel = function (
 		 */
 		getSupervisorTargetState: async (
 			uuidOrId: string | number,
+			version: 2 | 3 = 2,
 		): Promise<DeviceState.DeviceState> => {
 			const { uuid } = await exports.get(uuidOrId, { $select: 'uuid' });
 			const { body } = await request.send({
-				url: `/device/v2/${uuid}/state`,
+				url: `/device/v${version}/${uuid}/state`,
+				baseUrl: apiUrl,
+			});
+			return body;
+		},
+
+		/**
+		 * @summary Get the target supervisor state on a "generic" device on a fleet
+		 * @name getSupervisorTargetStateForApp
+		 * @public
+		 * @function
+		 * @memberof balena.models.device
+		 *
+		 * @param {String|Number} uuidOrId - fleet uuid (string) or id (number)
+		 * @param {String} release - (optional) release uuid (default tracked)
+		 * @returns {Promise}
+		 *
+		 * @example
+		 * balena.models.device.getSupervisorTargetStateForApp('7cf02a6').then(function(state) {
+		 * 	console.log(state);
+		 * });
+		 *
+		 * @example
+		 * balena.models.device.getSupervisorTargetStateForApp(123).then(function(state) {
+		 * 	console.log(state);
+		 * });
+		 *
+		 * @example
+		 * balena.models.device.getSupervisorTargetStateForApp(123, '7cf02a6').then(function(state) {
+		 * 	console.log(state);
+		 * });
+		 *
+		 */
+		getSupervisorTargetStateForApp: async (
+			slugOrUuidOrId: string | number,
+			release?: string | number,
+		): Promise<DeviceState.DeviceStateV3> => {
+			const { uuid } = await applicationModel().get(slugOrUuidOrId, {
+				$select: 'uuid',
+			});
+			const { body } = await request.send({
+				url: `/device/v3/fleet/${uuid}/state/?releaseUuid=${release ?? ''}`,
 				baseUrl: apiUrl,
 			});
 			return body;

--- a/src/models/os.ts
+++ b/src/models/os.ts
@@ -30,7 +30,12 @@ import type {
 	ResolvableReturnType,
 	TypeOrDictionary,
 } from '../../typings/utils';
-import type { ResourceTagBase, ApplicationTag, Release } from '../types/models';
+import type {
+	ResourceTagBase,
+	ApplicationTag,
+	Release,
+	SupervisorRelease,
+} from '../types/models';
 import type {
 	InjectedDependenciesParam,
 	InjectedOptionsParam,
@@ -969,6 +974,40 @@ const getOsModel = function (
 		);
 	};
 
+	/**
+	 * @summary Returns image name for a specific supervisor version for a Device Type
+	 * @name getSupervisorImageForDeviceType
+	 * @public
+	 * @function
+	 * @memberof balena.models.os
+	 *
+	 * @param {Number} deviceTypeId - The Id for the Device Type
+	 * @param {String} version - The semver version string for the supervisor
+	 * @returns {Promise<String>} - Docker image name for the Supervisor version and arch
+	 *
+	 * @example
+	 * const result = balena.models.os.getSupervisorImageForDT(60, 'v12.11.0').then(result => console.log(result))
+	 * // 60 would be raspberrypi4-64 on balena-cloud
+	 *
+	 */
+	const getSupervisorReleaseByDeviceType = async (
+		deviceTypeId: number,
+		version: string,
+	): Promise<SupervisorRelease | null> => {
+		const results: any = await pine.get<SupervisorRelease>({
+			resource: 'supervisor_release',
+			options: {
+				$top: 1,
+				$filter: {
+					is_for__device_type: deviceTypeId,
+					supervisor_version: version,
+				},
+			},
+		});
+
+		return results?.[0] ?? null;
+	};
+
 	return {
 		// Cast the exported types for internal methods so `@types/memoizee` can be a dev depenency.
 		_getNormalizedDeviceTypeSlug: _getNormalizedDeviceTypeSlug as (
@@ -991,6 +1030,7 @@ const getOsModel = function (
 		isSupportedOsUpdate,
 		getSupportedOsUpdateVersions,
 		isArchitectureCompatibleWith,
+		getSupervisorReleaseByDeviceType,
 	};
 };
 

--- a/src/types/device-state.ts
+++ b/src/types/device-state.ts
@@ -45,3 +45,24 @@ export interface DeviceState {
 		}>;
 	};
 }
+
+export interface DeviceStateV3 {
+	[deviceUuid: string]: {
+		name?: string;
+		config: Dictionary<string>;
+		apps: {
+			[appUuid: string]: {
+				release_uuid?: string;
+				releases: {
+					[releaseUuid: string]: {
+						services: {
+							[serviceName: string]: {
+								image: string;
+							};
+						};
+					};
+				};
+			};
+		};
+	};
+}

--- a/src/util/device.ts
+++ b/src/util/device.ts
@@ -1,4 +1,5 @@
 import type * as BalenaSdk from '..';
+import type * as DeviceState from '../types/device-state';
 
 export const isProvisioned = (
 	device: Partial<
@@ -10,4 +11,34 @@ export const isProvisioned = (
 		device.supervisor_version.length > 0 &&
 		device.last_connectivity_event != null
 	);
+};
+
+/**
+ *
+ * @param targetState
+ * @returns array containing all images for all services for all releases for all apps for the device
+ */
+export const listImagesFromTargetState = (
+	targetState: DeviceState.DeviceStateV3,
+): string[] => {
+	const images: string[] = [];
+	// list apps keys
+	for (const device of Object.keys(targetState)) {
+		for (const app of Object.keys(targetState[device].apps)) {
+			for (const release of Object.keys(
+				targetState[device].apps[app].releases,
+			)) {
+				for (const service of Object.keys(
+					targetState[device].apps[app].releases[release].services,
+				)) {
+					images.push(
+						targetState[device].apps[app].releases[release].services[service]
+							.image,
+					);
+				}
+			}
+		}
+	}
+
+	return images;
 };

--- a/tests/integration/models/device.spec.js
+++ b/tests/integration/models/device.spec.js
@@ -1951,6 +1951,68 @@ describe('Device Model', function () {
 						'900000',
 					);
 				});
+
+				it(`should return a state v3 if version is set to 3`, async function () {
+					const state = await balena.models.device.getSupervisorTargetState(
+						this.device.id,
+						3,
+					);
+					// basic check for v3 format
+					expect(state[this.device.uuid].apps[this.application.uuid]).to.be.an(
+						'object',
+					);
+				});
+			});
+
+			describe('balena.models.device.getSupervisorTargetStateForApp()', function () {
+				givenADevice(before);
+
+				it('should be rejected if the fleet does not exist', function () {
+					const promise =
+						balena.models.device.getSupervisorTargetStateForApp('asdfghjkl');
+					return expect(promise).to.be.rejectedWith(
+						'Application not found: asdfghjkl',
+					);
+				});
+
+				it(`should give a device's target state (v3) for a _generic_ device of a fleet`, async function () {
+					const state =
+						await balena.models.device.getSupervisorTargetStateForApp(
+							this.application.uuid,
+						);
+
+					// basic check for v3 format
+					expect(
+						state[this.application.uuid].apps[this.application.uuid],
+					).to.be.an('object');
+
+					// check the name
+					expect(state[this.application.uuid].name).to.be.a('string');
+					expect(state[this.application.uuid].name).to.equal(
+						this.application.app_name,
+					);
+
+					// and the structure
+					expect(state[this.application.uuid].apps).to.be.an('object');
+
+					// finally, check configuration type and values
+					expect(state[this.application.uuid].config).to.be.an('object');
+					expect(
+						state[this.application.uuid].config[
+							'RESIN_SUPERVISOR_NATIVE_LOGGER'
+						],
+					).to.equal('true');
+					expect(
+						state[this.application.uuid].config[
+							'RESIN_SUPERVISOR_POLL_INTERVAL'
+						],
+					).to.equal('900000');
+				});
+
+				it.skip(`should give a device's target state (v3) for a _generic_ device of a fleet and a specific release`, async function () {
+					// Due to the complexity of setting up a release for the fleet to test here, this one is currently skipped.
+					// Will be revisited later when the value of the test is greater than it's cost
+				});
 			});
 
 			describe('balena.models.device.getSupervisorState()', function () {

--- a/tests/integration/models/os.spec.ts
+++ b/tests/integration/models/os.spec.ts
@@ -1115,4 +1115,29 @@ describe('OS model', function () {
 				it(`should return true when comparing ${deviceArch} and ${appArch} architectures`, () => expect(balena.models.os.isArchitectureCompatibleWith(deviceArch, appArch)).to.equal(true));
 			});
 		}));
+
+	describe('supervisor', () =>
+		describe('balena.models.os.getSupervisorReleaseByDeviceType()', function () {
+			it('should return null if no image was found', async () => {
+				const svImage = await balena.models.os.getSupervisorReleaseByDeviceType(
+					1,
+					'v999.99.99',
+				);
+				expect(svImage).to.equal(null);
+			});
+
+			it('should return the right string when asking for raspberrypi4-64 and v12.11.0', async () => {
+				const dtId: number = await balena.models.deviceType
+					.get('raspberrypi4-64')
+					.then((res) => res.id);
+
+				const svImage = await balena.models.os.getSupervisorReleaseByDeviceType(
+					dtId,
+					'v12.11.0',
+				);
+				expect(svImage?.image_name).to.equal(
+					'registry2.balena-cloud.com/v2/4ca706e1c624daff7e519b3009746b2c',
+				);
+			});
+		}));
 });


### PR DESCRIPTION
- Get "Fleet level Target State v3" on devices
- Get "supervisor image for version and dt" on os
- Util to list images name from a target state

Change-type: patch
Signed-off-by: Edwin Joassart <edwin.joassart@balena.io>

See: 
- [Zulip preloading thread](https://balena.zulipchat.com/#narrow/stream/346008-balena-io.2Fetcher/topic/.2Eetch.20.2F.20preloading.20status.20.28and.20some.20more.29/near/318093854)

Depends-on: https://github.com/balena-io/open-balena-api/pull/1081
Change-type: patch

---
##### Contributor checklist
- [x] Includes tests
- [x] Includes typings
- [/] Includes updated documentation -> should be handled by CI from jsdoc
- [/] Includes updated build output -> should be handled by CI
