### PR TITLE
Add typing for `update_status` and `last_update_status_event` in the Device resource

### DIFF
--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -422,6 +422,15 @@ export interface Device {
 	is_accessible_by_support_until__date: string | null;
 	is_connected_to_vpn: boolean;
 	is_locked_until__date: string;
+	update_status:
+		| 'rejected'
+		| 'downloading'
+		| 'downloaded'
+		| 'applying changes'
+		| 'aborted'
+		| 'done'
+		| null;
+	last_update_status_event: string | null;
 	is_web_accessible: boolean;
 	is_active: boolean;
 	/** This is a computed term */


### PR DESCRIPTION
Depends-on: https://github.com/balena-io/open-balena-api/pull/1692
Depends-on: https://github.com/balena-io/balena-api/pull/5130

Project: https://balena.fibery.io/Work/Project/Closing-the-loop-on-device-management-465#Project/Closing-the-loop-continued-697

Change-type: minor
