### PR TITLE
tests: Reformat describe & it calls to have curly braces

### DIFF
--- a/tests/integration/balena.spec.ts
+++ b/tests/integration/balena.spec.ts
@@ -97,7 +97,7 @@ describe('Balena SDK', function () {
 				);
 		});
 
-		describe('for request', () =>
+		describe('for request', () => {
 			it('should be able to intercept requests', function () {
 				const requestInterceptor = sinon.mock().returnsArg(0);
 				balena.interceptors.push({ request: requestInterceptor });
@@ -110,9 +110,10 @@ describe('Balena SDK', function () {
 						'Interceptor request hook should be called',
 					),
 				);
-			}));
+			});
+		});
 
-		describe('for requestError', () =>
+		describe('for requestError', () => {
 			it('should intercept request errors from other interceptors', function () {
 				const requestInterceptor = sinon.mock().throws(new Error('rejected'));
 				const requestErrorInterceptor = sinon
@@ -132,9 +133,10 @@ describe('Balena SDK', function () {
 							'Interceptor requestError hook should be called',
 						),
 					);
-			}));
+			});
+		});
 
-		describe('for response', () =>
+		describe('for response', () => {
 			it('should be able to intercept responses', function () {
 				const responseInterceptor = sinon.mock().returnsArg(0);
 				balena.interceptors.push({ response: responseInterceptor });
@@ -146,9 +148,10 @@ describe('Balena SDK', function () {
 						'Interceptor response hook should be called',
 					),
 				);
-			}));
+			});
+		});
 
-		describe('for responseError', () =>
+		describe('for responseError', () => {
 			it('should be able to intercept error responses', function () {
 				let called = false;
 				balena.interceptors.push({
@@ -166,7 +169,8 @@ describe('Balena SDK', function () {
 						'responseError should be called when request fails',
 					),
 				);
-			}));
+			});
+		});
 
 		describe('version header', function () {
 			const getVersionHeaderResponseInterceptor = function () {
@@ -198,7 +202,7 @@ describe('Balena SDK', function () {
 				return responseInterceptor;
 			};
 
-			describe('model requests', () =>
+			describe('model requests', () => {
 				it('should include the version header', function () {
 					const responseInterceptor = getVersionHeaderResponseInterceptor();
 					balena.interceptors.push({ response: responseInterceptor });
@@ -211,9 +215,10 @@ describe('Balena SDK', function () {
 							'Interceptor response hook should be called',
 						),
 					);
-				}));
+				});
+			});
 
-			describe('pine requests', () =>
+			describe('pine requests', () => {
 				it('should include the version header', function () {
 					const responseInterceptor = getVersionHeaderResponseInterceptor();
 					balena.interceptors.push({ response: responseInterceptor });
@@ -228,10 +233,11 @@ describe('Balena SDK', function () {
 							'Interceptor response hook should be called',
 						),
 					);
-				}));
+				});
+			});
 
 			describe('plain requests', function () {
-				describe('with a relative url & without a baseUrl', () =>
+				describe('with a relative url & without a baseUrl', () => {
 					it('should not include the version header', function () {
 						const responseInterceptor =
 							getVersionHeaderResponseErrorInterceptor();
@@ -248,10 +254,11 @@ describe('Balena SDK', function () {
 								'Interceptor response hook should be called',
 							),
 						);
-					}));
+					});
+				});
 
 				describe('with a baseUrl option', function () {
-					describe('to the API', () =>
+					describe('to the API', () => {
 						it('should include the version header', function () {
 							const responseInterceptor = getVersionHeaderResponseInterceptor();
 							balena.interceptors.push({ response: responseInterceptor });
@@ -268,9 +275,10 @@ describe('Balena SDK', function () {
 									'Interceptor response hook should be called',
 								),
 							);
-						}));
+						});
+					});
 
-					describe('to a differnet server', () =>
+					describe('to a different server', () => {
 						it('should not include the version header', function () {
 							const responseInterceptor =
 								getVersionHeaderResponseErrorInterceptor();
@@ -288,11 +296,12 @@ describe('Balena SDK', function () {
 									'Interceptor response hook should be called',
 								),
 							);
-						}));
+						});
+					});
 				});
 
 				describe('with a complete url option', function () {
-					describe('to the API', () =>
+					describe('to the API', () => {
 						it('should include the version header', function () {
 							const responseInterceptor = getVersionHeaderResponseInterceptor();
 							balena.interceptors.push({ response: responseInterceptor });
@@ -308,9 +317,10 @@ describe('Balena SDK', function () {
 									'Interceptor response hook should be called',
 								),
 							);
-						}));
+						});
+					});
 
-					describe('to a differnet server', () =>
+					describe('to a different server', () => {
 						it('should not include the version header', function () {
 							const responseInterceptor =
 								getVersionHeaderResponseErrorInterceptor();
@@ -327,13 +337,14 @@ describe('Balena SDK', function () {
 									'Interceptor response hook should be called',
 								),
 							);
-						}));
+						});
+					});
 				});
 			});
 		});
 	});
 
