### PR TITLE
**BREAKING**: Remove the device-type.json state & name normalization

### DIFF
--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -73,28 +73,11 @@ const getConfigModel = function (
 	const { apiUrl } = opts;
 
 	const normalizeDeviceTypes = (
-		deviceTypes: DeviceTypeJson.DeviceType[], // Patch device types to be marked as ALPHA and BETA instead
+		deviceTypes: DeviceTypeJson.DeviceType[],
 	): DeviceTypeJson.DeviceType[] =>
-		// of PREVIEW and EXPERIMENTAL, respectively.
-		// This logic is literally copy and pasted from balena UI, but
-		// there are plans to move this to `resin-device-types` so it
-		// should be a matter of time for this to be removed.
 		deviceTypes.map(function (deviceType) {
-			// TODO: Drop in the next major the `deviceType.name.replace`s
-			if (deviceType.state === 'DISCONTINUED') {
-				deviceType.name = deviceType.name.replace(
-					/(\(PREVIEW|EXPERIMENTAL\))/,
-					'(DISCONTINUED)',
-				);
-			}
-			if (deviceType.state === 'PREVIEW') {
-				deviceType.state = 'ALPHA';
-				deviceType.name = deviceType.name.replace('(PREVIEW)', '(ALPHA)');
-			}
-			if (deviceType.state === 'EXPERIMENTAL') {
-				deviceType.state = 'NEW';
-				deviceType.name = deviceType.name.replace('(EXPERIMENTAL)', '(NEW)');
-			}
+			// Remove the device-type.json instructions to enforce
+			// users to use the contract based ones.
 			delete deviceType.instructions;
 			return deviceType;
 		});

--- a/tests/integration/models/config.spec.ts
+++ b/tests/integration/models/config.spec.ts
@@ -19,47 +19,14 @@ const expectDeviceTypeArray = function (
 	}
 };
 
-const REPLACED_STATES = ['PREVIEW', 'EXPERIMENTAL'];
-
-const REPLACED_NAME_SUFFIXES = ['(PREVIEW)', '(EXPERIMENTAL)', '(BETA)'];
-
 type ConfigContext = Mocha.Context & {
 	deviceTypes: BalenaSdk.DeviceTypeJson.DeviceType[];
 };
 
 const itNormalizesDeviceTypes = function () {
-	it('changes old device type states', function (this: Mocha.Context) {
+	it('should not have an `instructions` field', function (this: Mocha.Context) {
 		for (const deviceType of (this as ConfigContext).deviceTypes) {
-			expect(deviceType.state).to.satisfy((dtState: string) =>
-				_.every(REPLACED_STATES, (replacedState) => dtState !== replacedState),
-			);
-		}
-	});
-
-	it('changes old device type name suffixes', function (this: Mocha.Context) {
-		for (const deviceType of (this as ConfigContext).deviceTypes) {
-			expect(deviceType.name).to.satisfy((dtName: string) =>
-				_.every(
-					REPLACED_NAME_SUFFIXES,
-					(replacedSuffix) => !_.endsWith(dtName, replacedSuffix),
-				),
-			);
-		}
-	});
-
-	it('properly replaces the names of device types with old states', function (this: Mocha.Context) {
-		for (const deviceType of (this as ConfigContext).deviceTypes) {
-			if (deviceType.state === 'PREVIEW') {
-				expect(deviceType.name).to.satisfy((dtName: string) =>
-					_.endsWith(dtName, '(ALPHA)'),
-				);
-			}
-
-			if (deviceType.state === 'BETA') {
-				expect(deviceType.name).to.satisfy((dtName: string) =>
-					_.endsWith(dtName, '(NEW)'),
-				);
-			}
+			expect(deviceType).to.not.have.property('instructions');
 		}
 	});
 };


### PR DESCRIPTION
We should not have any code any more
relying on these.

Change-type: major
See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/device-type.2Ejson.20field.20deprecation