### PR TITLE
Use NODE_OPTIONS=--no-experimental-strip-types for node 22.18

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,11 @@ const OPTIONS = {
 gulp.task('test', function (cb) {
 	require('dotenv').config();
 
+	// Only set NODE_OPTIONS for Node.js >= 22.18
+	const nodeVersion = process.versions.node.split('.').map(Number);
+	if (nodeVersion[0] > 22 || (nodeVersion[0] === 22 && nodeVersion[1] >= 18)) {
+		process.env.NODE_OPTIONS = '--no-experimental-strip-types';
+	}
 	const TEST_ONLY_ON_ENVIRONMENT = optionalVar('TEST_ONLY_ON_ENVIRONMENT');
 	if (TEST_ONLY_ON_ENVIRONMENT && TEST_ONLY_ON_ENVIRONMENT !== 'node') {
 		console.log(


### PR DESCRIPTION
See: https://github.com/nodejs/node/issues/59364
See: https://github.com/TypeStrong/ts-node/issues/2086
See: https://balena.fibery.io/Work/Project/Make-release-assets-publicly-available-and-maintained-1177
Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