-	describe('setSharedOptions()', () =>
+	describe('setSharedOptions()', () => {
 		it('should set a global containing shared options', function () {
 			const root =
 				typeof window !== 'undefined' && window !== null ? window : global;
@@ -343,7 +354,8 @@ describe('Balena SDK', function () {
 			balenaSdkExports.setSharedOptions(opts);
 
 			expect(root['BALENA_SDK_SHARED_OPTIONS']).to.equal(opts);
-		}));
+		});
+	});
 
 	describe('fromSharedOptions()', () => {
 		it('should return an object with valid keys', function () {

--- a/tests/integration/models/application.spec.ts
+++ b/tests/integration/models/application.spec.ts
@@ -135,8 +135,8 @@ describe('Application Model', function () {
 					});
 				});
 
-				it('should be rejected if the user did not provide an organization parameter', () =>
-					expect(
+				it('should be rejected if the user did not provide an organization parameter', () => {
+					return expect(
 						// @ts-expect-error missing parameter
 						balena.models.application.create({
 							name: 'FooBar',
@@ -144,7 +144,8 @@ describe('Application Model', function () {
 						}),
 					).to.be.rejectedWith(
 						"undefined is not a valid value for parameter 'organization'",
-					));
+					);
+				});
 
 				it('should be rejected if the user does not have access to find the organization by handle', function () {
 					const promise = balena.models.application.create({
@@ -186,7 +187,7 @@ describe('Application Model', function () {
 					}),
 				);
 
-				organizationRetrievalFields.forEach((prop) =>
+				organizationRetrievalFields.forEach((prop) => {
 					it(`should be able to create an application using the user's initial organization ${prop}`, async function () {
 						await balena.models.application.create({
 							name: `FooBarByOrg${_.startCase(prop)}`,
@@ -206,8 +207,8 @@ describe('Application Model', function () {
 							'organization[0].id',
 							this.initialOrg.id,
 						);
-					}),
-				);
+					});
+				});
 
 				it('...should be able to create an application w/o providing an application type', function () {
 					return balena.models.application
@@ -446,14 +447,14 @@ describe('Application Model', function () {
 				);
 
 				parallel('balena.models.application.get()', function () {
-					applicationRetrievalFields.forEach((prop) =>
+					applicationRetrievalFields.forEach((prop) => {
 						it(`should be able to get an application by ${prop}`, function () {
 							const promise = balena.models.application.get(
 								ctx.application[prop],
 							);
 							return expect(promise).to.become(ctx.application);
-						}),
-					);
+						});
+					});
 
 					it('should be able to get an application by slug regardless of casing', function () {
 						if (
@@ -502,26 +503,26 @@ describe('Application Model', function () {
 				parallel(
 					'balena.models.application.getDirectlyAccessible()',
 					function () {
-						applicationRetrievalFields.forEach((prop) =>
+						applicationRetrievalFields.forEach((prop) => {
 							it(`should be able to get an application by ${prop}`, function () {
 								const promise = balena.models.application.getDirectlyAccessible(
 									ctx.application[prop],
 								);
 								return expect(promise).to.become(ctx.application);
-							}),
-						);
+							});
+						});
 					},
 				);
 
 				parallel('balena.models.application.has()', function () {
-					applicationRetrievalFields.forEach((prop) =>
+					applicationRetrievalFields.forEach((prop) => {
 						it(`should eventually be true if the application ${prop} exists`, function () {
 							const promise = balena.models.application.has(
 								ctx.application[prop],
 							);
 							return expect(promise).to.eventually.be.true;
-						}),
-					);
+						});
+					});
 
 					it('should return false if the application id is undefined', function () {
 						// @ts-expect-error invalid value
@@ -584,7 +585,7 @@ describe('Application Model', function () {
 			});
 
 			describe('balena.models.application.generateApiKey()', function () {
-				applicationRetrievalFields.forEach((prop) =>
+				applicationRetrievalFields.forEach((prop) => {
 					it(`should be able to generate an API key by ${prop}`, async function () {
 						const apiKey = await balena.models.application.generateApiKey(
 							this.application[prop],
@@ -592,8 +593,8 @@ describe('Application Model', function () {
 
 						expect(apiKey).to.be.a('string');
 						expect(apiKey).to.have.length(32);
-					}),
-				);
+					});
+				});
 
 				it('should be rejected if the application slug does not exist', function () {
 					const promise = balena.models.application.generateApiKey(
@@ -625,7 +626,7 @@ describe('Application Model', function () {
 					return provisioningKeys;
 				};
 
-				applicationRetrievalFields.forEach((prop) =>
+				applicationRetrievalFields.forEach((prop) => {
 					it(`should be able to generate a provisioning key by ${prop}`, function () {
 						return balena.models.application
 							.generateProvisioningKey(this.application[prop])
@@ -633,8 +634,8 @@ describe('Application Model', function () {
 								expect(_.isString(key)).to.be.true;
 								return expect(key).to.have.length(32);
 							});
-					}),
-				);
+					});
+				});
 
 				applicationRetrievalFields.forEach((prop) => {
 					it(`should be able to generate a provisioning key by ${prop} with key name as key_${prop}`, async function () {
@@ -1583,7 +1584,7 @@ describe('Application Model', function () {
 				},
 			} as const;
 
-			describe('balena.models.application.getWithDeviceServiceDetails()', () =>
+			describe('balena.models.application.getWithDeviceServiceDetails()', () => {
 				it("should retrieve the application and it's devices along with service details including their commit", function () {
 					return balena.models.application
 						.getWithDeviceServiceDetails(
@@ -1597,11 +1598,12 @@ describe('Application Model', function () {
 								true,
 							);
 						});
-				}));
+				});
+			});
 		});
 	});
 
-	describe('helpers', () =>
+	describe('helpers', () => {
 		describe('balena.models.application.getDashboardUrl()', function () {
 			it('should return the respective DashboardUrl when an application id is provided', function () {
 				const dashboardUrl = sdkOpts.apiUrl!.replace(/api/, 'dashboard');
@@ -1610,18 +1612,21 @@ describe('Application Model', function () {
 				);
 			});
 
-			it('should throw when an application id is not a number', () =>
+			it('should throw when an application id is not a number', () => {
 				expect(() =>
 					// @ts-expect-error invalid parameter
 					balena.models.application.getDashboardUrl('my-app'),
-				).to.throw());
+				).to.throw();
+			});
 
-			it('should throw when an application id is not provided', () =>
+			it('should throw when an application id is not provided', () => {
 				expect(() =>
 					// @ts-expect-error invalid parameter
 					balena.models.application.getDashboardUrl(),
-				).to.throw());
-		}));
+				).to.throw();
+			});
+		});
+	});
 
 	describe('given public apps', function () {
 		let publicApp: Pick<BalenaSdk.Application, 'id' | 'app_name' | 'slug'>;
@@ -1648,21 +1653,21 @@ describe('Application Model', function () {
 
 		describe('when logged in', function () {
 			parallel('balena.models.application.get()', function () {
-				applicationRetrievalFields.forEach((prop) =>
+				applicationRetrievalFields.forEach((prop) => {
 					$it(
 						`should be able to get the public application by ${prop}`,
 						async function () {
 							const app = await balena.models.application.get(publicApp[prop]);
 							expect(app.id).to.equal(publicApp.id);
 						},
-					),
-				);
+					);
+				});
 			});
 
 			parallel(
 				'balena.models.application.get() [directly_accessible]',
 				function () {
-					applicationRetrievalFields.forEach((prop) =>
+					applicationRetrievalFields.forEach((prop) => {
 						$it(
 							`should not return the public application by ${prop}`,
 							async function () {
@@ -1675,15 +1680,15 @@ describe('Application Model', function () {
 									`Application not found: ${publicApp[prop]}`,
 								);
 							},
-						),
-					);
+						);
+					});
 				},
 			);
 
 			parallel(
 				'balena.models.application.getDirectlyAccessible()',
 				function () {
-					applicationRetrievalFields.forEach((prop) =>
+					applicationRetrievalFields.forEach((prop) => {
 						$it(
 							`should not return the public application by ${prop}`,
 							async function () {
@@ -1694,8 +1699,8 @@ describe('Application Model', function () {
 									`Application not found: ${publicApp[prop]}`,
 								);
 							},
-						),
-					);
+						);
+					});
 				},
 			);
 
@@ -1758,7 +1763,7 @@ describe('Application Model', function () {
 		describe('when not being logged in', function () {
 			before(() => balena.auth.logout());
 
-			describe('arbitrary pinejs queries', () =>
+			describe('arbitrary pinejs queries', () => {
 				$it(
 					'should be able to retrieve the available public apps',
 					function () {
@@ -1784,7 +1789,8 @@ describe('Application Model', function () {
 								});
 							});
 					},
-				));
+				);
+			});
 
 			parallel('balena.models.application.get()', function () {
 				applicationRetrievalFields.forEach((prop) => {

--- a/tests/integration/models/config.spec.ts
+++ b/tests/integration/models/config.spec.ts
@@ -39,17 +39,19 @@ describe('Config Model', function () {
 
 	describe('balena.models.config.getAll()', function () {
 		parallel('', function () {
-			it('should return all the configuration', () =>
-				balena.models.config.getAll().then(function (config) {
+			it('should return all the configuration', () => {
+				return balena.models.config.getAll().then(function (config) {
 					expect(_.isPlainObject(config)).to.be.true;
 					expect(_.isEmpty(config)).to.be.false;
-				}));
+				});
+			});
 
-			it('should include the mixpanel token', () =>
-				balena.models.config.getAll().then(function ({ mixpanelToken }) {
+			it('should include the mixpanel token', () => {
+				return balena.models.config.getAll().then(function ({ mixpanelToken }) {
 					expect(mixpanelToken).to.be.a('string');
 					expect(mixpanelToken).to.equal('balena-main');
-				}));
+				});
+			});
 
 			it('should include the deviceTypes', async function () {
 				const { deviceTypes } = await balena.models.config.getAll();
@@ -160,15 +162,17 @@ describe('Config Model', function () {
 	});
 
 	parallel('balena.models.config.getDeviceOptions()', function () {
-		it('should become the device options', () =>
-			balena.models.config
+		it('should become the device options', () => {
+			return balena.models.config
 				.getDeviceOptions('raspberry-pi')
-				.then((options) => expect(Array.isArray(options)).to.be.true));
+				.then((options) => expect(Array.isArray(options)).to.be.true);
+		});
 
-		it('should become the device options given a device type alias', () =>
-			balena.models.config
+		it('should become the device options given a device type alias', () => {
+			return balena.models.config
 				.getDeviceOptions('raspberrypi')
-				.then((options) => expect(Array.isArray(options)).to.be.true));
+				.then((options) => expect(Array.isArray(options)).to.be.true);
+		});
 
 		it('should reject if device type is invalid', function () {
 			const promise = balena.models.config.getDeviceOptions('foobarbaz');

--- a/tests/integration/models/device.spec.ts
+++ b/tests/integration/models/device.spec.ts
@@ -63,21 +63,23 @@ describe('Device Model', function () {
 					ctx = this;
 				});
 
-				describe('balena.models.device.getAllByApplication()', () =>
+				describe('balena.models.device.getAllByApplication()', () => {
 					it('should become an empty array', async function () {
 						const result = await balena.models.device.getAllByApplication(
 							ctx.application.id,
 						);
 						expect(result).to.deep.equal([]);
-					}));
+					});
+				});
 
-				describe('balena.models.device.getAllByOrganization()', () =>
+				describe('balena.models.device.getAllByOrganization()', () => {
 					it('should become an empty array', async function () {
 						const result = await balena.models.device.getAllByOrganization(
 							ctx.initialOrg.id,
 						);
 						expect(result).to.deep.equal([]);
-					}));
+					});
+				});
 
 				parallel('balena.models.device.generateUniqueKey()', function () {
 					it('should generate a valid uuid', function () {
@@ -221,15 +223,15 @@ describe('Device Model', function () {
 				});
 
 				parallel('balena.models.device.getAllByApplication()', function () {
-					applicationRetrievalFields.forEach((prop) =>
+					applicationRetrievalFields.forEach((prop) => {
 						it(`should get the device given the right application ${prop}`, async function () {
 							const devices = await balena.models.device.getAllByApplication(
 								ctx.application[prop],
 							);
 							expect(devices).to.have.length(1);
 							return expect(devices[0].id).to.equal(ctx.device.id);
-						}),
-					);
+						});
+					});
 
 					it('should be rejected if the application slug does not exist', function () {
 						const promise = balena.models.device.getAllByApplication(
@@ -271,15 +273,15 @@ describe('Device Model', function () {
 				});
 
 				parallel('balena.models.device.getAllByOrganization()', function () {
-					organizationRetrievalFields.forEach((prop) =>
+					organizationRetrievalFields.forEach((prop) => {
 						it(`should get the device given the right organization ${prop}`, async function () {
 							const devices = await balena.models.device.getAllByOrganization(
 								ctx.initialOrg[prop],
 							);
 							expect(devices).to.have.length(1);
 							return expect(devices[0].id).to.equal(ctx.device.id);
-						}),
-					);
+						});
+					});
 
 					it('should be rejected if the organization slug does not exist', function () {
 						const promise = balena.models.device.getAllByOrganization(
@@ -542,14 +544,14 @@ describe('Device Model', function () {
 						);
 					});
 
-					deviceUniqueFields.forEach((field) =>
+					deviceUniqueFields.forEach((field) => {
 						it(`should retrieve a empty list of mac addresses by ${field}`, async function () {
 							const result = await balena.models.device.getMACAddresses(
 								ctx.device[field],
 							);
 							expect(result).to.deep.equal([]);
-						}),
-					);
+						});
+					});
 				});
 
 				parallel('balena.models.device.getMetrics()', function () {
@@ -567,7 +569,7 @@ describe('Device Model', function () {
 						);
 					});
 
-					deviceUniqueFields.forEach((field) =>
+					deviceUniqueFields.forEach((field) => {
 						it(`should retrieve an empty device metrics object by ${field}`, async function () {
 							const result = await balena.models.device.getMetrics(
 								ctx.device[field],
@@ -583,8 +585,8 @@ describe('Device Model', function () {
 								cpu_id: null,
 								is_undervolted: false,
 							});
-						}),
-					);
+						});
+					});
 				});
 
 				describe('balena.models.device.getMACAddresses()', function () {
@@ -597,7 +599,7 @@ describe('Device Model', function () {
 					});
 
 					parallel('', function () {
-						deviceUniqueFields.forEach((field) =>
+						deviceUniqueFields.forEach((field) => {
 							it(`should be able to retrieve the device mac addresses by ${field}`, async function () {
 								const result = await balena.models.device.getMACAddresses(
 									ctx.device[field],
@@ -606,8 +608,8 @@ describe('Device Model', function () {
 									'00:11:22:33:44:55',
 									'66:77:88:99:AA:BB',
 								]);
-							}),
-						);
+							});
+						});
 					});
 				});
 
@@ -629,7 +631,7 @@ describe('Device Model', function () {
 					});
 
 					parallel('', function () {
-						deviceUniqueFields.forEach((field) =>
+						deviceUniqueFields.forEach((field) => {
 							it(`should be able to retrieve the device metrics by ${field}`, async function () {
 								const result = await balena.models.device.getMetrics(
 									ctx.device[field],
@@ -645,8 +647,8 @@ describe('Device Model', function () {
 									is_undervolted: true,
 									cpu_id: 'a CPU string',
 								});
-							}),
-						);
+							});
+						});
 					});
 				});
 			});
@@ -1247,7 +1249,7 @@ describe('Device Model', function () {
 					last_connectivity_event: '2019-05-13T16:14',
 				});
 
-				describe('balena.models.device.getLocalModeSupport()', () =>
+				describe('balena.models.device.getLocalModeSupport()', () => {
 					it('should identify the device as not supported', function () {
 						return expect(
 							balena.models.device.getLocalModeSupport(this.device),
@@ -1256,7 +1258,8 @@ describe('Device Model', function () {
 							message:
 								'Local mode is only supported on development OS versions',
 						});
-					}));
+					});
+				});
 
 				describe('balena.models.device.isInLocalMode()', function () {
 					it('should be false by default for a device retrieved by uuid', async function () {
@@ -1303,7 +1306,7 @@ describe('Device Model', function () {
 					last_connectivity_event: '2019-05-13T16:14',
 				});
 
-				describe('balena.models.device.getLocalModeSupport()', () =>
+				describe('balena.models.device.getLocalModeSupport()', () => {
 					it('should identify the device as supported', function () {
 						return expect(
 							balena.models.device.getLocalModeSupport(this.device),
@@ -1311,9 +1314,10 @@ describe('Device Model', function () {
 							supported: true,
 							message: 'Supported',
 						});
-					}));
+					});
+				});
 
-				describe('[mutating operations]', () =>
+				describe('[mutating operations]', () => {
 					deviceUniqueFields.forEach(function (deviceParam) {
 						describe('balena.models.device.isInLocalMode()', function () {
 							it(`should be false by default for a device retrieved by ${deviceParam}`, async function () {
@@ -1377,7 +1381,8 @@ describe('Device Model', function () {
 								);
 							});
 						});
-					}));
+					});
+				});
 			});
 
 			describe('balena.models.device.hasLockOverride()', function () {
@@ -2096,15 +2101,16 @@ describe('Device Model', function () {
 					);
 				});
 
-				describe('Given an inactive device', () =>
-					deviceUniqueFields.forEach((prop) =>
+				describe('Given an inactive device', () => {
+					deviceUniqueFields.forEach((prop) => {
 						it(`should return inactive when retrieving by ${prop}`, async function () {
 							const status = await balena.models.device.getStatus(
 								this.device[prop],
 							);
 							expect(status).to.equal('inactive');
-						}),
-					));
+						});
+					});
+				});
 
 				describe('Given an online device', function () {
 					before(function () {
@@ -2118,14 +2124,14 @@ describe('Device Model', function () {
 						});
 					});
 
-					deviceUniqueFields.forEach((prop) =>
+					deviceUniqueFields.forEach((prop) => {
 						it(`should return idle when retrieving by ${prop}`, async function () {
 							const status = await balena.models.device.getStatus(
 								this.device[prop],
 							);
 							expect(status).to.equal('idle');
-						}),
-					);
+						});
+					});
 				});
 
 				describe('Given an offline device', function () {
@@ -2139,14 +2145,14 @@ describe('Device Model', function () {
 						});
 					});
 
-					deviceUniqueFields.forEach((prop) =>
+					deviceUniqueFields.forEach((prop) => {
 						it(`should return offline when retrieving by ${prop}`, async function () {
 							const status = await balena.models.device.getStatus(
 								this.device[prop],
 							);
 							expect(status).to.equal('offline');
-						}),
-					);
+						});
+					});
 				});
 			});
 		});
@@ -2227,7 +2233,7 @@ describe('Device Model', function () {
 				]);
 			});
 
-			describe('balena.models.device.get()', () =>
+			describe('balena.models.device.get()', () => {
 				it('should be rejected with an error if there is an ambiguation between shorter uuids', async function () {
 					const promise = balena.models.device.get(this.uuidRoot);
 
@@ -2235,9 +2241,10 @@ describe('Device Model', function () {
 						'code',
 						'BalenaAmbiguousDevice',
 					);
-				}));
+				});
+			});
 
-			describe('balena.models.device.has()', () =>
+			describe('balena.models.device.has()', () => {
 				it('should be rejected with an error for an ambiguous shorter uuid', async function () {
 					const promise = balena.models.device.has(this.uuidRoot);
 
@@ -2245,7 +2252,8 @@ describe('Device Model', function () {
 						'code',
 						'BalenaAmbiguousDevice',
 					);
-				}));
+				});
+			});
 		});
 	});
 
@@ -2717,20 +2725,22 @@ describe('Device Model', function () {
 				last_connectivity_event: '2019-05-13T16:14',
 			});
 
-			describe('balena.models.device.getStatus()', () =>
+			describe('balena.models.device.getStatus()', () => {
 				it('should properly retrieve the status', async function () {
 					const status = await balena.models.device.getStatus(this.device.uuid);
 					expect(status).to.equal('updating');
-				}));
+				});
+			});
 
-			describe('balena.models.device.getProgress()', () =>
+			describe('balena.models.device.getProgress()', () => {
 				it('should properly retrieve the progress', async function () {
 					const result = await balena.models.device.getProgress(
 						this.device.uuid,
 					);
 					expect(result).to.be.a('number');
 					expect(result).to.equal(75);
-				}));
+				});
+			});
 		});
 
 		describe('given a newly registered offline device', function () {
@@ -3034,7 +3044,7 @@ describe('Device Model', function () {
 			describe('given a single offline device', function () {
 				givenADevice(before);
 
-				describe('balena.models.device.getWithServiceDetails()', () =>
+				describe('balena.models.device.getWithServiceDetails()', () => {
 					it('should retrieve the current service details', async function () {
 						const deviceDetails =
 							await balena.models.device.getWithServiceDetails(this.device.id);
@@ -3084,7 +3094,8 @@ describe('Device Model', function () {
 								download_progress: null,
 							},
 						]);
-					}));
+					});
+				});
 			});
 		});
 	});
@@ -3154,7 +3165,7 @@ describe('Device Model', function () {
 
 		describe('balena.models.device.move()', function () {
 			describe('when trying to move between applications of the same device type', function () {
-				applicationRetrievalFields.forEach((prop) =>
+				applicationRetrievalFields.forEach((prop) => {
 					it(`should be able to move a device by device uuid and application ${prop}`, async function () {
 						await balena.models.device.move(
 							this.deviceInfo.uuid,
@@ -3167,8 +3178,8 @@ describe('Device Model', function () {
 						return expect(applicationName).to.equal(
 							this.applicationSameDT.app_name,
 						);
-					}),
-				);
+					});
+				});
 
 				it('should be able to move a device using shorter uuids', async function () {
 					await balena.models.device.move(
@@ -3311,25 +3322,28 @@ describe('Device Model', function () {
 				);
 			});
 
-			it('should throw when a device uuid is not a string', () =>
+			it('should throw when a device uuid is not a string', () => {
 				expect(() =>
 					// @ts-expect-error invalid parameter
 					balena.models.device.getDashboardUrl(1234567),
-				).to.throw());
+				).to.throw();
+			});
 
-			it('should throw when a device uuid is not provided', () =>
+			it('should throw when a device uuid is not provided', () => {
 				// @ts-expect-error invalid parameter
-				expect(() => balena.models.device.getDashboardUrl()).to.throw());
+				expect(() => balena.models.device.getDashboardUrl()).to.throw();
+			});
 		});
 
 		describe('balena.models.device.lastOnline()', function () {
-			it('should return the string "Connecting..." if the device has no `last_connectivity_event`', () =>
+			it('should return the string "Connecting..." if the device has no `last_connectivity_event`', () => {
 				expect(
 					balena.models.device.lastOnline({
 						last_connectivity_event: null,
 						is_online: false,
 					}),
-				).to.equal('Connecting...'));
+				).to.equal('Connecting...');
+			});
 
 			it('should return the correct time string if the device is online', function () {
 				const mockDevice = {
@@ -3359,7 +3373,7 @@ describe('Device Model', function () {
 		});
 
 		describe('balena.models.device.getLocalModeSupport()', function () {
-			it('should identify a device w/o a supervisor_version as not supported', () =>
+			it('should identify a device w/o a supervisor_version as not supported', () => {
 				expect(
 					balena.models.device.getLocalModeSupport({
 						is_online: true,
@@ -3371,9 +3385,10 @@ describe('Device Model', function () {
 				).to.deep.equal({
 					supported: false,
 					message: 'Device is not yet fully provisioned',
-				}));
+				});
+			});
 
-			it('should identify a device w/o a last_connectivity_event as not supported', () =>
+			it('should identify a device w/o a last_connectivity_event as not supported', () => {
 				expect(
 					balena.models.device.getLocalModeSupport({
 						is_online: true,
@@ -3385,9 +3400,10 @@ describe('Device Model', function () {
 				).to.deep.equal({
 					supported: false,
 					message: 'Device is not yet fully provisioned',
-				}));
+				});
+			});
 
-			it('should identify a device w/o an os_version as not supported', () =>
+			it('should identify a device w/o an os_version as not supported', () => {
 				expect(
 					balena.models.device.getLocalModeSupport({
 						is_online: true,
@@ -3399,9 +3415,10 @@ describe('Device Model', function () {
 				).to.deep.equal({
 					supported: false,
 					message: 'Device OS version does not support local mode',
-				}));
+				});
+			});
 
-			it('should identify a device with an invalid os_version as not supported', () =>
+			it('should identify a device with an invalid os_version as not supported', () => {
 				expect(
 					balena.models.device.getLocalModeSupport({
 						is_online: true,
@@ -3413,9 +3430,10 @@ describe('Device Model', function () {
 				).to.deep.equal({
 					supported: false,
 					message: 'Device OS version does not support local mode',
-				}));
+				});
+			});
 
-			it('should identify a device with a v1 OS as not supported', () =>
+			it('should identify a device with a v1 OS as not supported', () => {
 				expect(
 					balena.models.device.getLocalModeSupport({
 						is_online: true,
@@ -3427,9 +3445,10 @@ describe('Device Model', function () {
 				).to.deep.equal({
 					supported: false,
 					message: 'Device OS version does not support local mode',
-				}));
+				});
+			});
 
-			it('should identify a device with an old supervisor as not supported', () =>
+			it('should identify a device with an old supervisor as not supported', () => {
 				expect(
 					balena.models.device.getLocalModeSupport({
 						is_online: true,
@@ -3441,9 +3460,10 @@ describe('Device Model', function () {
 				).to.deep.equal({
 					supported: false,
 					message: 'Device supervisor version does not support local mode',
-				}));
+				});
+			});
 
-			it('should identify a device w/o an os_variant as not supported', () =>
+			it('should identify a device w/o an os_variant as not supported', () => {
 				expect(
 					balena.models.device.getLocalModeSupport({
 						is_online: true,
@@ -3455,9 +3475,10 @@ describe('Device Model', function () {
 				).to.deep.equal({
 					supported: false,
 					message: 'Local mode is only supported on development OS versions',
-				}));
+				});
+			});
 
-			it('should identify a device with a production image as not supported', () =>
+			it('should identify a device with a production image as not supported', () => {
 				expect(
 					balena.models.device.getLocalModeSupport({
 						is_online: true,
@@ -3469,9 +3490,10 @@ describe('Device Model', function () {
 				).to.deep.equal({
 					supported: false,
 					message: 'Local mode is only supported on development OS versions',
-				}));
+				});
+			});
 
-			it('should identify a device with a development image as supported', () =>
+			it('should identify a device with a development image as supported', () => {
 				expect(
 					balena.models.device.getLocalModeSupport({
 						is_online: true,
@@ -3483,11 +3505,12 @@ describe('Device Model', function () {
 				).to.deep.equal({
 					supported: true,
 					message: 'Supported',
-				}));
+				});
+			});
 		});
 
 		describe('balena.models.device.getOsVersion()', function () {
-			it('should not parse invalid semver versions', () =>
+			it('should not parse invalid semver versions', () => {
 				_.forEach(
 					[
 						['Resin OS ', 'dev'],
@@ -3502,9 +3525,10 @@ describe('Device Model', function () {
 							}),
 						).to.equal(null);
 					},
-				));
+				);
+			});
 
-			it('should parse plain os versions w/o variant', () =>
+			it('should parse plain os versions w/o variant', () => {
 				_.forEach(
 					[
 						['Resin OS 1.2.1', '', '1.2.1'],
@@ -3530,9 +3554,10 @@ describe('Device Model', function () {
 							}),
 						).to.equal(expectation);
 					},
-				));
+				);
+			});
 
-			it('should properly combine the plain os version & variant', () =>
+			it('should properly combine the plain os version & variant', () => {
 				_.forEach(
 					[
 						['Resin OS 2.0.0-beta.8', 'prod', '2.0.0-beta.8+prod'],
@@ -3580,9 +3605,10 @@ describe('Device Model', function () {
 							}),
 						).to.equal(expectation);
 					},
-				));
+				);
+			});
 
-			it('should properly parse the os_version with variant suffix w/o os_variant', () =>
+			it('should properly parse the os_version with variant suffix w/o os_variant', () => {
 				_.forEach(
 					[
 						['Resin OS 2.0.0-rc6.rev1 (prod)', '', '2.0.0-rc6.rev1+prod'],
@@ -3601,9 +3627,10 @@ describe('Device Model', function () {
 							}),
 						).to.equal(expectation);
 					},
-				));
+				);
+			});
 
-			it('should properly combine the os_version with variant suffix & os_variant', () =>
+			it('should properly combine the os_version with variant suffix & os_variant', () => {
 				_.forEach(
 					[
 						['Resin OS 2.0.0.rev1 (prod)', 'prod', '2.0.0+rev1.prod'],
@@ -3621,7 +3648,8 @@ describe('Device Model', function () {
 							}),
 						).to.equal(expectation);
 					},
-				));
+				);
+			});
 		});
 
 		describe('balena.models.device._checkOsUpdateTarget()', function () {
@@ -3632,7 +3660,7 @@ describe('Device Model', function () {
 
 			const { _checkOsUpdateTarget } = balena.models.device;
 
-			it('should throw when the current os version is invalid', () =>
+			it('should throw when the current os version is invalid', () => {
 				[
 					['Resin OS ', 'dev'],
 					['Resin OS ', 'prod'],
@@ -3650,9 +3678,10 @@ describe('Device Model', function () {
 							'2.29.2+rev1.prod',
 						),
 					).to.throw('Invalid current balenaOS version');
-				}));
+				});
+			});
 
-			it('should throw when the device is offline', () =>
+			it('should throw when the device is offline', () => {
 				[
 					['Resin OS 1.21.0', '', '1.28.0'],
 					['Resin OS 1.30.1', '', '2.5.0+rev1'],
@@ -3670,9 +3699,10 @@ describe('Device Model', function () {
 							targetOsVersion,
 						),
 					).to.throw('The device is offline');
-				}));
+				});
+			});
 
-			it('should throw for upgrades from prod -> dev', () =>
+			it('should throw for upgrades from prod -> dev', () => {
 				[
 					['Resin OS 2.0.0+rev3 (prod)', 'prod'],
 					['Resin OS 2.0.0+rev3 (prod)', ''],
@@ -3698,9 +3728,10 @@ describe('Device Model', function () {
 					).to.throw(
 						'Updates cannot be performed between development and production balenaOS variants',
 					);
-				}));
+				});
+			});
 
-			it('should throw for upgrades from dev -> prod', () =>
+			it('should throw for upgrades from dev -> prod', () => {
 				[
 					['Resin OS 2.0.0+rev3 (dev)', 'dev'],
 					['Resin OS 2.0.0+rev5 (dev)', ''],
@@ -3730,12 +3761,13 @@ describe('Device Model', function () {
 					).to.throw(
 						'Updates cannot be performed between development and production balenaOS variants',
 					);
-				}));
+				});
+			});
 
-			describe('v1 -> v1 hup', () =>
-				['raspberrypi3', 'intel-nuc'].forEach((deviceType) =>
+			describe('v1 -> v1 hup', () => {
+				['raspberrypi3', 'intel-nuc'].forEach((deviceType) => {
 					describe(`given a ${deviceType}`, function () {
-						it('should throw when current os version is < 1.8.0', () =>
+						it('should throw when current os version is < 1.8.0', () => {
 							[
 								['Resin OS 1.2.1', ''],
 								['Resin OS 1.6.0', ''],
@@ -3753,9 +3785,10 @@ describe('Device Model', function () {
 										'1.26.0',
 									),
 								).to.throw('Current OS version must be >= 1.8.0');
-							}));
+							});
+						});
 
-						it('should throw when the target os version is below the min supported v1 version', () =>
+						it('should throw when the target os version is below the min supported v1 version', () => {
 							[
 								['Resin OS 1.8.0', ''],
 								['Resin OS 1.10.0', ''],
@@ -3774,9 +3807,10 @@ describe('Device Model', function () {
 										'1.25.0',
 									),
 								).to.throw('Target OS version must be >= 1.26.0');
-							}));
+							});
+						});
 
-						it('should not throw when it is a valid v1 -> v1 hup', () =>
+						it('should not throw when it is a valid v1 -> v1 hup', () => {
 							[
 								['Resin OS 1.8.0', ''],
 								['Resin OS 1.10.0', ''],
@@ -3795,13 +3829,15 @@ describe('Device Model', function () {
 										'1.28.0',
 									),
 								).to.not.throw();
-							}));
-					}),
-				));
+							});
+						});
+					});
+				});
+			});
 
 			describe('v1 -> v2 hup', function () {
 				describe('given a raspberrypi3', function () {
-					it('should throw when current os version is < 1.8.0', () =>
+					it('should throw when current os version is < 1.8.0', () => {
 						[
 							['Resin OS 1.2.1', ''],
 							['Resin OS 1.6.0', ''],
@@ -3819,9 +3855,10 @@ describe('Device Model', function () {
 									'2.5.0+rev1',
 								),
 							).to.throw('Current OS version must be >= 1.8.0');
-						}));
+						});
+					});
 
-					it('should not throw when it is a valid v1 -> v2 hup', () =>
+					it('should not throw when it is a valid v1 -> v2 hup', () => {
 						[
 							['Resin OS 1.8.0', ''],
 							['Resin OS 1.10.0', ''],
@@ -3842,11 +3879,12 @@ describe('Device Model', function () {
 									'2.5.0+rev1',
 								),
 							).to.not.throw();
-						}));
+						});
+					});
 				});
 
 				describe('given a beaglebone-black', function () {
-					it('should throw when current os version is < 1.30.1', () =>
+					it('should throw when current os version is < 1.30.1', () => {
 						[
 							['Resin OS 1.2.1', ''],
 							['Resin OS 1.6.0', ''],
@@ -3869,9 +3907,10 @@ describe('Device Model', function () {
 									'2.5.0+rev1',
 								),
 							).to.throw('Current OS version must be >= 1.30.1');
-						}));
+						});
+					});
 
