### PR TITLE
logs: Add support for a start parameter when reading logs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7028,6 +7028,7 @@ can be used to listen for logs as they appear, line by line.
 | uuidOrId | <code>String</code> \| <code>Number</code> |  | device uuid (string) or id (number) |
 | [options] | <code>Object</code> |  | options |
 | [options.count] | <code>Number</code> \| <code>&#x27;all&#x27;</code> | <code>0</code> | number of historical messages to include (or 'all') |
+| [options.start] | <code>Number</code> \| <code>String</code> |  | the timestamp or ISO Date string after which to retrieve historical messages. When specified, the count parameter needs to also be provided. |
 
 **Example**  
 ```js
@@ -7060,6 +7061,7 @@ Get an array of the latest log messages for a given device.
 | uuidOrId | <code>String</code> \| <code>Number</code> |  | device uuid (string) or id (number) |
 | [options] | <code>Object</code> |  | options |
 | [options.count] | <code>Number</code> \| <code>&#x27;all&#x27;</code> | <code>1000</code> | number of log messages to return (or 'all') |
+| [options.start] | <code>Number</code> \| <code>String</code> |  | the timestamp or ISO Date string after which to retrieve historical messages |
 
 **Example**  
 ```js


### PR DESCRIPTION
The new parameter requires open-balena-api
v34.5.0.

Depends-on: https://github.com/balena-io/open-balena-api/pull/1957
Change-type: minor
See: https://balena.fibery.io/Work/Project/Device-logs-Allow-specifying-a-start-date-when-fetching-logs-1164

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
