### PR TITLE
Remove no longer needed eslint-disable @typescript-eslint/await

### DIFF
--- a/src/models/application-invite.ts
+++ b/src/models/application-invite.ts
@@ -141,7 +141,6 @@ const getApplicationInviteModel = function (
 		) {
 			const [{ id }, roles] = await Promise.all([
 				getApplication(slugOrUuidOrId, { $select: 'id' }),
-				// eslint-disable-next-line @typescript-eslint/await-thenable -- Remove this once typescript-eslint re-allows Promise unions w/ non-Promises https://github.com/typescript-eslint/typescript-eslint/issues/11609
 				roleName
 					? pine.get({
 							resource: 'application_membership_role',

--- a/src/models/application-membership.ts
+++ b/src/models/application-membership.ts
@@ -273,7 +273,6 @@ const getApplicationMembershipModel = function (
 
 			const [{ id, organization }, roleId] = await Promise.all([
 				getApplication(application, appOptions),
-				// eslint-disable-next-line @typescript-eslint/await-thenable -- Remove this once typescript-eslint re-allows Promise unions w/ non-Promises https://github.com/typescript-eslint/typescript-eslint/issues/11609
 				roleName ? getRoleId(roleName) : undefined,
 			]);
 

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -1363,7 +1363,6 @@ const getDeviceModel = function (
 						applicationSlugOrUuidOrId,
 						applicationOptions,
 					),
-					// eslint-disable-next-line @typescript-eslint/await-thenable -- Remove this once typescript-eslint re-allows Promise unions w/ non-Promises https://github.com/typescript-eslint/typescript-eslint/issues/11609
 					typeof deviceTypeSlug === 'string'
 						? sdkInstance.models.deviceType.get(deviceTypeSlug, {
 								$select: 'slug',

--- a/src/models/organization-invite.ts
+++ b/src/models/organization-invite.ts
@@ -143,7 +143,6 @@ const getOrganizationInviteModel = function (
 		) {
 			const [{ id }, roles] = await Promise.all([
 				getOrganization(handleOrId, { $select: 'id' }),
-				// eslint-disable-next-line @typescript-eslint/await-thenable -- Remove this once typescript-eslint re-allows Promise unions w/ non-Promises https://github.com/typescript-eslint/typescript-eslint/issues/11609
 				roleName
 					? pine.get({
 							resource: 'organization_membership_role',


### PR DESCRIPTION
Change-type: patch
See: https://github.com/typescript-eslint/typescript-eslint/issues/11609
See: https://github.com/typescript-eslint/typescript-eslint/pull/11611
See: https://github.com/balena-io-modules/node-balena-lint/pull/139
See: https://balena.fibery.io/Work/Project/We-should-migrate-from-lodash-to-es-toolkit-(UI-CLI-etc.)-1895

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