-					it('should not throw when it is a valid v1 -> v2 hup', () =>
+					it('should not throw when it is a valid v1 -> v2 hup', () => {
 						[['Resin OS 1.30.1', '']].forEach(function ([
 							osVersion,
 							osVariant,
@@ -3888,7 +3927,8 @@ describe('Device Model', function () {
 									'2.5.0+rev1',
 								),
 							).to.not.throw();
-						}));
+						});
+					});
 				});
 			});
 
@@ -4025,7 +4065,7 @@ describe('Device Model', function () {
 				});
 
 				describe('given a jetson-tx2', function () {
-					it('should throw when current os version is < 2.7.4', () =>
+					it('should throw when current os version is < 2.7.4', () => {
 						[
 							['Resin OS 2.0.0.rev1 (prod)', 'prod'],
 							['Resin OS 2.0.0.rev1 (prod)', ''],
@@ -4073,9 +4113,10 @@ describe('Device Model', function () {
 									'2.29.2+rev1.prod',
 								),
 							).to.throw('Current OS version must be >= 2.7.4');
-						}));
+						});
+					});
 
-					it('should not throw when it is a valid v2 -> v2 prod variant hup', () =>
+					it('should not throw when it is a valid v2 -> v2 prod variant hup', () => {
 						[
 							['Resin OS 2.7.4+rev1', 'prod'],
 							['Resin OS 2.7.4+rev2', 'prod'],
@@ -4101,9 +4142,10 @@ describe('Device Model', function () {
 									'2.29.2+rev1.prod',
 								),
 							).to.not.throw();
-						}));
+						});
+					});
 
