### PR TITLE
Fix the device.setSupervisorRelease docs to not include a v prefix for the version

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2929,6 +2929,7 @@ In order to have the following computed properties in the result
 you have to explicitly define them in a `$select` in the extra options:
 * `overall_status`
 * `overall_progress`
+* `should_be_running__release`
 
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
 **Summary**: Get all devices by application  
@@ -2966,6 +2967,7 @@ In order to have the following computed properties in the result
 you have to explicitly define them in a `$select` in the extra options:
 * `overall_status`
 * `overall_progress`
+* `should_be_running__release`
 
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
 **Summary**: Get all devices by organization  
@@ -3003,6 +3005,7 @@ In order to have the following computed properties in the result
 you have to explicitly define them in a `$select` in the extra options:
 * `overall_status`
 * `overall_progress`
+* `should_be_running__release`
 
 **Kind**: static method of [<code>device</code>](#balena.models.device)  
 **Summary**: Get a single device  
@@ -3998,17 +4001,17 @@ Configures the device to run a particular supervisor release.
 | Param | Type | Description |
 | --- | --- | --- |
 | uuidOrIdOrArray | <code>String</code> \| <code>Array.&lt;String&gt;</code> \| <code>Number</code> \| <code>Array.&lt;Number&gt;</code> | device uuid (string) or id (number) or array of full uuids or ids |
-| supervisorVersionOrId | <code>String</code> \| <code>Number</code> | the version of a released supervisor (string) or id (number) |
+| supervisorVersionOrId | <code>String</code> \| <code>Number</code> | the raw version of a supervisor release (string) or id (number) |
 
 **Example**  
 ```js
-balena.models.device.setSupervisorRelease('7cf02a6', 'v10.8.0').then(function() {
+balena.models.device.setSupervisorRelease('7cf02a6', '10.8.0').then(function() {
 	...
 });
 ```
 **Example**  
 ```js
-balena.models.device.setSupervisorRelease(123, 'v11.4.14').then(function() {
+balena.models.device.setSupervisorRelease(123, '11.4.14').then(function() {
 	...
 });
 ```

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -2091,16 +2091,16 @@ const getDeviceModel = function (
 		 * @description Configures the device to run a particular supervisor release.
 		 *
 		 * @param {String|String[]|Number|Number[]} uuidOrIdOrArray - device uuid (string) or id (number) or array of full uuids or ids
-		 * @param {String|Number} supervisorVersionOrId - the version of a released supervisor (string) or id (number)
+		 * @param {String|Number} supervisorVersionOrId - the raw version of a supervisor release (string) or id (number)
 		 * @returns {Promise}
 		 *
 		 * @example
-		 * balena.models.device.setSupervisorRelease('7cf02a6', 'v10.8.0').then(function() {
+		 * balena.models.device.setSupervisorRelease('7cf02a6', '10.8.0').then(function() {
 		 * 	...
 		 * });
 		 *
 		 * @example
-		 * balena.models.device.setSupervisorRelease(123, 'v11.4.14').then(function() {
+		 * balena.models.device.setSupervisorRelease(123, '11.4.14').then(function() {
 		 * 	...
 		 * });
 		 */


### PR DESCRIPTION
Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
