### PR TITLE
os.getSupportedOsUpdateVersions: List ESR versions when an ESR version is provided & no osType is specified

### DIFF
--- a/src/models/os.ts
+++ b/src/models/os.ts
@@ -942,8 +942,7 @@ const getOsModel = function (
 		deviceType: string,
 		currentVersion: string,
 		{
-			// TODO: Stop defaulting to 'default' on the next major
-			osType = OsTypes.DEFAULT,
+			osType,
 			...options
 		}: {
 			osType?: 'default' | 'esr' | null;
@@ -957,6 +956,12 @@ const getOsModel = function (
 				currentVersion,
 			);
 		}
+		const isEsr = currentSemver.major > 2000;
+		// TODO: Remove this defaulting in the next major
+		if (osType === undefined) {
+			osType = isEsr ? OsTypes.ESR : OsTypes.DEFAULT;
+		}
+
 		deviceType = await _getNormalizedDeviceTypeSlug(deviceType);
 		const allOsReleases = await getAvailableOsVersions(deviceType, options);
 		// use bSemver.compare to find the current version in the OS list
@@ -977,7 +982,7 @@ const getOsModel = function (
 					r.raw_version,
 				) &&
 				(r.basedOnVersion == null ||
-					currentSemver.major > 2000 ||
+					isEsr ||
 					hupActionHelper().isSupportedOsUpdate(
 						deviceType,
 						currentVersion,

--- a/tests/integration/models/os.spec.ts
+++ b/tests/integration/models/os.spec.ts
@@ -1131,6 +1131,74 @@ describe('OS model', function () {
 				);
 				expect(draftVersions).to.have.length.greaterThan(0);
 			});
+
+			it('should only include ESR OS releases as supported hup targets when an ESR version is passed and the osType is not provided', async () => {
+				const { current, recommended, versions } =
+					await balena.models.os.getSupportedOsUpdateVersions(
+						'raspberrypi3',
+						'2021.07.1.prod',
+					);
+				expect(current).to.equal('2021.07.1.prod');
+				expect(bSemver.gt(recommended, '2021.07.1')).to.be.true;
+				expect(
+					versions.filter((v) => bSemver.lte(v, '2021.07.1')),
+				).to.deep.equal([]);
+				expect(
+					versions.filter((v) => bSemver.gt(v, '2021.07.1')),
+				).to.have.length.greaterThan(0);
+			});
+
+			it('should only include ESR OS releases as supported hup targets when an ESR version is passed and the osType is null', async () => {
+				const { current, recommended, versions } =
+					await balena.models.os.getSupportedOsUpdateVersions(
+						'raspberrypi3',
+						'2021.07.1.prod',
+						{
+							osType: null,
+						},
+					);
+				expect(current).to.equal('2021.07.1.prod');
+				expect(bSemver.gt(recommended, '2021.07.1')).to.be.true;
+				expect(
+					versions.filter((v) => bSemver.lte(v, '2021.07.1')),
+				).to.deep.equal([]);
+				expect(
+					versions.filter((v) => bSemver.gt(v, '2021.07.1')),
+				).to.have.length.greaterThan(0);
+			});
+
+			it(`should return no supported hup targets when an ESR version is passed and the osType is 'default'`, async () => {
+				const { current, recommended, versions } =
+					await balena.models.os.getSupportedOsUpdateVersions(
+						'raspberrypi3',
+						'2021.07.1.prod',
+						{
+							osType: 'default',
+						},
+					);
+				expect(current).to.equal('2021.07.1.prod');
+				expect(recommended).to.equal(undefined);
+				expect(versions).to.deep.equal([]);
+			});
+
+			it(`should only include ESR OS releases as supported hup targets when an ESR version is passed and the osType is 'esr'`, async () => {
+				const { current, recommended, versions } =
+					await balena.models.os.getSupportedOsUpdateVersions(
+						'raspberrypi3',
+						'2021.07.1.prod',
+						{
+							osType: 'esr',
+						},
+					);
+				expect(current).to.equal('2021.07.1.prod');
+				expect(bSemver.gt(recommended, '2021.07.1')).to.be.true;
+				expect(
+					versions.filter((v) => bSemver.lte(v, '2021.07.1')),
+				).to.deep.equal([]);
+				expect(
+					versions.filter((v) => bSemver.gt(v, '2021.07.1')),
+				).to.have.length.greaterThan(0);
+			});
 		});
 	});
 


### PR DESCRIPTION
This should unblock HUPing devices on ESR releases via the CLI.
It doesn't enable Rolling-to-ESR HUPs, since that's postponed for later.

Change-type: minor
See: https://balena.fibery.io/Work/Project/2022

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