-					it('should not throw when it is a valid v2 -> v2 dev variant hup', () =>
+					it('should not throw when it is a valid v2 -> v2 dev variant hup', () => {
 						[
 							['Resin OS 2.7.4+rev1.dev', 'dev'],
 							['Resin OS 2.9.7+rev2.dev', 'dev'],
@@ -4121,7 +4163,8 @@ describe('Device Model', function () {
 									'2.29.2+rev1.dev',
 								),
 							).to.not.throw();
-						}));
+						});
+					});
 				});
 			});
 		});

--- a/tests/integration/models/os.spec.ts
+++ b/tests/integration/models/os.spec.ts
@@ -83,20 +83,22 @@ const describeCacheInvalidationChanges = function (
 			describe('balena.auth.logout()', () =>
 				itFnWithStep(() => balena.auth.logout()));
 
-			describe('balena.auth.login()', () =>
+			describe('balena.auth.login()', () => {
 				itFnWithStep(() =>
 					balena.auth.login({
 						email: credentials.email,
 						password: credentials.password,
 					}),
-				));
+				);
+			});
 
-			describe('balena.auth.loginWithToken()', () =>
+			describe('balena.auth.loginWithToken()', () => {
 				itFnWithStep(() =>
 					balena.auth
 						.authenticate(credentials)
 						.then(balena.auth.loginWithToken),
-				));
+				);
+			});
 		});
 
 		describe('when logged in with credentials', function () {
@@ -104,23 +106,26 @@ const describeCacheInvalidationChanges = function (
 
 			afterEach(() => balena.auth.logout());
 
-			describe('balena.auth.logout()', () =>
-				itFnWithStep(() => balena.auth.logout()));
+			describe('balena.auth.logout()', () => {
+				itFnWithStep(() => balena.auth.logout());
+			});
 
-			describe('balena.auth.login()', () =>
+			describe('balena.auth.login()', () => {
 				itFnWithStep(() =>
 					balena.auth.login({
 						email: credentials.email,
 						password: credentials.password,
 					}),
-				));
+				);
+			});
 
-			describe('balena.auth.loginWithToken()', () =>
+			describe('balena.auth.loginWithToken()', () => {
 				itFnWithStep(() =>
 					balena.auth
 						.authenticate(credentials)
 						.then(balena.auth.loginWithToken),
-				));
+				);
+			});
 		});
 	});
 };
