### PR TITLE
Typings: remove optionality from any property that is expanded

### DIFF
--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -95,14 +95,14 @@ type ExpandedProperty<
 					: never;
 
 export type ExpandResultObject<T, Props extends keyof T> = {
-	[P in Props]: ExpandedProperty<T, P, object>;
+	[P in Props]-?: ExpandedProperty<T, P, object>;
 };
 
 type ExpandResourceExpandObject<
 	T,
 	TResourceExpand extends ResourceExpand<T>,
 > = {
-	[P in keyof TResourceExpand]: ExpandedProperty<
+	[P in keyof TResourceExpand]-?: ExpandedProperty<
 		T,
 		P extends keyof T ? P : never,
 		Exclude<TResourceExpand[P], undefined>


### PR DESCRIPTION
By expanding them we are explicitly requesting them to be included

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
