### PR TITLE
Limit pinejs-client-core to ~6.14.0, to fix errors in TypeScript 5.0.2 that we still support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "mime": "^3.0.0",
     "ndjson": "^2.0.0",
     "p-throttle": "^4.1.1",
-    "pinejs-client-core": "^6.12.0",
+    "pinejs-client-core": "~6.14.0",
     "tslib": "^2.1.0"
   },
   "versionist": {

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,6 +1,7 @@
 {
 	"extends": "./tsconfig.json",
 	"include": [
-		"typings/**/*.d.ts"
+		"typings/*.d.ts",
+		"es2018/**/*"
 	]
 }


### PR DESCRIPTION
Fix the TypeScript incompatibility test.
Pin pinejs-client-core to ~6.14.0, to fix errors in TypeScript 5.0.2 that we still support.

Change-type: patch
See: https://github.com/balena-io-modules/pinejs-client-js/commit/1077e19ef18cc4cede4d6401496a016fef459150
