### PR TITLE
tests/logs: Re-use the same test device across all test cases

### DIFF
--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -455,6 +455,7 @@ export function givenADevice(
 
 		const device = await balena.models.device.get(deviceInfo.uuid);
 		this.device = device;
+		this.deviceApiKey = deviceInfo.api_key;
 
 		if (!this.currentRelease?.commit) {
 			return;


### PR DESCRIPTION
Reduces the runtime of the logs tests from 2m
to 1m.

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