@@ -464,72 +469,85 @@ describe('OS model', function () {
 
 		const osVersions = [...esrOsVersions, ...defaultOsVersions];
 
-		it("should support 'latest'", () =>
+		it("should support 'latest'", () => {
 			expect(_getMaxSatisfyingVersion('latest', osVersions)).to.equal(
 				'2021.10.2.prod',
-			));
+			);
+		});
 
-		it("should support 'latest' with among default OS versions", () =>
+		it("should support 'latest' with among default OS versions", () => {
 			expect(_getMaxSatisfyingVersion('latest', defaultOsVersions)).to.equal(
 				'2.85.2+rev3.prod',
-			));
+			);
+		});
 
-		it("should support 'latest' with among esr OS versions", () =>
+		it("should support 'latest' with among esr OS versions", () => {
 			expect(_getMaxSatisfyingVersion('latest', esrOsVersions)).to.equal(
 				'2021.10.2.prod',
-			));
+			);
+		});
 
-		it("should support 'recommended'", () =>
+		it("should support 'recommended'", () => {
 			expect(
 				_getMaxSatisfyingVersion('recommended', defaultOsVersions),
-			).to.equal('2.85.2+rev3.prod'));
+			).to.equal('2.85.2+rev3.prod');
+		});
 
-		it("should support 'default'", () =>
+		it("should support 'default'", () => {
 			expect(_getMaxSatisfyingVersion('default', defaultOsVersions)).to.equal(
 				'2.85.2+rev3.prod',
-			));
+			);
+		});
 
