### PR TITLE
Use the device.is_connected_to_vpn instead of is_online where possible

### DIFF
--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -364,7 +364,7 @@ const getDeviceModel = function (
 			options: {
 				$select: [
 					'uuid',
-					'is_online',
+					'is_connected_to_vpn',
 					'os_version',
 					'supervisor_version',
 					'os_variant',
@@ -825,10 +825,10 @@ const getDeviceModel = function (
 		 * });
 		 */
 		isOnline: async (uuidOrId: string | number): Promise<boolean> => {
-			const { is_online } = await exports.get(uuidOrId, {
-				$select: 'is_online',
+			const { is_connected_to_vpn } = await exports.get(uuidOrId, {
+				$select: 'is_connected_to_vpn',
 			});
-			return is_online;
+			return is_connected_to_vpn;
 		},
 
 		/**
@@ -860,10 +860,10 @@ const getDeviceModel = function (
 		getLocalIPAddresses: async (
 			uuidOrId: string | number,
 		): Promise<string[]> => {
-			const { is_online, ip_address } = await exports.get(uuidOrId, {
-				$select: ['is_online', 'ip_address'],
+			const { is_connected_to_vpn, ip_address } = await exports.get(uuidOrId, {
+				$select: ['is_connected_to_vpn', 'ip_address'],
 			});
-			if (!is_online) {
+			if (!is_connected_to_vpn) {
 				throw new Error(`The device is offline: ${uuidOrId}`);
 			}
 			return (ip_address ?? '').split(' ');
@@ -2172,12 +2172,12 @@ const getDeviceModel = function (
 			{
 				uuid,
 				is_of__device_type,
-				is_online,
+				is_connected_to_vpn,
 				os_version,
 				os_variant,
 			}: Pick<
 				Device['Read'],
-				'uuid' | 'is_online' | 'os_version' | 'os_variant'
+				'uuid' | 'is_connected_to_vpn' | 'os_version' | 'os_variant'
 			> & {
 				is_of__device_type: [Pick<DeviceType['Read'], 'slug'>];
 			},
@@ -2185,10 +2185,6 @@ const getDeviceModel = function (
 		) {
 			if (!uuid) {
 				throw new Error('The uuid of the device is not available');
-			}
-
-			if (!is_online) {
-				throw new Error(`The device is offline: ${uuid}`);
 			}
 
 			if (!os_version) {
@@ -2209,6 +2205,10 @@ const getDeviceModel = function (
 				throw new Error(
 					`The os variant of the device is not available: ${uuid}`,
 				);
+			}
+
+			if (!is_connected_to_vpn) {
+				throw new Error(`The device is offline: ${uuid}`);
 			}
 
 			const currentOsVersion =

--- a/tests/integration/models/device.spec.ts
+++ b/tests/integration/models/device.spec.ts
@@ -1544,30 +1544,6 @@ describe('Device Model', function () {
 							);
 						});
 
-						it('should not be able to start an OS update for an offline device', async function () {
-							await expectError(async () => {
-								await (paramType === 'array of uuids'
-									? balena.models.device.startOsUpdate(
-											[this.device.uuid],
-											'2.29.2+rev1.prod',
-										)
-									: balena.models.device.startOsUpdate(
-											this.device.uuid,
-											'2.29.2+rev1.prod',
-										));
-							}, `The device is offline: ${this.device.uuid}`);
-						});
-					});
-
-					describe('given an online device w/o os info', function () {
-						before(async function () {
-							await balena.pine.patch({
-								resource: 'device',
-								id: this.device.id,
-								body: { is_online: true },
-							});
-						});
-
 						it('should not be able to start an OS update for a device that has not yet reported its current version', async function () {
 							await expectError(async () => {
 								await (paramType === 'array of uuids'
@@ -1583,43 +1559,18 @@ describe('Device Model', function () {
 						});
 					});
 
-					describe('given an online device with os info', function () {
+					// We cannot test these since is_connected_to_vpn is not write-able by users
+					describe('given an offline device with os info', function () {
 						before(async function () {
 							await balena.pine.patch({
 								resource: 'device',
 								id: this.device.id,
-								body: {
-									is_online: true,
-									...testDeviceOsInfo,
-								},
+								body: testDeviceOsInfo,
 							});
 						});
 
-						it('should not be able to start an OS update when the target os version is not specified', async function () {
-							await expectError(
-								async () => {
-									// @ts-expect-error missing parameter
-									await balena.models.device.startOsUpdate(
-										paramType === 'array of uuids'
-											? [this.device.uuid]
-											: this.device.uuid,
-									);
-								},
-								(error) => {
-									expect(error)
-										.to.have.property('message')
-										.that.includes(
-											"undefined is not a valid value for parameter 'targetOsVersion'",
-										);
-									expect(error).to.have.property(
-										'code',
-										'BalenaInvalidParameterError',
-									);
-								},
-							);
-						});
-
-						it('should not be able to start an OS update when the target os version does not exist', async function () {
+						// TODO; Re-enable once we move from startOsUpdate/pinToOsRelease no longer checks for the device being online
+						it.skip('should not be able to start an OS update when the target os version does not exist', async function () {
 							await expectError(
 								async () => {
 									await balena.models.device.startOsUpdate(
@@ -1643,9 +1594,7 @@ describe('Device Model', function () {
 							);
 						});
 
-						// just to confirm that the above checks do not give false positives,
-						// allow the request to reach the actions server and document the current error
-						it('should not be able to start an OS update for a fake device', async function () {
+						it('should not be able to start an OS update for an offline device', async function () {
 							await expectError(
 								async () => {
 									await balena.models.device.startOsUpdate(
@@ -1656,14 +1605,10 @@ describe('Device Model', function () {
 									);
 								},
 								(error) => {
-									expect(error).to.have.property('statusCode', 500);
 									expect(error).to.have.property(
 										'message',
-										'Request error: Device is not online',
+										`The device is offline: ${this.device.uuid}`,
 									);
-									expect(error)
-										.to.have.property('code')
-										.that.is.not.equal('BalenaInvalidParameterError');
 								},
 							);
 						});
@@ -3672,7 +3617,7 @@ describe('Device Model', function () {
 							{
 								uuid,
 								is_of__device_type: [{ slug: 'raspberrypi3' }],
-								is_online: true,
+								is_connected_to_vpn: true,
 								os_version: osVersion,
 								os_variant: osVariant,
 							},
@@ -3693,7 +3638,7 @@ describe('Device Model', function () {
 							{
 								uuid,
 								is_of__device_type: [{ slug: 'raspberrypi3' }],
-								is_online: false,
+								is_connected_to_vpn: false,
 								os_version: osVersion,
 								os_variant: osVariant,
 							},
@@ -3720,7 +3665,7 @@ describe('Device Model', function () {
 							{
 								uuid,
 								is_of__device_type: [{ slug: 'raspberrypi3' }],
-								is_online: true,
+								is_connected_to_vpn: true,
 								os_version: osVersion,
 								os_variant: osVariant,
 							},
@@ -3753,7 +3698,7 @@ describe('Device Model', function () {
 							{
 								uuid,
 								is_of__device_type: [{ slug: 'raspberrypi3' }],
-								is_online: true,
+								is_connected_to_vpn: true,
 								os_version: osVersion,
 								os_variant: osVariant,
 							},
@@ -3779,7 +3724,7 @@ describe('Device Model', function () {
 										{
 											uuid,
 											is_of__device_type: [{ slug: deviceType }],
-											is_online: true,
+											is_connected_to_vpn: true,
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
@@ -3801,7 +3746,7 @@ describe('Device Model', function () {
 										{
 											uuid,
 											is_of__device_type: [{ slug: deviceType }],
-											is_online: true,
+											is_connected_to_vpn: true,
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
@@ -3823,7 +3768,7 @@ describe('Device Model', function () {
 										{
 											uuid,
 											is_of__device_type: [{ slug: deviceType }],
-											is_online: true,
+											is_connected_to_vpn: true,
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
@@ -3849,7 +3794,7 @@ describe('Device Model', function () {
 									{
 										uuid,
 										is_of__device_type: [{ slug: 'raspberrypi3' }],
-										is_online: true,
+										is_connected_to_vpn: true,
 										os_version: osVersion,
 										os_variant: osVariant,
 									},
@@ -3873,7 +3818,7 @@ describe('Device Model', function () {
 									{
 										uuid,
 										is_of__device_type: [{ slug: 'raspberrypi3' }],
-										is_online: true,
+										is_connected_to_vpn: true,
 										os_version: osVersion,
 										os_variant: osVariant,
 									},
@@ -3901,7 +3846,7 @@ describe('Device Model', function () {
 									{
 										uuid,
 										is_of__device_type: [{ slug: 'beaglebone-black' }],
-										is_online: true,
+										is_connected_to_vpn: true,
 										os_version: osVersion,
 										os_variant: osVariant,
 									},
@@ -3921,7 +3866,7 @@ describe('Device Model', function () {
 									{
 										uuid,
 										is_of__device_type: [{ slug: 'beaglebone-black' }],
-										is_online: true,
+										is_connected_to_vpn: true,
 										os_version: osVersion,
 										os_variant: osVariant,
 									},
@@ -3945,7 +3890,7 @@ describe('Device Model', function () {
 									{
 										uuid,
 										is_of__device_type: [{ slug: 'raspberrypi3' }],
-										is_online: true,
+										is_connected_to_vpn: true,
 										os_version: osVersion,
 										os_variant: osVariant,
 									},
@@ -3989,7 +3934,7 @@ describe('Device Model', function () {
 									{
 										uuid,
 										is_of__device_type: [{ slug: 'raspberrypi3' }],
-										is_online: true,
+										is_connected_to_vpn: true,
 										os_version: osVersion,
 										os_variant: osVariant,
 									},
@@ -4009,7 +3954,7 @@ describe('Device Model', function () {
 									{
 										uuid,
 										is_of__device_type: [{ slug: 'raspberrypi3' }],
-										is_online: true,
+										is_connected_to_vpn: true,
 										os_version: osVersion,
 										os_variant: osVariant,
 									},
@@ -4025,7 +3970,7 @@ describe('Device Model', function () {
 								{
 									uuid,
 									is_of__device_type: [{ slug: 'raspberrypi3' }],
-									is_online: true,
+									is_connected_to_vpn: true,
 									os_version: 'balenaOS 2.28.0+rev1',
 									os_variant: 'prod',
 								},
@@ -4040,7 +3985,7 @@ describe('Device Model', function () {
 								{
 									uuid,
 									is_of__device_type: [{ slug: 'raspberrypi3' }],
-									is_online: true,
+									is_connected_to_vpn: true,
 									os_version: 'balenaOS 2.28.0-1704382553234',
 									os_variant: 'prod',
 								},
@@ -4055,7 +4000,7 @@ describe('Device Model', function () {
 								{
 									uuid,
 									is_of__device_type: [{ slug: 'raspberrypi3' }],
-									is_online: true,
+									is_connected_to_vpn: true,
 									os_version: 'balenaOS 2.28.0-1704382553234',
 									os_variant: 'prod',
 								},
@@ -4107,7 +4052,7 @@ describe('Device Model', function () {
 									{
 										uuid,
 										is_of__device_type: [{ slug: 'jetson-tx2' }],
-										is_online: true,
+										is_connected_to_vpn: true,
 										os_version: osVersion,
 										os_variant: osVariant,
 									},
@@ -4136,7 +4081,7 @@ describe('Device Model', function () {
 									{
 										uuid,
 										is_of__device_type: [{ slug: 'jetson-tx2' }],
-										is_online: true,
+										is_connected_to_vpn: true,
 										os_version: osVersion,
 										os_variant: osVariant,
 									},
@@ -4157,7 +4102,7 @@ describe('Device Model', function () {
 									{
 										uuid,
 										is_of__device_type: [{ slug: 'jetson-tx2' }],
-										is_online: true,
+										is_connected_to_vpn: true,
 										os_version: osVersion,
 										os_variant: osVariant,
 									},


### PR DESCRIPTION
Side note, we still use `is_online` in
```
lastOnline(device: AtLeast<Device['Read'], 'last_connectivity_event' | 'is_online'>)
```
since changing it there would need a major, and also that method is deprecated and marked to be dropped on the next major anyway.

Change-type: patch
See: https://balena.fibery.io/Work/Project/2068

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
