### PR TITLE
Replace the deprecated url.parse & url.resolve with WHATWG URL API

### DIFF
--- a/src/models/application.ts
+++ b/src/models/application.ts
@@ -20,8 +20,6 @@ import type {
 	Application,
 } from '..';
 
-import * as url from 'url';
-
 import once from 'lodash/once';
 import * as errors from 'balena-errors';
 
@@ -213,7 +211,7 @@ const getApplicationModel = function (
 				throw new Error('The id option should be a finite number');
 			}
 
-			return url.resolve(dashboardUrl, `/apps/${id}`);
+			return new URL(`/apps/${id}`, dashboardUrl).href;
 		},
 
 		/**

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -32,8 +32,6 @@ import type * as DeviceState from '../types/device-state';
 
 import type { OsUpdateActionResult } from '../util/device-actions/os-update';
 
-import * as url from 'url';
-
 import once from 'lodash/once';
 import * as bSemver from 'balena-semver';
 import * as errors from 'balena-errors';
@@ -428,7 +426,7 @@ const getDeviceModel = function (
 				throw new Error('The uuid option should be a non empty string');
 			}
 
-			return url.resolve(dashboardUrl, `/devices/${uuid}/summary`);
+			return new URL(`/devices/${uuid}/summary`, dashboardUrl).href;
 		},
 
 		/**

--- a/src/pine.ts
+++ b/src/pine.ts
@@ -1,4 +1,3 @@
-import * as url from 'url';
 import * as errors from 'balena-errors';
 import type { Params } from 'pinejs-client-core';
 import { PinejsClientCore } from 'pinejs-client-core';
@@ -38,10 +37,8 @@ export class PinejsClient extends PinejsClientCore<BalenaModel> {
 	) {
 		super({
 			...params,
-			apiPrefix: url.resolve(
-				backendParams.apiUrl,
-				`/${backendParams.apiVersion}/`,
-			),
+			apiPrefix: new URL(`/${backendParams.apiVersion}/`, backendParams.apiUrl)
+				.href,
 		});
 
 		this.backendParams = backendParams;


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Project/2258

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
