### PR TITLE
patch: Split instruction strings on linebreak

### DIFF
--- a/lib/models/balenaos-contract.ts
+++ b/lib/models/balenaos-contract.ts
@@ -46,7 +46,8 @@ export const BalenaOS: Contract = {
 			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
 		],
 		usbMassStorage: [
-			`{{#each deviceType.partials.instructions}}{{{this}}} {{/each}}`,
+			`{{#each deviceType.partials.instructions}}{{{this}}} 
+			{{/each}}`,
 		],
 		edisonFlash: {
 			Linux: [

--- a/lib/models/device-type.ts
+++ b/lib/models/device-type.ts
@@ -21,6 +21,7 @@ import { mergePineOptions } from '../util';
 import * as errors from 'balena-errors';
 import * as Handlebars from 'handlebars';
 import cloneDeep = require('lodash/cloneDeep');
+import flatten = require('lodash/flatten');
 
 // REPLACE ONCE HOST OS CONTRACTS ARE GENERATED THROUGH YOCTO
 import {
@@ -48,10 +49,16 @@ const traversingCompile = (
 				location = location[key];
 			}
 			// if array of partials, compile the template
-			location[partialKey] = current
-				.map((partial) =>
-					Handlebars.compile(partial)(interpolated, handlebarsRuntimeOptions),
-				)
+			// TODO: Replace `flatten` with flatMap in the next major.
+			location[partialKey] = flatten(
+				current.map((partial) =>
+					Handlebars.compile(partial)(
+						interpolated,
+						handlebarsRuntimeOptions,
+					).split(`\n`),
+				),
+			)
+				.map((n) => n.trim())
 				.filter((n) => n);
 		} else {
 			// if it's another dictionary, keep traversing

--- a/tests/integration/models/device-type.spec.ts
+++ b/tests/integration/models/device-type.spec.ts
@@ -131,7 +131,11 @@ describe('Device Type model', function () {
 				[
 					RADXA_ZERO_DEVICE_TYPE_SLUG,
 					[
-						"Use the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Enable_maskrom>maskrom mode</a> instructions provided by the vendor and make sure the board's USB2 port is used for provisioning. Install on your PC the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Install_required_tools>tools</a> required for flashing. Clear eMMC and set it in UMS mode. Make sure to use <a href=https://dl.radxa.com/zero/images/loader/radxa-zero-erase-emmc.bin>this loader</a> when following the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Side_loading_binaries>sideloading instructions</a>. Write the OS to the internal eMMC storage device. We recommend using <a href=http://www.etcher.io/>Etcher</a>. Once the OS has been written to the eMMC you need to repower your board. ",
+						"Use the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Enable_maskrom>maskrom mode</a> instructions provided by the vendor and make sure the board's USB2 port is used for provisioning.",
+						'Install on your PC the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Install_required_tools>tools</a> required for flashing.',
+						'Clear eMMC and set it in UMS mode. Make sure to use <a href=https://dl.radxa.com/zero/images/loader/radxa-zero-erase-emmc.bin>this loader</a> when following the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Side_loading_binaries>sideloading instructions</a>.',
+						'Write the OS to the internal eMMC storage device. We recommend using <a href=http://www.etcher.io/>Etcher</a>.',
+						'Once the OS has been written to the eMMC you need to repower your board.',
 					],
 				],
 				[
@@ -143,7 +147,7 @@ describe('Device Type model', function () {
 						'Remove the USB key from the host machine.',
 						'Insert the freshly flashed USB key into the Intel NUC.',
 						'<strong role="alert">Warning!</strong> This will also completely erase internal storage medium, so please make a backup first.',
-						'Ensure there are no other USB keys are inserted. Power on the Intel NUC with a keyboard connected. Press the F10 key while BIOS is loading to enter the boot menu. Select the USB key from the boot menu. ',
+						'Ensure there are no other USB keys are inserted. Power on the Intel NUC with a keyboard connected. Press the F10 key while BIOS is loading to enter the boot menu. Select the USB key from the boot menu.',
 						'Wait for the Intel NUC to finish flashing and shutdown. Please wait until all LEDs are off.',
 						'Remove the USB key from the Intel NUC.',
 						'Power up the Intel NUC to boot the device.',


### PR DESCRIPTION
iot-gate-imx8plus's provisioning instructions was resulting in a paragraph being generated rather than bullet points. On further investigation, it was determind to be a issue with all `usbMassStorage` flashProtocol devices. Hence, to resolve that we added a linebreak to each instruction step for these devices and split the instructions to create the bullet points that are needed. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
