### PR TITLE
Fix eslint path not allowing tsconfigRootDir to be a relative path

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@balena/env-parsing": "^1.2.0",
-    "@balena/lint": "^9.0.1",
+    "@balena/lint": "9.3.3-build-fix-tsconfigRootDir-issue-8c78329b78507f0ed19fc80db422122fcbe988e8-1",
     "@types/chai": "^4.3.0",
     "@types/lodash": "^4.14.195",
     "@types/memoizee": "^0.4.12",


### PR DESCRIPTION
Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