-		it('should support exact version', () =>
+		it('should support exact version', () => {
 			expect(_getMaxSatisfyingVersion('2.73.1+rev1.prod', osVersions)).to.equal(
 				'2.73.1+rev1.prod',
-			));
+			);
+		});
 
-		it('should support stripped version', () =>
+		it('should support stripped version', () => {
 			expect(_getMaxSatisfyingVersion('2.73.1', osVersions)).to.equal(
 				'2.73.1+rev1.prod',
-			));
+			);
+		});
 
-		it('should support exact non-semver version', () =>
+		it('should support exact non-semver version', () => {
 			expect(_getMaxSatisfyingVersion('2.0.0.rev1', osVersions)).to.equal(
 				'2.0.0.rev1.prod',
-			));
+			);
+		});
 
-		it('should return an exact match, if it exists, when given a specific version', () =>
+		it('should return an exact match, if it exists, when given a specific version', () => {
 			// Concern here is that semver says .dev is equivalent to .prod, but
 			// we want provide an exact version and use _exactly_ that version.
 			expect(_getMaxSatisfyingVersion('2.73.1+rev1.dev', osVersions)).to.equal(
 				'2.73.1+rev1.dev',
-			));
+			);
+		});
 
-		it('should return an exact match, if it exists, when given a specific ESR version', () =>
+		it('should return an exact match, if it exists, when given a specific ESR version', () => {
 			expect(_getMaxSatisfyingVersion('2020.07.2.dev', osVersions)).to.equal(
 				'2020.07.2.dev',
-			));
+			);
+		});
 
-		it('should return an equivalent result, if no exact result exists, when given a specific version', () =>
+		it('should return an equivalent result, if no exact result exists, when given a specific version', () => {
 			expect(_getMaxSatisfyingVersion('2.73.1+rev1', osVersions)).to.equal(
 				'2.73.1+rev1.prod',
-			));
+			);
+		});
 
-		it('should support ^ semver ranges in default OS releases', () =>
+		it('should support ^ semver ranges in default OS releases', () => {
 			expect(_getMaxSatisfyingVersion('^2.0.1', osVersions)).to.equal(
 				'2.85.2+rev3.prod',
-			));
+			);
+		});
 
-		it('should support ~ semver ranges in default OS releases', () =>
+		it('should support ~ semver ranges in default OS releases', () => {
 			expect(_getMaxSatisfyingVersion('~2.80.3', osVersions)).to.equal(
 				'2.80.5+rev1.prod',
-			));
+			);
+		});
 
 		it('should support > semver ranges in default OS releases', () => {
 			expect(_getMaxSatisfyingVersion('>2.80.3', defaultOsVersions)).to.equal(
@@ -543,15 +561,17 @@ describe('OS model', function () {
 			);
 		});
 
-		it('should support ^ semver ranges in ESR OS releases', () =>
+		it('should support ^ semver ranges in ESR OS releases', () => {
 			expect(_getMaxSatisfyingVersion('^2020.04.0', osVersions)).to.equal(
 				'2020.07.2.prod',
-			));
+			);
+		});
 
-		it('should support ~ semver ranges in ESR OS releases', () =>
+		it('should support ~ semver ranges in ESR OS releases', () => {
 			expect(_getMaxSatisfyingVersion('~2020.04.0', osVersions)).to.equal(
 				'2020.04.1.prod',
-			));
+			);
+		});
 
 		it('should support > semver ranges in ESR OS releases', () => {
 			expect(_getMaxSatisfyingVersion('>2020.04.0', esrOsVersions)).to.equal(
@@ -565,10 +585,11 @@ describe('OS model', function () {
 			);
 		});
 
-		it('should support non-semver version ranges', () =>
+		it('should support non-semver version ranges', () => {
 			expect(_getMaxSatisfyingVersion('^2020.04.0', osVersions)).to.equal(
 				'2020.07.2.prod',
-			));
+			);
+		});
 
 		it('should drop unsupported exact versions', () => {
 			expect(_getMaxSatisfyingVersion('2.8.8+rev8.prod', osVersions)).to.equal(
@@ -630,31 +651,34 @@ describe('OS model', function () {
 				expect(downloadSize).to.be.a('number');
 			});
 
-			it('should cache the results', () =>
-				balena.models.os
+			it('should cache the results', () => {
+				return balena.models.os
 					.getDownloadSize('raspberry-pi', '1.26.1')
 					.then((result1) =>
 						balena.models.os
 							.getDownloadSize('raspberry-pi', '1.26.1')
 							.then((result2) => expect(result1).to.equal(result2)),
-					));
+					);
+			});
 
-			it('should cache download sizes independently for each version', () =>
-				Promise.all([
+			it('should cache download sizes independently for each version', () => {
+				return Promise.all([
 					balena.models.os.getDownloadSize('raspberry-pi', '1.26.1'),
 					balena.models.os.getDownloadSize('raspberry-pi', '2.0.6+rev3.prod'),
 				]).then(function ([os1Size, os2Size]) {
 					expect(os1Size).not.to.equal(os2Size);
-				}));
+				});
+			});
 		});
 
-		describe('given an invalid device slug', () =>
+		describe('given an invalid device slug', () => {
 			it('should be rejected with an error message', function () {
 				const promise = balena.models.os.getDownloadSize('foo-bar-baz');
 				return expect(promise).to.be.rejectedWith(
 					'Invalid device type: foo-bar-baz',
 				);
-			}));
+			});
+		});
 	});
 
 	describe('balena.models.os._getDownloadSize()', function () {
@@ -716,13 +740,14 @@ describe('OS model', function () {
 			});
 		});
 
