### PR TITLE
Update `lastOnline` function to return "Connected" instead of "Online"

### DIFF
--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -1898,7 +1898,7 @@ const getDeviceModel = function (
 
 			const { timeSince } = dateUtils();
 			if (device.is_online) {
-				return `Online (for ${timeSince(lce, false)})`;
+				return `Connected (for ${timeSince(lce, false)})`;
 			}
 
 			return timeSince(lce);

--- a/tests/integration/models/device.spec.ts
+++ b/tests/integration/models/device.spec.ts
@@ -3351,7 +3351,7 @@ describe('Device Model', function () {
 				};
 
 				return expect(balena.models.device.lastOnline(mockDevice)).to.equal(
-					'Online (for 5 minutes)',
+					'Connected (for 5 minutes)',
 				);
 			});
 


### PR DESCRIPTION
see: https://balena.zulipchat.com/#narrow/stream/408336-aspect.2Fuser-experience/topic/Last.20seen.20column.20contains.20mixed.20data.20from.20other.20columns/near/469060113

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
