### PR TITLE
Add configVarInvalidRegex to Config Var typing

### DIFF
--- a/lib/models/config.ts
+++ b/lib/models/config.ts
@@ -51,6 +51,7 @@ export interface ConfigVarDefinition {
 	blackListedNames: string[];
 	configVarSchema: ConfigVarSchema;
 	invalidRegex: string;
+	configVarInvalidRegex: string;
 	reservedNames: string[];
 	reservedNamespaces: string[];
 	whiteListedNames: string[];


### PR DESCRIPTION
This is part of the work for enabling the creation of configuration variables with a colon character as a means to allow Raspberry PI users to enable the second HDMI port on RPI4 and others.

Relates-to: balena-io/open-balena-api#1199, balena-io/open-balena-api#1251
Change-type: minor

---

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [x] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
