### PR TITLE
application.create: Enable creating fleets with archived device types 

### DIFF
--- a/src/models/application.ts
+++ b/src/models/application.ts
@@ -25,7 +25,6 @@ import type {
 	ApplicationVariable,
 	BuildVariable,
 	Device,
-	DeviceType,
 	PinePostResult,
 } from '..';
 import type {
@@ -702,30 +701,9 @@ const getApplicationModel = function (
 				: undefined;
 
 			const deviceTypeIdPromise = (async () => {
-				const deviceTypeOptions = {
+				const dt = await sdkInstance.models.deviceType.get(deviceType, {
 					$select: 'id',
-					$expand: {
-						is_default_for__application: {
-							$select: 'is_archived',
-							$filter: {
-								is_host: true,
-							},
-						},
-					},
-				} as const;
-				const dt = (await sdkInstance.models.deviceType.get(
-					deviceType,
-					deviceTypeOptions,
-				)) as PineTypedResult<DeviceType, typeof deviceTypeOptions>;
-				const hostApps = dt.is_default_for__application;
-				// TODO: We are now checking whether all returned hostApps are marked as archived so that we
-				// do not break open-balena. Once open-balena gets hostApps, we can change this to just a $filter on is_archived.
-				if (
-					hostApps.length > 0 &&
-					hostApps.every((hostApp) => hostApp.is_archived)
-				) {
-					throw new errors.BalenaDiscontinuedDeviceType(deviceType);
-				}
+				});
 				return dt.id;
 			})();
 

--- a/tests/integration/models/application.spec.ts
+++ b/tests/integration/models/application.spec.ts
@@ -118,17 +118,6 @@ describe('Application Model', function () {
 					);
 				});
 
-				it('should be rejected if the device type is discontinued', function () {
-					const promise = balena.models.application.create({
-						name: 'FooBar',
-						deviceType: 'edge',
-						organization: ctx.initialOrg.id,
-					});
-					return expect(promise).to.be.rejectedWith(
-						'Discontinued device type: edge',
-					);
-				});
-
 				it('should be rejected if the name has less than four characters', function () {
 					const promise = balena.models.application.create({
 						name: 'Foo',
@@ -284,6 +273,15 @@ describe('Application Model', function () {
 						'directly_accessible',
 					);
 					await expect(promise).to.eventually.have.length(appCount);
+				});
+
+				it('should succeed even if the device type is discontinued', function () {
+					const promise = balena.models.application.create({
+						name: 'FooBar',
+						deviceType: 'edge',
+						organization: ctx.initialOrg.id,
+					});
+					return expect(promise).to.be.fulfilled;
 				});
 			});
 		});


### PR DESCRIPTION
application.create: Enable creating fleets with archived device types

See: https://balena.zulipchat.com/#narrow/stream/345746-aspect.2Fproduct/topic/balenaFin.20discontinuation
Connects-to: https://github.com/balena-io/balena-ui/pull/6030
Change-type: patch

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
