### PR TITLE
typing_tests: Target es2017 to fix compilation after recent @types/node changes

### DIFF
--- a/typing_tests/tsconfig.json
+++ b/typing_tests/tsconfig.json
@@ -1,16 +1,9 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es2017",
-            "dom"
-        ],
+        "target": "es2017",
         "strict": true,
         "noEmit": true,
-        "baseUrl": ".",
-        "typeRoots": [
-            "node_modules/@types",
-            "node_modules/@resin.io"
-        ]
+        "baseUrl": "."
     }
 }


### PR DESCRIPTION
Fixes the v error that we started getting on master
```
> balena-sdk@20.3.3 test:typings
> tsc --project ./typing_tests/tsconfig.json

Error: node_modules/@types/node/events.d.ts(140,18): error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
Error: Process completed with exit code 2.
```
See: https://github.com/balena-io/balena-sdk/actions/runs/11614536642/job/32343010756?pr=1441

Change-type: patch


<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
