### PR TITLE
os.getSupportedOsUpdateVersions: Fix the jsdoc of osType to String|Null

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -5574,7 +5574,7 @@ that is _not_ pre-release, can be `null`
 | currentVersion | <code>String</code> |  | semver-compatible version for the starting OS version |
 | [options] | <code>Object</code> |  | Extra options to filter the OS releases by |
 | [options.includeDraft] | <code>Boolean</code> | <code>false</code> | Whether pre-releases should be included in the results |
-| [options.osType] | <code>Boolean</code> \| <code>Null</code> | <code>&#x27;default&#x27;</code> | Can be one of 'default', 'esr' or null to include all types |
+| [options.osType] | <code>String</code> \| <code>Null</code> | <code>&#x27;default&#x27;</code> | Can be one of 'default', 'esr' or null to include all types |
 
 **Example**  
 ```js

--- a/src/models/os.ts
+++ b/src/models/os.ts
@@ -921,7 +921,7 @@ const getOsModel = function (
 	 * @param {String} currentVersion - semver-compatible version for the starting OS version
 	 * @param {Object} [options] - Extra options to filter the OS releases by
 	 * @param {Boolean} [options.includeDraft=false] - Whether pre-releases should be included in the results
-	 * @param {Boolean|Null} [options.osType='default'] - Can be one of 'default', 'esr' or null to include all types
+	 * @param {String|Null} [options.osType='default'] - Can be one of 'default', 'esr' or null to include all types
 	 * @fulfil {Object[]|Object} - An array of OsVersion objects when a single device type slug is provided,
 	 * or a dictionary of OsVersion objects by device type slug when an array of device type slugs is provided.
 	 * @fulfil {Object} - the versions information, of the following structure:


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Project/1704
See: https://github.com/balena-io/balena-sdk/pull/1580#discussion_r2756917256

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
