### PR TITLE
Drop the toWritable helper in favor of TypeScript's satisfies

### DIFF
--- a/src/models/device.supervisor-api.partial.ts
+++ b/src/models/device.supervisor-api.partial.ts
@@ -19,6 +19,7 @@ import type {
 	InjectedOptionsParam,
 	InjectedDependenciesParam,
 	PineTypedResult,
+	PineOptions,
 } from '..';
 import type { Device } from '../types/models';
 
@@ -29,8 +30,6 @@ import {
 } from '../util';
 
 import { ensureVersionCompatibility } from '../util/device-os-version';
-
-import { toWritable } from '../util/types';
 
 // The min version where /apps API endpoints are implemented is 1.8.0 but we'll
 // be accepting >= 1.8.0-alpha.0 instead. This is a workaround for a published 1.8.0-p1
@@ -150,9 +149,9 @@ export const getSupervisorApiHelper = function (
 			imageId: string;
 		}> => {
 			const deviceOptions = {
-				$select: toWritable(['id', 'supervisor_version'] as const),
+				$select: ['id', 'supervisor_version'],
 				$expand: { belongs_to__application: { $select: 'id' } },
-			} as const;
+			} satisfies PineOptions<Device>;
 
 			const device = (await sdkInstance.models.device.get(
 				uuidOrId,
@@ -232,9 +231,9 @@ export const getSupervisorApiHelper = function (
 			withSupervisorLockedError(async () => {
 				try {
 					const deviceOptions = {
-						$select: toWritable(['id', 'supervisor_version'] as const),
-						$expand: { belongs_to__application: { $select: 'id' as const } },
-					};
+						$select: ['id', 'supervisor_version'],
+						$expand: { belongs_to__application: { $select: 'id' } },
+					} satisfies PineOptions<Device>;
 					const device = (await sdkInstance.models.device.get(
 						uuidOrId,
 						deviceOptions,
@@ -304,9 +303,9 @@ export const getSupervisorApiHelper = function (
 		 */
 		startApplication: async (uuidOrId: string | number): Promise<void> => {
 			const deviceOptions = {
-				$select: toWritable(['id', 'supervisor_version'] as const),
-				$expand: { belongs_to__application: { $select: 'id' as const } },
-			};
+				$select: ['id', 'supervisor_version'],
+				$expand: { belongs_to__application: { $select: 'id' } },
+			} satisfies PineOptions<Device>;
 			const device = (await sdkInstance.models.device.get(
 				uuidOrId,
 				deviceOptions,
@@ -358,9 +357,9 @@ export const getSupervisorApiHelper = function (
 		stopApplication: (uuidOrId: string | number): Promise<void> =>
 			withSupervisorLockedError(async () => {
 				const deviceOptions = {
-					$select: toWritable(['id', 'supervisor_version'] as const),
-					$expand: { belongs_to__application: { $select: 'id' as const } },
-				};
+					$select: ['id', 'supervisor_version'],
+					$expand: { belongs_to__application: { $select: 'id' } },
+				} satisfies PineOptions<Device>;
 				const device = (await sdkInstance.models.device.get(
 					uuidOrId,
 					deviceOptions,
@@ -643,9 +642,9 @@ export const getSupervisorApiHelper = function (
 			imageId: number,
 		): Promise<void> => {
 			const deviceOptions = {
-				$select: toWritable(['id', 'supervisor_version'] as const),
-				$expand: { belongs_to__application: { $select: 'id' as const } },
-			};
+				$select: ['id', 'supervisor_version'],
+				$expand: { belongs_to__application: { $select: 'id' } },
+			} satisfies PineOptions<Device>;
 			const device = (await sdkInstance.models.device.get(
 				uuidOrId,
 				deviceOptions,
@@ -696,9 +695,9 @@ export const getSupervisorApiHelper = function (
 		stopService: (uuidOrId: string | number, imageId: number): Promise<void> =>
 			withSupervisorLockedError(async () => {
 				const deviceOptions = {
-					$select: toWritable(['id', 'supervisor_version'] as const),
-					$expand: { belongs_to__application: { $select: 'id' as const } },
-				};
+					$select: ['id', 'supervisor_version'],
+					$expand: { belongs_to__application: { $select: 'id' } },
+				} satisfies PineOptions<Device>;
 				const device = (await sdkInstance.models.device.get(
 					uuidOrId,
 					deviceOptions,
@@ -752,9 +751,9 @@ export const getSupervisorApiHelper = function (
 		): Promise<void> =>
 			withSupervisorLockedError(async () => {
 				const deviceOptions = {
-					$select: toWritable(['id', 'supervisor_version'] as const),
-					$expand: { belongs_to__application: { $select: 'id' as const } },
-				};
+					$select: ['id', 'supervisor_version'],
+					$expand: { belongs_to__application: { $select: 'id' } },
+				} satisfies PineOptions<Device>;
 				const device = (await sdkInstance.models.device.get(
 					uuidOrId,
 					deviceOptions,

--- a/src/models/image.ts
+++ b/src/models/image.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import * as errors from 'balena-errors';
 import type { Image, PineOptions, InjectedDependenciesParam } from '..';
 import { mergePineOptions } from '../util';
-import { toWritable } from '../util/types';
 
 const getImageModel = function (deps: InjectedDependenciesParam) {
 	const { pine } = deps;
@@ -41,7 +40,7 @@ const getImageModel = function (deps: InjectedDependenciesParam) {
 		 */
 		async get(id: number, options: PineOptions<Image> = {}): Promise<Image> {
 			const baseOptions = {
-				$select: toWritable([
+				$select: [
 					// Select all the interesting fields *except* build_log
 					// (which can be very large)
 					'id',
@@ -55,8 +54,8 @@ const getImageModel = function (deps: InjectedDependenciesParam) {
 					'push_timestamp',
 					'start_timestamp',
 					'end_timestamp',
-				] as const),
-			};
+				],
+			} satisfies PineOptions<Image>;
 			const image = await pine.get({
 				resource: 'image',
 				id,

--- a/src/models/os.ts
+++ b/src/models/os.ts
@@ -43,7 +43,6 @@ import type {
 	PineTypedResult,
 } from '..';
 import { getAuthDependentMemoize } from '../util/cache';
-import { toWritable } from '../util/types';
 
 const RELEASE_POLICY_TAG_NAME = 'release-policy';
 const ESR_NEXT_TAG_NAME = 'esr-next';
@@ -68,19 +67,13 @@ export enum OsVariant {
 export type OsLines = 'next' | 'current' | 'sunset' | 'outdated' | undefined;
 
 const baseReleasePineOptions = {
-	$select: toWritable([
-		'id',
-		'known_issue_list',
-		'raw_version',
-		'variant',
-		'phase',
-	] as const),
+	$select: ['id', 'known_issue_list', 'raw_version', 'variant', 'phase'],
 	$expand: {
 		release_tag: {
-			$select: toWritable(['tag_key', 'value'] as const),
+			$select: ['tag_key', 'value'],
 		},
 	},
-};
+} satisfies PineOptions<Release>;
 
 export interface OsVersion
 	extends PineTypedResult<Release, typeof baseReleasePineOptions> {

--- a/src/models/release.ts
+++ b/src/models/release.ts
@@ -23,7 +23,6 @@ import type {
 	PineTypedResult,
 } from '..';
 import { isId, mergePineOptions } from '../util';
-import { toWritable } from '../util/types';
 import type { Application, ReleaseTag, Release, User } from '../types/models';
 import type { BuilderUrlDeployOptions } from '../util/builder';
 
@@ -222,7 +221,7 @@ const getReleaseModel = function (
 					$select: 'service_name',
 				},
 			},
-		} as const;
+		} satisfies BalenaSdk.PineOptions<BalenaSdk.Image>;
 
 		const baseReleaseOptions = {
 			$expand: {
@@ -235,10 +234,10 @@ const getReleaseModel = function (
 					},
 				},
 				is_created_by__user: {
-					$select: toWritable(['id', 'username'] as const),
+					$select: ['id', 'username'],
 				},
 			},
-		} as const;
+		} satisfies BalenaSdk.PineOptions<BalenaSdk.Release>;
 
 		const rawRelease = (await get(
 			commitOrIdOrRawVersion,

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,4 +1,0 @@
-import type { Writable } from '../../typings/utils';
-
-export const toWritable = <T extends Readonly<any>>(obj: T) =>
-	obj as Writable<T>;

--- a/tests/integration/models/application.spec.ts
+++ b/tests/integration/models/application.spec.ts
@@ -3,7 +3,6 @@ import * as _ from 'lodash';
 import { expect } from 'chai';
 import parallel from 'mocha.parallel';
 import type * as BalenaSdk from '../../..';
-import { toWritable } from '../../../src/util/types';
 import { timeSuite } from '../../util';
 import type * as tagsHelper from './tags';
 
@@ -1575,14 +1574,14 @@ describe('Application Model', function () {
 							image_install: {
 								$expand: {
 									is_provided_by__release: {
-										$select: toWritable(['id', 'commit'] as const),
+										$select: ['id', 'commit'],
 									},
 								},
 							},
 						},
 					},
 				},
-			} as const;
+			} satisfies BalenaSdk.PineOptions<BalenaSdk.Application>;
 
 			describe('balena.models.application.getWithDeviceServiceDetails()', () => {
 				it("should retrieve the application and it's devices along with service details including their commit", function () {

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -5,7 +5,6 @@ import chaiSamsam from 'chai-samsam';
 import memoizee from 'memoizee';
 import type * as BalenaSdk from '../../';
 import type { Dictionary } from '../../typings/utils';
-import { toWritable } from '../../src/util/types';
 import { getInitialOrganization } from './utils';
 chai.use(chaiAsPromised);
 chai.use(chaiSamsam);
@@ -675,13 +674,14 @@ export function givenASupervisorRelease(
 	});
 }
 
-export const organizationRetrievalFields = toWritable([
-	'id',
-	'handle',
-] as const);
-export const applicationRetrievalFields = toWritable([
+export const organizationRetrievalFields = ['id', 'handle'] satisfies Array<
+	keyof BalenaSdk.Organization
+>;
+export const applicationRetrievalFields = [
 	'id',
 	'slug',
 	'uuid',
-] as const);
-export const deviceUniqueFields = toWritable(['id', 'uuid'] as const);
+] satisfies Array<keyof BalenaSdk.Application>;
+export const deviceUniqueFields = ['id', 'uuid'] satisfies Array<
+	keyof BalenaSdk.Device
+>;

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -32,8 +32,6 @@ export type ResolvableReturnType<T extends (...args: any[]) => any> =
 
 export type AtLeast<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;
 
-export type Writable<T> = { -readonly [K in keyof T]: T[K] };
-
 // TODO: Change this approximation once TS properly supports Exact Types for generics.
 // See: https://github.com/microsoft/TypeScript/issues/12936#issuecomment-711172739
 export type ExactlyExtends<T, ExtendsBase> = ExtendsBase extends T


### PR DESCRIPTION
Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
