### PR TITLE
logs.history(): Add examples about using the start parameter

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7079,6 +7079,24 @@ balena.logs.history(123).then(function(lines) {
 	});
 });
 ```
+**Example**  
+```js
+const oneDayAgoTimestamp = Date.now() - 24*60*60*1000;
+balena.logs.history('7cf02a6', { start: oneDayAgoTimestamp }).then(function(lines) {
+	lines.forEach(function(line) {
+		console.log(line);
+	});
+});
+```
+**Example**  
+```js
+const oneDayAgoIsoDateString = new Date(Date.now() - 24*60*60*1000).toISOString();
+balena.logs.history('7cf02a6', { start: oneDayAgoIsoDateString }).then(function(lines) {
+	lines.forEach(function(line) {
+		console.log(line);
+	});
+});
+```
 <a name="balena.logs.LogSubscription"></a>
 
 #### logs.LogSubscription : <code>EventEmitter</code>

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -256,6 +256,22 @@ const getLogs = function (
 		 * 		console.log(line);
 		 * 	});
 		 * });
+		 *
+		 * @example
+		 * const oneDayAgoTimestamp = Date.now() - 24*60*60*1000;
+		 * balena.logs.history('7cf02a6', { start: oneDayAgoTimestamp }).then(function(lines) {
+		 * 	lines.forEach(function(line) {
+		 * 		console.log(line);
+		 * 	});
+		 * });
+		 *
+		 * @example
+		 * const oneDayAgoIsoDateString = new Date(Date.now() - 24*60*60*1000).toISOString();
+		 * balena.logs.history('7cf02a6', { start: oneDayAgoIsoDateString }).then(function(lines) {
+		 * 	lines.forEach(function(line) {
+		 * 		console.log(line);
+		 * 	});
+		 * });
 		 */
 		async history(
 			uuidOrId: string | number,


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Project/Device-logs-Allow-specifying-a-start-date-when-fetching-logs-1164