### PR TITLE
Update Nvidia provisioning instructions to use Jetson Flash tool

### DIFF
--- a/src/models/balenaos-contract.ts
+++ b/src/models/balenaos-contract.ts
@@ -39,11 +39,7 @@ export const BalenaOS: Contract = {
 			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
 		],
 		jetsonFlash: [
-			`Put the device in recovery mode and connect to the host computer via USB`,
-			`{{#if deviceType.partials.jetsonNotes}}{{#each deviceType.partials.jetsonNotes}}{{{this}}} {{/each}}{{/if}}`,
-			`Unzip the {{name}} image and use the <a href="https://github.com/balena-os/jetson-flash">Jetson Flash tool</a> to flash the {{deviceType.name}}.`,
-			`Wait for writing of {{name}} to complete.`,
-			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
+			`To provision {{deviceType.name}}, follow the instructions using our <a href="https://github.com/balena-os/jetson-flash/blob/master/docs/{{deviceType.slug}}.md">Jetson Flash tool</a> to make the process more streamlined.`,
 		],
 		usbMassStorage: [
 			`{{#each deviceType.partials.instructions}}{{{this}}} 

--- a/tests/integration/models/device-type.spec.ts
+++ b/tests/integration/models/device-type.spec.ts
@@ -137,6 +137,12 @@ describe('Device Type model', function () {
 						'Power up the Intel NUC to boot the device.',
 					],
 				],
+				[
+					'jetson-nano',
+					[
+						'To provision Nvidia Jetson Nano SD-CARD, follow the instructions using our <a href="https://github.com/balena-os/jetson-flash/blob/master/docs/jetson-nano.md">Jetson Flash tool</a> to make the process more streamlined.',
+					],
+				],
 			] as const
 		).forEach(([deviceTypeSlug, instructions]) => {
 			it(`should get just the full instructions for installing BalenaOS for ${deviceTypeSlug} with templates strings resolved when passing the slug`, async function () {


### PR DESCRIPTION
Recently, we updated our Jetson Flash instructions to provide a more streamlined flashing experience for Nvidia devices. 
This PR points the users from both docs and dashboard to directly use the Jetson flash tool instructions.

Context; https://balena.zulipchat.com/#narrow/channel/350505-aspect.2Fgrowth/topic/Improving.20Jetson-flash.20documentation
Requires, https://github.com/balena-os/jetson-flash/pull/186

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
