### PR TITLE
Add `owns__saml_account` property to `User` interface

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6275,7 +6275,7 @@ balena.models.image.get(123).then(function(image) {
 **Kind**: static method of [<code>image</code>](#balena.models.image)  
 **Summary**: Get the logs for an image  
 **Access**: public  
-**Fulfil**: <code>string</code> - logs  
+**Fulfil**: <code>string \| null</code> - logs  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -146,6 +146,7 @@ export interface User {
 	team_membership?: ReverseNavigationResource<TeamMembership>;
 	has_direct_access_to__application?: ReverseNavigationResource<Application>;
 	user_profile?: ReverseNavigationResource<UserProfile>;
+	owns__saml_account?: ReverseNavigationResource<SamlAccount>;
 }
 
 export interface UserProfile {

--- a/typing_tests/pine-options.ts
+++ b/typing_tests/pine-options.ts
@@ -618,7 +618,8 @@ type UserExpandablePropsExpectation =
 	| 'user_application_membership'
 	| 'user_profile'
 	| 'team_membership'
-	| 'has_direct_access_to__application';
+	| 'has_direct_access_to__application'
+	| 'owns__saml_account';
 
 export const userExpandablePropsTest: Equals<
 	BalenaSdk.PineExpandableProps<BalenaSdk.User>,


### PR DESCRIPTION
Add `owns__saml_account` property to `User` interface

Change-type: minor

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
