### PR TITLE
Deprecate the device-type.json's instructions field

### DIFF
--- a/lib/types/device-type-json.ts
+++ b/lib/types/device-type-json.ts
@@ -14,6 +14,7 @@ export interface DeviceType {
 
 	isDependent?: boolean;
 	imageDownloadAlerts?: DeviceTypeDownloadAlert[];
+	/** @deprecated Use the balena.models.deviceType.getInstructions() */
 	instructions?: string[] | DeviceTypeInstructions;
 	gettingStartedLink?: string | DeviceTypeGettingStartedLink;
 	stateInstructions?: { [key: string]: string[] };


### PR DESCRIPTION
Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
