### PR TITLE
Add aliases for the DT contrast slugs used in getInstructions

### DIFF
--- a/lib/models/balenaos-contract.ts
+++ b/lib/models/balenaos-contract.ts
@@ -1,8 +1,9 @@
+import { Dictionary } from '../../typings/utils';
 import { Contract } from '../types/contract';
 
 // Hardcoded host OS contract, this should be moved to the Yocto build process with meta-balena.
 // Here for initial implementatin and testing purposes
-const BalenaOS: Contract = {
+export const BalenaOS: Contract = {
 	name: 'balenaOS',
 	slug: 'balenaos',
 	type: 'sw.os',
@@ -17,24 +18,24 @@ const BalenaOS: Contract = {
 			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
 		],
 		externalFlash: [
-			`Insert the {{deviceType.data.media.altBoot.[0]}} to the host machine.`,
-			`Write the {{name}} file you downloaded to the {{deviceType.data.media.altBoot.[0]}}. We recommend using <a href="http://www.etcher.io/">Etcher</a>.`,
+			`Insert the {{resolveContractAlias deviceType.data.media.altBoot.[0]}} to the host machine.`,
+			`Write the {{name}} file you downloaded to the {{resolveContractAlias deviceType.data.media.altBoot.[0]}}. We recommend using <a href="http://www.etcher.io/">Etcher</a>.`,
 			`Wait for writing of {{name}} to complete.`,
-			`Remove the {{deviceType.data.media.altBoot.[0]}} from the host machine.`,
-			`Insert the freshly flashed {{deviceType.data.media.altBoot.[0]}} into the {{deviceType.name}}.`,
+			`Remove the {{resolveContractAlias deviceType.data.media.altBoot.[0]}} from the host machine.`,
+			`Insert the freshly flashed {{resolveContractAlias deviceType.data.media.altBoot.[0]}} into the {{deviceType.name}}.`,
 			`<strong role="alert">Warning!</strong> This will also completely erase internal storage medium, so please make a backup first.`,
 			`{{#each deviceType.partials.bootDeviceExternal}}{{{this}}} {{/each}}`,
 			`Wait for the {{deviceType.name}} to finish flashing and shutdown. {{#if deviceType.partials.flashIndicator}}Please wait until {{deviceType.partials.flashIndicator}}.{{/if}}`,
-			`Remove the {{deviceType.data.media.altBoot.[0]}} from the {{deviceType.name}}.`,
+			`Remove the {{resolveContractAlias deviceType.data.media.altBoot.[0]}} from the {{deviceType.name}}.`,
 			`{{#each deviceType.partials.bootDeviceInternal}}{{{this}}} {{/each}}`,
 			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
 		],
 		externalBoot: [
-			`Insert the {{deviceType.data.media.defaultBoot}} to the host machine.`,
-			`Write the {{name}} file you downloaded to the {{deviceType.data.media.defaultBoot}}. We recommend using <a href="http://www.etcher.io/">Etcher</a>.`,
+			`Insert the {{resolveContractAlias deviceType.data.media.defaultBoot}} to the host machine.`,
+			`Write the {{name}} file you downloaded to the {{resolveContractAlias deviceType.data.media.defaultBoot}}. We recommend using <a href="http://www.etcher.io/">Etcher</a>.`,
 			`Wait for writing of {{name}} to complete.`,
-			`Remove the {{deviceType.data.media.defaultBoot}} from the host machine.`,
-			`Insert the freshly flashed {{deviceType.data.media.defaultBoot}} into the {{deviceType.name}}.`,
+			`Remove the {{resolveContractAlias deviceType.data.media.defaultBoot}} from the host machine.`,
+			`Insert the freshly flashed {{resolveContractAlias deviceType.data.media.defaultBoot}} into the {{deviceType.name}}.`,
 			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
 		],
 		jetsonFlash: [
@@ -76,4 +77,7 @@ const BalenaOS: Contract = {
 	},
 };
 
-export { BalenaOS };
+export const aliases: Dictionary<string> = {
+	sdcard: 'SD card',
+	usb_mass_storage: 'USB key',
+};

--- a/lib/models/device-type.ts
+++ b/lib/models/device-type.ts
@@ -23,7 +23,16 @@ import * as Handlebars from 'handlebars';
 import cloneDeep = require('lodash/cloneDeep');
 
 // REPLACE ONCE HOST OS CONTRACTS ARE GENERATED THROUGH YOCTO
-import { BalenaOS } from './balenaos-contract';
+import {
+	aliases as contractAliases,
+	BalenaOS as BalenaOsContract,
+} from './balenaos-contract';
+
+const handlebarsRuntimeOptions = {
+	helpers: {
+		resolveContractAlias: (slug: string) => contractAliases[slug] ?? slug,
+	},
+};
 
 const traversingCompile = (
 	partials: Partials,
@@ -40,7 +49,9 @@ const traversingCompile = (
 			}
 			// if array of partials, compile the template
 			location[partialKey] = current
-				.map((partial) => Handlebars.compile(partial)(interpolated))
+				.map((partial) =>
+					Handlebars.compile(partial)(interpolated, handlebarsRuntimeOptions),
+				)
 				.filter((n) => n);
 		} else {
 			// if it's another dictionary, keep traversing
@@ -92,7 +103,7 @@ function getInstructionsFromContract(contract: Contract) {
 		deviceType: interpolatedPartials(contract),
 	};
 	const interpolatedHostOS = interpolatedPartials({
-		...cloneDeep(BalenaOS),
+		...cloneDeep(BalenaOsContract),
 		...interpolatedDeviceType,
 	});
 

--- a/tests/integration/models/device-type.spec.ts
+++ b/tests/integration/models/device-type.spec.ts
@@ -120,11 +120,11 @@ describe('Device Type model', function () {
 				[
 					RPI2_DEVICE_TYPE_SLUG,
 					[
-						'Insert the sdcard to the host machine.',
-						'Write the balenaOS file you downloaded to the sdcard. We recommend using <a href="http://www.etcher.io/">Etcher</a>.',
+						'Insert the SD card to the host machine.',
+						'Write the balenaOS file you downloaded to the SD card. We recommend using <a href="http://www.etcher.io/">Etcher</a>.',
 						'Wait for writing of balenaOS to complete.',
-						'Remove the sdcard from the host machine.',
-						'Insert the freshly flashed sdcard into the Raspberry Pi 2.',
+						'Remove the SD card from the host machine.',
+						'Insert the freshly flashed SD card into the Raspberry Pi 2.',
 						'Connect power to the Raspberry Pi 2 to boot the device.',
 					],
 				],
@@ -132,6 +132,21 @@ describe('Device Type model', function () {
 					RADXA_ZERO_DEVICE_TYPE_SLUG,
 					[
 						"Use the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Enable_maskrom>maskrom mode</a> instructions provided by the vendor and make sure the board's USB2 port is used for provisioning. Install on your PC the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Install_required_tools>tools</a> required for flashing. Clear eMMC and set it in UMS mode. Make sure to use <a href=https://dl.radxa.com/zero/images/loader/radxa-zero-erase-emmc.bin>this loader</a> when following the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Side_loading_binaries>sideloading instructions</a>. Write the OS to the internal eMMC storage device. We recommend using <a href=http://www.etcher.io/>Etcher</a>. Once the OS has been written to the eMMC you need to repower your board. ",
+					],
+				],
+				[
+					'intel-nuc',
+					[
+						'Insert the USB key to the host machine.',
+						'Write the balenaOS file you downloaded to the USB key. We recommend using <a href="http://www.etcher.io/">Etcher</a>.',
+						'Wait for writing of balenaOS to complete.',
+						'Remove the USB key from the host machine.',
+						'Insert the freshly flashed USB key into the Intel NUC.',
+						'<strong role="alert">Warning!</strong> This will also completely erase internal storage medium, so please make a backup first.',
+						'Ensure there are no other USB keys are inserted. Power on the Intel NUC with a keyboard connected. Press the F10 key while BIOS is loading to enter the boot menu. Select the USB key from the boot menu. ',
+						'Wait for the Intel NUC to finish flashing and shutdown. Please wait until all LEDs are off.',
+						'Remove the USB key from the Intel NUC.',
+						'Power up the Intel NUC to boot the device.',
 					],
 				],
 			] as const


### PR DESCRIPTION
Change-type: minor

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
