### PR TITLE
Add support for creating isolated in-memory instances

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -124,7 +124,7 @@ startup and before any calls to `fromSharedOptions()` are made.
 | [options.deviceUrlsBase] | <code>String</code> | <code>&#x27;balena-devices.com&#x27;</code> | the base balena device API url to use. |
 | [options.requestLimit] | <code>Number</code> |  | the number of requests per requestLimitInterval that the SDK should respect. |
 | [options.requestLimitInterval] | <code>Number</code> | <code>60000</code> | the timespan that the requestLimit should apply to in milliseconds, defaults to 60000 (1 minute). |
-| [options.dataDirectory] | <code>String</code> | <code>&#x27;$HOME/.balena&#x27;</code> | *ignored in the browser*, the directory where the user settings are stored, normally retrieved like `require('balena-settings-client').get('dataDirectory')`. |
+| [options.dataDirectory] | <code>String</code> \| <code>False</code> | <code>&#x27;$HOME/.balena&#x27;</code> | *ignored in the browser unless false*, the directory where the user settings are stored, normally retrieved like `require('balena-settings-client').get('dataDirectory')`. Providing `false` creates an isolated in-memory instance. |
 | [options.isBrowser] | <code>Boolean</code> |  | the flag to tell if the module works in the browser. If not set will be computed based on the presence of the global `window` value. |
 | [options.debug] | <code>Boolean</code> |  | when set will print some extra debug information. |
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Where the factory method accepts the following options:
 * `apiUrl`, string, *optional*, is the balena API url. Defaults to `https://api.balena-cloud.com/`,
 * `builderUrl`, string, *optional* , is the balena builder url. Defaults to `https://builder.balena-cloud.com/`,
 * `deviceUrlsBase`, string, *optional*, is the base balena device API url. Defaults to `balena-devices.com`,
-* `dataDirectory`, string, *optional*, *ignored in the browser*, is the directory where the user settings are stored, normally retrieved like `require('balena-settings-client').get('dataDirectory')`. Defaults to `$HOME/.balena`,
+* `dataDirectory`, string or false, *optional*, *ignored in the browser unless false*, specifies the directory where the user settings are stored, normally retrieved like `require('balena-settings-client').get('dataDirectory')`. Providing `false` creates an isolated in-memory instance. Defaults to `$HOME/.balena`,
 * `isBrowser`, boolean, *optional*, is the flag to tell if the module works in the browser. If not set will be computed based on the presence of the global `window` value,
 * `debug`, boolean, *optional*, when set will print some extra debug information.
 

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@types/json-schema": "^7.0.9",
     "@types/node": "^14.0.0",
     "abortcontroller-polyfill": "^1.7.1",
-    "balena-auth": "^5.0.0",
+    "balena-auth": "^5.1.0",
     "balena-errors": "^4.8.0",
     "balena-hup-action-utils": "~5.0.0",
     "balena-register-device": "^8.0.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ export interface SdkOptions {
 	apiUrl?: string;
 	builderUrl?: string;
 	dashboardUrl?: string;
-	dataDirectory?: string;
+	dataDirectory?: string | false;
 	isBrowser?: boolean;
 	debug?: boolean;
 	deviceUrlsBase?: string;
@@ -496,7 +496,7 @@ export const getSdk = function ($opts?: SdkOptions) {
  * @param {String} [options.deviceUrlsBase='balena-devices.com'] - the base balena device API url to use.
  * @param {Number} [options.requestLimit] - the number of requests per requestLimitInterval that the SDK should respect.
  * @param {Number} [options.requestLimitInterval = 60000] - the timespan that the requestLimit should apply to in milliseconds, defaults to 60000 (1 minute).
- * @param {String} [options.dataDirectory='$HOME/.balena'] - *ignored in the browser*, the directory where the user settings are stored, normally retrieved like `require('balena-settings-client').get('dataDirectory')`.
+ * @param {String|False} [options.dataDirectory='$HOME/.balena'] - *ignored in the browser unless false*, the directory where the user settings are stored, normally retrieved like `require('balena-settings-client').get('dataDirectory')`. Providing `false` creates an isolated in-memory instance.
  * @param {Boolean} [options.isBrowser] - the flag to tell if the module works in the browser. If not set will be computed based on the presence of the global `window` value.
  * @param {Boolean} [options.debug] - when set will print some extra debug information.
  *


### PR DESCRIPTION
Update balena-auth from 5.0.0 to 5.1.0

Depends-on: https://github.com/balena-io-modules/balena-auth/pull/35
Change-type: minor

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
