### PR TITLE
Enable OS Updates to pre-release versions of higher base semver

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -367,7 +367,7 @@ const sdk = fromSharedOptions();
             * [.download(options)](#balena.models.os.download) ⇒ <code>Promise</code>
             * [.getConfig(slugOrUuidOrId, options)](#balena.models.os.getConfig) ⇒ <code>Promise</code>
             * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
-            * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
+            * [.getSupportedOsUpdateVersions(deviceType, currentVersion, [options])](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
             * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
             * [.getSupervisorImageForDeviceType(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDeviceType) ⇒ <code>Promise.&lt;String&gt;</code>
         * [.config](#balena.models.config) : <code>object</code>
@@ -774,7 +774,7 @@ balena.models.device.get(123).catch(function (error) {
         * [.download(options)](#balena.models.os.download) ⇒ <code>Promise</code>
         * [.getConfig(slugOrUuidOrId, options)](#balena.models.os.getConfig) ⇒ <code>Promise</code>
         * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
-        * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
+        * [.getSupportedOsUpdateVersions(deviceType, currentVersion, [options])](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
         * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
         * [.getSupervisorImageForDeviceType(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDeviceType) ⇒ <code>Promise.&lt;String&gt;</code>
     * [.config](#balena.models.config) : <code>object</code>
@@ -5261,7 +5261,7 @@ balena.models.organization.remove(123);
     * [.download(options)](#balena.models.os.download) ⇒ <code>Promise</code>
     * [.getConfig(slugOrUuidOrId, options)](#balena.models.os.getConfig) ⇒ <code>Promise</code>
     * [.isSupportedOsUpdate(deviceType, currentVersion, targetVersion)](#balena.models.os.isSupportedOsUpdate) ⇒ <code>Promise</code>
-    * [.getSupportedOsUpdateVersions(deviceType, currentVersion)](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
+    * [.getSupportedOsUpdateVersions(deviceType, currentVersion, [options])](#balena.models.os.getSupportedOsUpdateVersions) ⇒ <code>Promise</code>
     * [.isArchitectureCompatibleWith(osArchitecture, applicationArchitecture)](#balena.models.os.isArchitectureCompatibleWith) ⇒ <code>Boolean</code>
     * [.getSupervisorImageForDeviceType(deviceTypeId, version)](#balena.models.os.getSupervisorImageForDeviceType) ⇒ <code>Promise.&lt;String&gt;</code>
 
@@ -5468,10 +5468,12 @@ balena.models.os.isSupportedOsUpgrade('raspberry-pi', '2.9.6+rev2.prod', '2.29.2
 ```
 <a name="balena.models.os.getSupportedOsUpdateVersions"></a>
 
-##### os.getSupportedOsUpdateVersions(deviceType, currentVersion) ⇒ <code>Promise</code>
+##### os.getSupportedOsUpdateVersions(deviceType, currentVersion, [options]) ⇒ <code>Promise</code>
 **Kind**: static method of [<code>os</code>](#balena.models.os)  
 **Summary**: Returns the supported OS update targets for the provided device type  
 **Access**: public  
+**Fulfil**: <code>Object[]\|Object</code> - An array of OsVersion objects when a single device type slug is provided,
+or a dictionary of OsVersion objects by device type slug when an array of device type slugs is provided.  
 **Fulfil**: <code>Object</code> - the versions information, of the following structure:
 * versions - an array of strings,
 containing exact version numbers that OS update is supported
@@ -5479,10 +5481,12 @@ containing exact version numbers that OS update is supported
 that is _not_ pre-release, can be `null`
 * current - the provided current version after normalization  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| deviceType | <code>String</code> | device type slug |
-| currentVersion | <code>String</code> | semver-compatible version for the starting OS version |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| deviceType | <code>String</code> |  | device type slug |
+| currentVersion | <code>String</code> |  | semver-compatible version for the starting OS version |
+| [options] | <code>Object</code> |  | Extra options to filter the OS releases by |
+| [options.includeDraft] | <code>Boolean</code> | <code>false</code> | Whether pre-releases should be included in the results |
 
 **Example**  
 ```js

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "abortcontroller-polyfill": "^1.7.1",
     "balena-auth": "^5.1.0",
     "balena-errors": "^4.9.0",
-    "balena-hup-action-utils": "~5.0.0",
+    "balena-hup-action-utils": "~6.1.0",
     "balena-register-device": "^9.0.1",
     "balena-request": "^13.2.0",
     "balena-semver": "^2.3.0",

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -350,6 +350,9 @@ const getDeviceModel = function (
 			);
 		}
 
+		const isDraft =
+			(bSemver.parse(targetOsVersion)?.prerelease.length ?? 0) > 0;
+
 		const getDeviceType = memoizee(
 			async (deviceTypeId: number) =>
 				await sdkInstance.models.deviceType.get(deviceTypeId, {
@@ -358,8 +361,10 @@ const getDeviceModel = function (
 			{ primitive: true, promise: true },
 		);
 		const getAvailableOsVersions = memoizee(
-			async (slug: string) =>
-				await sdkInstance.models.os.getAvailableOsVersions(slug),
+			async (slug: string, includeDraft: boolean) =>
+				await sdkInstance.models.os.getAvailableOsVersions(slug, {
+					includeDraft,
+				}),
 			{ primitive: true, promise: true },
 		);
 
@@ -392,7 +397,7 @@ const getDeviceModel = function (
 						targetOsVersion,
 					);
 
-					const osVersions = await getAvailableOsVersions(dt.slug);
+					const osVersions = await getAvailableOsVersions(dt.slug, isDraft);
 
 					if (
 						!osVersions.some(

--- a/src/models/os.ts
+++ b/src/models/os.ts
@@ -362,27 +362,32 @@ const getOsModel = function (
 	};
 
 	const _memoizedGetAllOsVersions = authDependentMemoizer(
-		async (deviceTypes: string[], listedByDefault: boolean | null) => {
+		async (
+			deviceTypes: string[],
+			filterOptions: 'supported' | 'include_draft' | 'all',
+		) => {
 			return await _getAllOsVersions(
 				deviceTypes,
-				listedByDefault
-					? {
+				filterOptions === 'all'
+					? undefined
+					: {
 							$filter: {
-								is_final: true,
+								...(filterOptions === 'supported' && { is_final: true }),
 								is_invalidated: false,
 								status: 'success',
 							},
-						}
-					: undefined,
+						},
 			);
 		},
 	);
 
 	async function getAvailableOsVersions(
 		deviceType: string,
+		options?: { includeDraft?: boolean },
 	): Promise<OsVersion[]>;
 	async function getAvailableOsVersions(
 		deviceTypes: string[],
+		options?: { includeDraft?: boolean },
 	): Promise<Dictionary<OsVersion[]>>;
 	/**
 	 * @summary Get the supported OS versions for the provided device type(s)
@@ -392,6 +397,8 @@ const getOsModel = function (
 	 * @memberof balena.models.os
 	 *
 	 * @param {String|String[]} deviceTypes - device type slug or array of slugs
+	 * @param {Object} [options] - Extra options to filter the OS releases by
+	 * @param {Boolean} [options.includeDraft=false] - Whether pre-releases should be included in the results
 	 * @fulfil {Object[]|Object} - An array of OsVersion objects when a single device type slug is provided,
 	 * or a dictionary of OsVersion objects by device type slug when an array of device type slugs is provided.
 	 * @returns {Promise}
@@ -404,13 +411,14 @@ const getOsModel = function (
 	 */
 	async function getAvailableOsVersions(
 		deviceTypes: string[] | string,
+		options?: { includeDraft?: boolean },
 	): Promise<TypeOrDictionary<OsVersion[]>> {
 		const singleDeviceTypeArg =
 			typeof deviceTypes === 'string' ? deviceTypes : false;
 		deviceTypes = Array.isArray(deviceTypes) ? deviceTypes : [deviceTypes];
 		const versionsByDt = await _memoizedGetAllOsVersions(
 			deviceTypes.slice().sort(),
-			true,
+			options?.includeDraft === true ? 'include_draft' : 'supported',
 		);
 		return singleDeviceTypeArg
 			? versionsByDt[singleDeviceTypeArg] ?? []
@@ -460,7 +468,7 @@ const getOsModel = function (
 		deviceTypes = Array.isArray(deviceTypes) ? deviceTypes : [deviceTypes];
 		const versionsByDt = (
 			options == null
-				? await _memoizedGetAllOsVersions(deviceTypes.slice().sort(), null)
+				? await _memoizedGetAllOsVersions(deviceTypes.slice().sort(), 'all')
 				: await _getAllOsVersions(deviceTypes, options)
 		) as Dictionary<Array<ExtendedPineTypedResult<Release, OsVersion, TP>>>;
 		return singleDeviceTypeArg

--- a/src/models/os.ts
+++ b/src/models/os.ts
@@ -877,6 +877,10 @@ const getOsModel = function (
 	 *
 	 * @param {String} deviceType - device type slug
 	 * @param {String} currentVersion - semver-compatible version for the starting OS version
+	 * @param {Object} [options] - Extra options to filter the OS releases by
+	 * @param {Boolean} [options.includeDraft=false] - Whether pre-releases should be included in the results
+	 * @fulfil {Object[]|Object} - An array of OsVersion objects when a single device type slug is provided,
+	 * or a dictionary of OsVersion objects by device type slug when an array of device type slugs is provided.
 	 * @fulfil {Object} - the versions information, of the following structure:
 	 * * versions - an array of strings,
 	 * containing exact version numbers that OS update is supported
@@ -893,9 +897,10 @@ const getOsModel = function (
 	const getSupportedOsUpdateVersions = async (
 		deviceType: string,
 		currentVersion: string,
+		options?: { includeDraft?: boolean },
 	): Promise<OsUpdateVersions> => {
 		deviceType = await _getNormalizedDeviceTypeSlug(deviceType);
-		const allVersions = (await getAvailableOsVersions(deviceType))
+		const allVersions = (await getAvailableOsVersions(deviceType, options))
 			.filter((v) => v.osType === OsTypes.DEFAULT)
 			.map((v) => v.raw_version);
 		// use bSemver.compare to find the current version in the OS list

--- a/tests/integration/models/device-type.spec.ts
+++ b/tests/integration/models/device-type.spec.ts
@@ -115,10 +115,10 @@ describe('Device Type model', function () {
 				[
 					RADXA_ZERO_DEVICE_TYPE_SLUG,
 					[
-						"Use the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Enable_maskrom>maskrom mode</a> instructions provided by the vendor and make sure the board's USB2 port is used for provisioning.",
+						'Use the <a href="https://wiki.radxa.com/Zero/dev/maskrom#Enable_maskrom">maskrom mode</a> instructions provided by the vendor and make sure the board\'s USB2 port is used for provisioning.',
 						'Install on your PC the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Install_required_tools>tools</a> required for flashing.',
 						'Clear eMMC and set it in UMS mode. Make sure to use <a href=https://dl.radxa.com/zero/images/loader/radxa-zero-erase-emmc.bin>this loader</a> when following the <a href=https://wiki.radxa.com/Zero/dev/maskrom#Side_loading_binaries>sideloading instructions</a>.',
-						'Write the OS to the internal eMMC storage device. We recommend using <a href=http://www.etcher.io/>Etcher</a>.',
+						'Write the OS to the internal eMMC storage device. We recommend using <a href="http://www.etcher.io">Etcher</a>.',
 						'Once the OS has been written to the eMMC you need to repower your board.',
 					],
 				],

--- a/tests/integration/models/os.spec.ts
+++ b/tests/integration/models/os.spec.ts
@@ -304,6 +304,32 @@ describe('OS model', function () {
 				});
 			});
 
+			it('should not include draft OS versions when the respective flag is not used [string device type argument]', async () => {
+				const versionInfos =
+					await balena.models.os.getAvailableOsVersions('raspberrypi3');
+				expect(versionInfos).to.be.an('array');
+
+				const draftVersions = versionInfos.filter(
+					(v) => bSemver.parse(v.raw_version)?.prerelease.length ?? 0 > 0,
+				);
+				expect(draftVersions).to.have.lengthOf(0);
+			});
+
+			// This relies on the API we are testing against having a newer OS version
+			// that's a draft, like api.balena-cloud.com had at the time of writing this test.
+			it('should include draft OS versions when the respective flag is used [string device type argument]', async () => {
+				const versionInfos = await balena.models.os.getAvailableOsVersions(
+					'raspberrypi3',
+					{ includeDraft: true },
+				);
+				expect(versionInfos).to.be.an('array');
+
+				const draftVersions = versionInfos.filter(
+					(v) => bSemver.parse(v.raw_version)?.prerelease.length ?? 0 > 0,
+				);
+				expect(draftVersions).to.have.length.greaterThan(0);
+			});
+
 			it('should contain both balenaOS and balenaOS ESR OS types [array of single device type]', async () => {
 				const res = await balena.models.os.getAvailableOsVersions(['fincm3']);
 				expect(res).to.be.an('object');

--- a/tests/integration/models/os.spec.ts
+++ b/tests/integration/models/os.spec.ts
@@ -860,24 +860,64 @@ describe('OS model', function () {
 				);
 			}));
 
-		describe('given a valid device slug', () =>
-			it('should return the list of supported hup targets', () =>
-				balena.models.os
-					.getSupportedOsUpdateVersions('raspberrypi3', '2.9.6+rev1.prod')
-					.then(function ({ current, recommended, versions }) {
-						expect(current).to.equal('2.9.6+rev1.prod');
-						expect(recommended).to.be.a('string');
-						expect(versions).to.be.an('array');
-						expect(versions).to.not.have.length(0);
-						versions.forEach(function (v) {
-							expect(v).to.be.a('string');
-							expect(bSemver.gte(v, current)).to.be.true;
-						});
+		describe('given a valid device slug', () => {
+			it('should return the list of supported hup targets', async () => {
+				const { current, recommended, versions } =
+					await balena.models.os.getSupportedOsUpdateVersions(
+						'raspberrypi3',
+						'2.9.6+rev1.prod',
+					);
+				expect(current).to.equal('2.9.6+rev1.prod');
+				expect(recommended).to.be.a('string');
+				expect(versions).to.be.an('array');
+				expect(versions).to.not.have.length(0);
+				versions.forEach(function (v) {
+					expect(v).to.be.a('string');
+					expect(bSemver.gte(v, current)).to.be.true;
+				});
 
-						expect(versions.length > 2).to.be.true;
-						const sortedVersions = versions.slice().sort(bSemver.rcompare);
-						expect(versions).to.deep.equal(sortedVersions);
-					})));
+				expect(versions.length > 2).to.be.true;
+				const sortedVersions = versions.slice().sort(bSemver.rcompare);
+				expect(versions).to.deep.equal(sortedVersions);
+			});
+
+			it('should not include draft OS releases when the respective flag is not used', async () => {
+				const { current, recommended, versions } =
+					await balena.models.os.getSupportedOsUpdateVersions(
+						'raspberrypi3',
+						'2.9.6+rev1.prod',
+					);
+				expect(current).to.equal('2.9.6+rev1.prod');
+				expect(recommended).to.be.a('string');
+				expect(versions).to.be.an('array');
+				expect(versions).to.not.have.length(0);
+
+				const draftVersions = versions.filter(
+					(v) => bSemver.parse(v)?.prerelease.length ?? 0 > 0,
+				);
+				expect(draftVersions).to.have.lengthOf(0);
+			});
+
+			// This relies on the API we are testing against having a newer OS version
+			// that's a draft, like api.balena-cloud.com had at the time of writing this test.
+			it('should include draft OS releases when the respective flag is used', async () => {
+				const { current, recommended, versions } =
+					await balena.models.os.getSupportedOsUpdateVersions(
+						'raspberrypi3',
+						'2.9.6+rev1.prod',
+						{ includeDraft: true },
+					);
+				expect(current).to.equal('2.9.6+rev1.prod');
+				expect(recommended).to.be.a('string');
+				expect(versions).to.be.an('array');
+				expect(versions).to.not.have.length(0);
+
+				const draftVersions = versions.filter(
+					(v) => bSemver.parse(v)?.prerelease.length ?? 0 > 0,
+				);
+				expect(draftVersions).to.have.length.greaterThan(0);
+			});
+		});
 	});
 
 	describe('when logged in as a user with a single application', function () {

--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -59,16 +59,14 @@ export type ExpandableProps<T> = PropsOfType<T, AssociatedResource<object>> &
 	PropsAssignableWithType<T, [] | [any] | any[]> &
 	string;
 
-type SelectedProperty<
-	T,
-	K extends keyof T,
-> = T[K] extends NavigationResource<any>
-	? PineDeferred
-	: T[K] extends OptionalNavigationResource<any>
-		? PineDeferred | null
-		: T[K] extends ConceptTypeNavigationResource<any>
-			? Exclude<T[K], any[]>
-			: T[K];
+type SelectedProperty<T, K extends keyof T> =
+	T[K] extends NavigationResource<any>
+		? PineDeferred
+		: T[K] extends OptionalNavigationResource<any>
+			? PineDeferred | null
+			: T[K] extends ConceptTypeNavigationResource<any>
+				? Exclude<T[K], any[]>
+				: T[K];
 
 type SelectResultObject<T, Props extends keyof T> = {
 	[P in Props]: SelectedProperty<T, P>;
@@ -91,15 +89,16 @@ type ExpandedProperty<
 	T,
 	K extends keyof T,
 	KOpts extends ODataOptions<InferAssociatedResourceType<T[K]>>,
-> = KOpts extends ODataOptionsWithCount<any>
-	? number
-	: T[K] extends NavigationResource<any> | ConceptTypeNavigationResource<any>
-		? [TypedResult<InferAssociatedResourceType<T[K]>, KOpts>]
-		: T[K] extends OptionalNavigationResource<any>
-			? [TypedResult<InferAssociatedResourceType<T[K]>, KOpts>] | []
-			: T[K] extends ReverseNavigationResource<any>
-				? Array<TypedResult<InferAssociatedResourceType<T[K]>, KOpts>>
-				: never;
+> =
+	KOpts extends ODataOptionsWithCount<any>
+		? number
+		: T[K] extends NavigationResource<any> | ConceptTypeNavigationResource<any>
+			? [TypedResult<InferAssociatedResourceType<T[K]>, KOpts>]
+			: T[K] extends OptionalNavigationResource<any>
+				? [TypedResult<InferAssociatedResourceType<T[K]>, KOpts>] | []
+				: T[K] extends ReverseNavigationResource<any>
+					? Array<TypedResult<InferAssociatedResourceType<T[K]>, KOpts>>
+					: never;
 
 export type ExpandResultObject<T, Props extends keyof T> = {
 	[P in Props]: ExpandedProperty<T, P, object>;
@@ -116,28 +115,27 @@ type ExpandResourceExpandObject<
 	>;
 };
 
-export type TypedExpandResult<
-	T,
-	TParams extends ODataOptions<T>,
-> = TParams['$expand'] extends ExpandableProps<T>
-	? ExpandResultObject<T, TParams['$expand']>
-	: TParams['$expand'] extends ResourceExpand<T>
-		? keyof TParams['$expand'] extends ExpandableProps<T>
-			? ExpandResourceExpandObject<T, TParams['$expand']>
-			: never
-		: object;
+export type TypedExpandResult<T, TParams extends ODataOptions<T>> =
+	TParams['$expand'] extends ExpandableProps<T>
+		? ExpandResultObject<T, TParams['$expand']>
+		: TParams['$expand'] extends ResourceExpand<T>
+			? keyof TParams['$expand'] extends ExpandableProps<T>
+				? ExpandResourceExpandObject<T, TParams['$expand']>
+				: never
+			: object;
 
-export type TypedResult<
-	T,
-	TParams extends ODataOptions<T> | undefined,
-> = TParams extends ODataOptionsWithCount<T>
-	? number
-	: TParams extends ODataOptions<T>
-		? Omit<TypedSelectResult<T, TParams>, keyof TypedExpandResult<T, TParams>> &
-				TypedExpandResult<T, TParams>
-		: undefined extends TParams
-			? TypedSelectResult<T, { $select: '*' }>
-			: never;
+export type TypedResult<T, TParams extends ODataOptions<T> | undefined> =
+	TParams extends ODataOptionsWithCount<T>
+		? number
+		: TParams extends ODataOptions<T>
+			? Omit<
+					TypedSelectResult<T, TParams>,
+					keyof TypedExpandResult<T, TParams>
+				> &
+					TypedExpandResult<T, TParams>
+			: undefined extends TParams
+				? TypedSelectResult<T, { $select: '*' }>
+				: never;
 
 export type PostResult<T> = SelectResultObject<
 	T,
@@ -190,18 +188,15 @@ type OrderBy<T> =
 			$dir: OrderByDirection;
 	  });
 
-type AssociatedResourceFilter<T> = T extends NonNullable<
-	ReverseNavigationResource<object>
->
-	? FilterObj<InferAssociatedResourceType<T>>
-	: FilterObj<InferAssociatedResourceType<T>> | number | null;
+type AssociatedResourceFilter<T> =
+	T extends NonNullable<ReverseNavigationResource<object>>
+		? FilterObj<InferAssociatedResourceType<T>>
+		: FilterObj<InferAssociatedResourceType<T>> | number | null;
 
-type ResourceObjFilterPropValue<
-	T,
-	k extends keyof T,
-> = T[k] extends AssociatedResource<object>
-	? AssociatedResourceFilter<T[k]>
-	: T[k] | FilterExpressions<T[k]> | null;
+type ResourceObjFilterPropValue<T, k extends keyof T> =
+	T[k] extends AssociatedResource<object>
+		? AssociatedResourceFilter<T[k]>
+		: T[k] | FilterExpressions<T[k]> | null;
 
 type ResourceObjFilter<T> = {
 	[k in keyof T]?: ResourceObjFilterPropValue<T, k>;


### PR DESCRIPTION
Depends-on: https://github.com/balena-io-modules/balena-hup-action-utils/pull/34
Depends-on: https://github.com/balena-io/balena-proxy/pull/1098
Update balena-hup-action-utils from 5.0.0 to 6.1.0

Change-type: minor

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
