### PR TITLE
Fix `application.create` method being wrongly marked as deprecated

### DIFF
--- a/src/models/application.ts
+++ b/src/models/application.ts
@@ -621,8 +621,7 @@ const getApplicationModel = function (
 		 * @memberof balena.models.application
 		 *
 		 * @param {Object} options - application creation parameters
-		 * @param {String} options.name - application name
-		 * @deprecated
+		 * @param {String} options.name - application names
 		 * @param {String} [options.applicationType] - application type slug e.g. microservices
 		 * @param {String} [options.applicationClass] - application class: 'app' | 'fleet' | 'block'
 		 * @param {String} options.deviceType - device type slug
@@ -656,11 +655,11 @@ const getApplicationModel = function (
 			organization,
 		}: {
 			name: string;
-			/** @deprecated */
+			/** @deprecated TODO: drop me in the next major */
 			applicationType?: string;
 			applicationClass?: 'app' | 'fleet' | 'block';
 			deviceType: string;
-			/** @deprecated */
+			/** @deprecated TODO: drop me in the next major */
 			parent?: number | string;
 			organization: number | string;
 		}): Promise<PinePostResult<Application>> {


### PR DESCRIPTION
Fix `application.create` method being wrongly marked as deprecated

The intention was to mark `options.applicationType` as deprecated
Change-type: patch

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
