### PR TITLE
Add jetsonFlashDirect instructions partial

### DIFF
--- a/src/models/balenaos-contract.ts
+++ b/src/models/balenaos-contract.ts
@@ -39,6 +39,13 @@ export const BalenaOS: Contract = {
 			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
 		],
 		jetsonFlash: [
+			`Put the device in recovery mode and connect to the host computer via USB`,
+			`{{#if deviceType.partials.jetsonNotes}}{{#each deviceType.partials.jetsonNotes}}{{{this}}} {{/each}}{{/if}}`,
+			`Unzip the {{name}} image and use the <a href="https://github.com/balena-os/jetson-flash">Jetson Flash tool</a> to flash the {{deviceType.name}}.`,
+			`Wait for writing of {{name}} to complete.`,
+			`{{{deviceType.partials.bootDevice}}} to boot the device.`,
+		],
+		jetsonFlashDirect: [
 			`To provision {{deviceType.name}}, follow the instructions using our <a href="https://github.com/balena-os/jetson-flash/blob/master/docs/{{deviceType.slug}}.md">Jetson Flash tool</a> to make the process more streamlined.`,
 		],
 		usbMassStorage: [


### PR DESCRIPTION
Soft reverting the previous patch by getting the `jetsonFlash` property back and adding a new property called jetsonFlashDirect.

Depends on: https://github.com/balena-io/contracts/pull/446