-		describe('given an invalid device slug', () =>
+		describe('given an invalid device slug', () => {
 			it('should be rejected with an error message', async function () {
 				const promise = balena.models.os.getLastModified('foo-bar-baz');
 				await expect(promise).to.be.rejectedWith(
 					'Invalid device type: foo-bar-baz',
 				);
-			}));
+			});
+		});
 	});
 
 	describe('balena.models.os.download()', function () {
@@ -736,19 +761,21 @@ describe('OS model', function () {
 		/* eslint-enable @typescript-eslint/no-var-requires */
 
 		describe('given a valid device slug', function () {
-			it('should contain a valid mime property', () =>
-				balena.models.os
+			it('should contain a valid mime property', () => {
+				return balena.models.os
 					.download({ deviceType: 'raspberry-pi' })
 					.then((stream) =>
 						expect(stream.mime).to.equal('application/octet-stream'),
-					));
+					);
+			});
 
-			it('should contain a valid mime property if passing a device type alias', () =>
-				balena.models.os
+			it('should contain a valid mime property if passing a device type alias', () => {
+				return balena.models.os
 					.download({ deviceType: 'raspberrypi' })
 					.then((stream) =>
 						expect(stream.mime).to.equal('application/octet-stream'),
-					));
+					);
+			});
 
 			it('should be able to download the image', function () {
 				const tmpFile = tmp.tmpNameSync();
@@ -762,7 +789,7 @@ describe('OS model', function () {
 			});
 		});
 
-		describe('given an invalid device slug', () =>
+		describe('given an invalid device slug', () => {
 			it('should be rejected with an error message', function () {
 				const promise = balena.models.os.download({
 					deviceType: 'foo-bar-baz',
@@ -770,11 +797,12 @@ describe('OS model', function () {
 				return expect(promise).to.be.rejectedWith(
 					'Invalid device type: foo-bar-baz',
 				);
-			}));
+			});
+		});
 	});
 
 	describe('balena.models.os.isSupportedOsUpdate()', function () {
-		describe('given an invalid device slug', () =>
+		describe('given an invalid device slug', () => {
 			it('should be rejected with an error message', function () {
 				const promise = balena.models.os.isSupportedOsUpdate(
 					'foo-bar-baz',
@@ -784,48 +812,57 @@ describe('OS model', function () {
 				return expect(promise).to.be.rejectedWith(
 					'Invalid device type: foo-bar-baz',
 				);
-			}));
+			});
+		});
 
 		describe('given a valid device slug', function () {
-			describe('given a unsupported low starting version number', () =>
-				it('should return false', () =>
-					expect(
+			describe('given a unsupported low starting version number', () => {
+				it('should return false', () => {
+					return expect(
 						balena.models.os.isSupportedOsUpdate(
 							'raspberrypi3',
 							'2.0.0+rev0.prod',
 							'2.2.0+rev2.prod',
 						),
-					).to.eventually.equal(false)));
+					).to.eventually.equal(false);
+				});
+			});
 
-			describe('given a unsupported low target version number', () =>
-				it('should return false', () =>
-					expect(
+			describe('given a unsupported low target version number', () => {
+				it('should return false', () => {
+					return expect(
 						balena.models.os.isSupportedOsUpdate(
 							'raspberrypi3',
 							'2.0.0+rev1.prod',
 							'2.1.0+rev1.prod',
 						),
-					).to.eventually.equal(false)));
+					).to.eventually.equal(false);
+				});
+			});
 
-			describe('given a dev starting version number', () =>
-				it('should return false', () =>
-					expect(
+			describe('given a dev starting version number', () => {
+				it('should return false', () => {
+					return expect(
 						balena.models.os.isSupportedOsUpdate(
 							'raspberrypi3',
 							'2.0.0+rev1.dev',
 							'2.2.0+rev2.prod',
 						),
-					).to.eventually.equal(false)));
+					).to.eventually.equal(false);
+				});
+			});
 
-			describe('given a dev target version number', () =>
-				it('should return false', () =>
-					expect(
+			describe('given a dev target version number', () => {
+				it('should return false', () => {
+					return expect(
 						balena.models.os.isSupportedOsUpdate(
 							'raspberrypi3',
 							'2.0.0+rev1.prod',
 							'2.1.0+rev1.dev',
 						),
-					).to.eventually.equal(false)));
+					).to.eventually.equal(false);
+				});
+			});
 
 			describe('given a supported os update path', () => {
 				[
@@ -849,7 +886,7 @@ describe('OS model', function () {
 	});
 
 	describe('balena.models.os.getSupportedOsUpdateVersions()', function () {
-		describe('given an invalid device slug', () =>
+		describe('given an invalid device slug', () => {
 			it('should be rejected with an error message', function () {
 				const promise = balena.models.os.getSupportedOsUpdateVersions(
 					'foo-bar-baz',
@@ -858,7 +895,8 @@ describe('OS model', function () {
 				return expect(promise).to.be.rejectedWith(
 					'Invalid device type: foo-bar-baz',
 				);
-			}));
+			});
+		});
 
 		describe('given a valid device slug', () => {
 			it('should return the list of supported hup targets', async () => {
@@ -1116,7 +1154,7 @@ describe('OS model', function () {
 		});
 	});
 
-	describe('helpers', () =>
+	describe('helpers', () => {
 		describe('balena.models.os.isArchitectureCompatibleWith()', function () {
 			[
 				['armv7hf', 'i386'],
@@ -1140,10 +1178,11 @@ describe('OS model', function () {
 				['armv7hf', 'aarch64'],
 				['aarch64', 'armv5e'],
 			].forEach(function ([deviceArch, appArch]) {
-				it(`should return false when comparing ${deviceArch} and ${appArch} architectures`, () =>
+				it(`should return false when comparing ${deviceArch} and ${appArch} architectures`, () => {
 					expect(
 						balena.models.os.isArchitectureCompatibleWith(deviceArch, appArch),
-					).to.equal(false));
+					).to.equal(false);
+				});
 			});
 
 			it('should return true when comparing the same architecture slugs', function () {
@@ -1175,14 +1214,16 @@ describe('OS model', function () {
 				['aarch64', 'rpi'],
 				['armv7hf', 'rpi'],
 			].forEach(function ([deviceArch, appArch]) {
-				it(`should return true when comparing ${deviceArch} and ${appArch} architectures`, () =>
+				it(`should return true when comparing ${deviceArch} and ${appArch} architectures`, () => {
 					expect(
 						balena.models.os.isArchitectureCompatibleWith(deviceArch, appArch),
-					).to.equal(true));
+					).to.equal(true);
+				});
 			});
-		}));
+		});
+	});
 
-	describe('supervisor', () =>
+	describe('supervisor', () => {
 		describe('balena.models.os.getSupervisorReleaseByDeviceType()', function () {
 			it('should return null if no image was found', async () => {
 				const svImage = await balena.models.os.getSupervisorReleaseByDeviceType(
@@ -1214,5 +1255,6 @@ describe('OS model', function () {
 					);
 				}
 			});
-		}));
+		});
+	});
 });

--- a/tests/integration/models/release.spec.ts
+++ b/tests/integration/models/release.spec.ts
@@ -87,14 +87,14 @@ describe('Release Model', function () {
 		});
 
 		parallel('balena.models.release.getAllByApplication()', function () {
-			applicationRetrievalFields.forEach((prop) =>
+			applicationRetrievalFields.forEach((prop) => {
 				it(`should eventually become an empty array given an application ${prop}`, async () => {
 					const releases = await balena.models.release.getAllByApplication(
 						ctx.application[prop],
 					);
 					expect(releases).to.have.lengthOf(0);
-				}),
-			);
+				});
+			});
 
 			it('should be rejected if the application name does not exist', async () => {
 				const promise =
@@ -438,7 +438,7 @@ describe('Release Model', function () {
 			});
 		});
 
-		describe('balena.models.release.getAllByApplication()', () =>
+		describe('balena.models.release.getAllByApplication()', () => {
 			it('should load both releases', async function () {
 				await balena.models.release
 					.getAllByApplication(this.application.id)
@@ -464,7 +464,8 @@ describe('Release Model', function () {
 							},
 						]);
 					});
-			}));
+			});
+		});
 
 		parallel('balena.models.release.getWithImageDetails()', function () {
 			it('should get the release with associated images attached by id', async () => {
@@ -674,7 +675,7 @@ describe('Release Model', function () {
 				});
 
 				parallel('', function () {
-					applicationRetrievalFields.forEach((prop) =>
+					applicationRetrievalFields.forEach((prop) => {
 						it(`should get the latest release by application ${prop}`, async () => {
 							const release =
 								await balena.models.release.getLatestByApplication(
@@ -686,8 +687,8 @@ describe('Release Model', function () {
 								commit: 'errored-then-fixed-release-commit',
 								belongs_to__application: { __id: ctx.application.id },
 							});
-						}),
-					);
+						});
+					});
 				});
 			});
 		});

--- a/tests/integration/models/tags.ts
+++ b/tests/integration/models/tags.ts
@@ -327,7 +327,7 @@ export const itShouldSetGetAndRemoveTags = function (opts: Options) {
 			});
 		});
 
-		describe(`${modelNamespace}.set()`, () =>
+		describe(`${modelNamespace}.set()`, () => {
 			it('should be able to update a tag without affecting the rest', async function () {
 				await model.set(ctx.resource.id, 'EDITOR', 'emacs');
 				let tags = await getAllByResource(ctx.resource.id);
@@ -337,6 +337,7 @@ export const itShouldSetGetAndRemoveTags = function (opts: Options) {
 				expect(tags[0].value).to.equal('emacs');
 				expect(tags[1].tag_key).to.equal('LANGUAGE');
 				expect(tags[1].value).to.equal('js');
-			}));
+			});
+		});
 	});
 };

--- a/tests/pine.spec.ts
+++ b/tests/pine.spec.ts
@@ -107,7 +107,7 @@ describe('Pine', function () {
 							});
 						});
 
