### PR TITLE
BREAKING config.getAll: Remove the missed deprecated deviceTypes property

### DIFF
--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -31,8 +31,6 @@ export interface Config {
 	recurlyPublicKey?: string;
 	stripePublicKey?: string;
 	freezeBillingVersions?: string[];
-	/** @deprecated Will be removed in a future API version. */
-	deviceTypes?: DeviceTypeJson.DeviceType[];
 	DEVICE_ONLINE_ICON: string;
 	DEVICE_OFFLINE_ICON: string;
 	signupCodeRequired: boolean;
@@ -107,7 +105,9 @@ const getConfigModel = function (
 				baseUrl: apiUrl,
 				sendToken: false,
 			});
-			body.deviceTypes = normalizeDeviceTypes(body.deviceTypes);
+			if ('deviceTypes' in body) {
+				delete body.deviceTypes;
+			}
 			return body;
 		},
 

--- a/tests/integration/models/config.spec.ts
+++ b/tests/integration/models/config.spec.ts
@@ -53,24 +53,10 @@ describe('Config Model', function () {
 				});
 			});
 
-			it('should include the deviceTypes', async function () {
-				const { deviceTypes } = await balena.models.config.getAll();
-				if (deviceTypes == null) {
-					this.skip();
-					return;
-				}
-				expectDeviceTypeArray(deviceTypes);
+			it('should not include the deviceTypes', async function () {
+				const config = await balena.models.config.getAll();
+				expect(config).to.not.have.property('deviceTypes');
 			});
-		});
-
-		describe('device type normalization', function () {
-			before(function () {
-				return balena.models.config.getAll().then(({ deviceTypes }) => {
-					this.deviceTypes = deviceTypes;
-				});
-			});
-
-			itNormalizesDeviceTypes();
 		});
 	});
 


### PR DESCRIPTION
We forgot to drop this as part of the major that we did an hour ago.

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