-						describe('given there is an api key', () =>
+						describe('given there is an api key', () => {
 							it('should make the request successfully', async function () {
 								const promise = this.pine._request({
 									baseUrl: this.pine.API_URL,
@@ -115,7 +115,8 @@ describe('Pine', function () {
 									url: '/public_resource',
 								});
 								await expect(promise).to.become({ hello: 'public world' });
-							}));
+							});
+						});
 					});
 
 					describe('given a non-public resource', function () {

--- a/tests/util.spec.ts
+++ b/tests/util.spec.ts
@@ -240,15 +240,17 @@ describe('Pine option merging', function () {
 		});
 	});
 
-	it('rejects any unknown extra options', () =>
+	it('rejects any unknown extra options', () => {
 		// @ts-expect-error b/c it's not typed
 		expect(() => mergePineOptions({}, { unknownKey: 'value' })).to.throw(
 			'Unknown pine option: unknownKey',
-		));
+		);
+	});
 
-	it('ignores any unknown default options', () =>
+	it('ignores any unknown default options', () => {
 		// @ts-expect-error b/c it's not typed
-		expect(() => mergePineOptions({ unknownKey: 'value' }, {})).not.to.throw());
+		expect(() => mergePineOptions({ unknownKey: 'value' }, {})).not.to.throw();
+	});
 });
 
 const itShouldCompareVersionsProperly = function (rcompare) {
@@ -269,8 +271,9 @@ const itShouldCompareVersionsProperly = function (rcompare) {
 		return expect(rcompare('2.0.0+rev1', '2.0.6+rev3.prod')).to.equal(1);
 	});
 
-	it('sorts any rev above no rev', () =>
-		expect(rcompare('2.0.0', '2.0.0+rev1')).to.equal(1));
+	it('sorts any rev above no rev', () => {
+		expect(rcompare('2.0.0', '2.0.0+rev1')).to.equal(1);
+	});
 
 	it('sorts by non-rev build metadata for matching revs', function () {
 		expect(rcompare('2.0.6+rev3.dev', '2.0.0+rev1')).to.equal(-1);
@@ -278,7 +281,7 @@ const itShouldCompareVersionsProperly = function (rcompare) {
 		return expect(rcompare('2.0.0+rev1', '2.0.6+rev3.dev')).to.equal(1);
 	});
 
-	it('correctly sorts a full list', () =>
+	it('correctly sorts a full list', () => {
 		expect(
 			[
 				'1.0.0',
@@ -297,15 +300,18 @@ const itShouldCompareVersionsProperly = function (rcompare) {
 			'2.0.0-rc1+rev5',
 			'1.24.0+rev100',
 			'1.0.0',
-		]));
+		]);
+	});
 };
 
-describe('version comparisons', () =>
-	describe('bSemver.rcompare', () =>
-		itShouldCompareVersionsProperly(bSemver.rcompare)));
+describe('version comparisons', () => {
+	describe('bSemver.rcompare', () => {
+		itShouldCompareVersionsProperly(bSemver.rcompare);
+	});
+});
 
 describe('getDeviceOsSemverWithVariant', function () {
-	it('should not parse invalid semver versions', () =>
+	it('should not parse invalid semver versions', () => {
 		_.forEach(
 			[
 				['Resin OS ', 'dev'],
@@ -320,9 +326,10 @@ describe('getDeviceOsSemverWithVariant', function () {
 					}),
 				).to.equal(null);
 			},
-		));
+		);
+	});
 
-	it('should parse plain os versions w/o variant', () =>
+	it('should parse plain os versions w/o variant', () => {
 		_.forEach(
 			[
 				['Resin OS 1.2.1', '', '1.2.1'],
@@ -348,9 +355,10 @@ describe('getDeviceOsSemverWithVariant', function () {
 					}),
 				).to.equal(expectation);
 			},
-		));
+		);
+	});
 
-	it('should properly combine the plain os version & variant', () =>
+	it('should properly combine the plain os version & variant', () => {
 		_.forEach(
 			[
 				['Resin OS 2.0.0-beta.8', 'prod', '2.0.0-beta.8+prod'],
@@ -398,9 +406,10 @@ describe('getDeviceOsSemverWithVariant', function () {
 					}),
 				).to.equal(expectation);
 			},
-		));
+		);
+	});
 
-	it('should properly parse the os_version with variant suffix w/o os_variant', () =>
+	it('should properly parse the os_version with variant suffix w/o os_variant', () => {
 		_.forEach(
 			[
 				['Resin OS 2.0.0-rc6.rev1 (prod)', '', '2.0.0-rc6.rev1+prod'],
@@ -419,9 +428,10 @@ describe('getDeviceOsSemverWithVariant', function () {
 					}),
 				).to.equal(expectation);
 			},
-		));
+		);
+	});
 
-	it('should properly combine the os_version with variant suffix & os_variant', () =>
+	it('should properly combine the os_version with variant suffix & os_variant', () => {
 		_.forEach(
 			[
 				['Resin OS 2.0.0.rev1 (prod)', 'prod', '2.0.0+rev1.prod'],
@@ -439,5 +449,6 @@ describe('getDeviceOsSemverWithVariant', function () {
 					}),
 				).to.equal(expectation);
 			},
-		));
+		);
+	});
 });


### PR DESCRIPTION
That was in a semi-automated way. I left removing unnecessary return statements for a follow-up PR.

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
