### PR TITLE
devices: Add downgrade checks to startOsUpdate & pinToOsRelease for rolling to ESR OS updates

### DIFF
--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -18,6 +18,7 @@ import type {
 	InjectedOptionsParam,
 	InjectedDependenciesParam,
 	CurrentService,
+	OsVersion,
 } from '..';
 import type {
 	Device,
@@ -125,11 +126,9 @@ const getDeviceModel = function (
 
 	const { buildDependentResource } =
 		require('../util/dependent-resource') as typeof import('../util/dependent-resource');
-	const hupActionHelper = once(
+	const hupActionUtils = once(
 		() =>
-			(
-				require('../util/device-actions/os-update/utils') as typeof import('../util/device-actions/os-update/utils')
-			).hupActionHelper,
+			require('../util/device-actions/os-update/utils') as typeof import('../util/device-actions/os-update/utils'),
 	);
 
 	const batchDeviceOperation = once(() =>
@@ -367,30 +366,31 @@ const getDeviceModel = function (
 			fn: async (devices, deviceTypeId) => {
 				const dt = await getDeviceType(deviceTypeId);
 				for (const device of devices) {
+					const availableOsReleases = await getAvailableOsVersions(
+						dt.slug,
+						isDraft,
+					);
+					const targetOsRelease = availableOsReleases.find(
+						(v) => bSemver.compare(v.raw_version, targetOsVersion) === 0,
+					);
+					if (targetOsRelease == null) {
+						throw new errors.BalenaInvalidParameterError(
+							'targetOsVersion',
+							targetOsVersion,
+						);
+					}
 					// this will throw an error if the action isn't available
 					exports._checkOsUpdateTarget(
 						{
 							...device,
 							is_of__device_type: [dt],
 						},
-						targetOsVersion,
+						targetOsRelease,
 						'start',
 					);
+
 					if (!device.is_connected_to_vpn) {
 						throw new Error(`The device is offline: ${device.uuid}`);
-					}
-
-					const osVersions = await getAvailableOsVersions(dt.slug, isDraft);
-
-					if (
-						!osVersions.some(
-							(v) => bSemver.compare(v.raw_version, targetOsVersion) === 0,
-						)
-					) {
-						throw new errors.BalenaInvalidParameterError(
-							'targetOsVersion',
-							targetOsVersion,
-						);
 					}
 				}
 
@@ -2147,7 +2147,7 @@ const getDeviceModel = function (
 			}: Pick<Device['Read'], 'uuid' | 'os_version' | 'os_variant'> & {
 				is_of__device_type: [Pick<DeviceType['Read'], 'slug'>];
 			},
-			targetOsVersion: string,
+			targetOsRelease: Pick<OsVersion, 'raw_version' | 'basedOnVersion'>,
 			// TODO: Drop this extra parameter in the next major when we drop startOsUpdate
 			mode: 'start' | 'pin',
 		) {
@@ -2159,6 +2159,12 @@ const getDeviceModel = function (
 				throw new Error(
 					`The current os version of the device is not available: ${uuid}`,
 				);
+			}
+
+			const currentOsSemver = bSemver.parse(os_version);
+			if (currentOsSemver == null) {
+				const { HUPActionError } = hupActionUtils();
+				throw new HUPActionError('Invalid current balenaOS version');
 			}
 
 			const deviceType = is_of__device_type?.[0]?.slug;
@@ -2175,19 +2181,17 @@ const getDeviceModel = function (
 				);
 			}
 
-			if (
-				mode === 'pin' &&
-				// Allow pinning the device back to the current OS version
-				bSemver.parse(os_version) != null &&
-				bSemver.parse(targetOsVersion) != null
-			) {
+			// Allow pinning the device back to the current OS version
+			if (mode === 'pin') {
 				// TODO: Switch the regex to capture groups once we bump to es2018
+				// We can assume that raw_version is valid since it comes from the API.
 				const [, targetOsVersionWoVariant, , targetReleaseVariant] =
-					targetOsVersion.match(/^(.+?)(\.(dev|prod))?$/) ?? [];
+					targetOsRelease.raw_version.match(/^(.+?)(\.(dev|prod))?$/) ?? [];
 				if (
 					targetOsVersionWoVariant != null &&
 					(targetReleaseVariant == null ||
 						targetReleaseVariant === os_variant) &&
+					// We have already checked that we can parse os_version
 					bSemver.compare(os_version, targetOsVersionWoVariant) === 0
 				) {
 					// This is not part of the hup-action utils b/c the proxy needs to block such requests,
@@ -2206,11 +2210,27 @@ const getDeviceModel = function (
 			// rely on getHUPActionType to throw an error
 
 			// this will throw an error if the action isn't available
-			hupActionHelper().getHUPActionType(
+			hupActionUtils().hupActionHelper.getHUPActionType(
 				deviceType,
 				currentOsVersionWithVariant,
-				targetOsVersion,
+				targetOsRelease.raw_version,
 			);
+			// Check for downgrades for rolling -> ESR HUPs
+			const isOnEsr = currentOsSemver.major > 2000;
+			if (!isOnEsr && targetOsRelease.basedOnVersion != null) {
+				const parsedTargetOsVersion = bSemver.parse(
+					targetOsRelease.raw_version,
+				);
+				const targetIsEsr =
+					parsedTargetOsVersion != null && parsedTargetOsVersion.major > 2000;
+				if (targetIsEsr) {
+					hupActionUtils().hupActionHelper.getHUPActionType(
+						deviceType,
+						currentOsVersionWithVariant,
+						targetOsRelease.basedOnVersion,
+					);
+				}
+			}
 		},
 
 		// TODO: At some point add => @deprecated Use models.device.pinToOsRelease
@@ -2320,7 +2340,7 @@ const getDeviceModel = function (
 								...device,
 								is_of__device_type: [dt],
 							},
-							targetOsRelease.raw_version,
+							targetOsRelease,
 							'pin',
 						);
 					}

--- a/src/util/device-actions/os-update/utils.ts
+++ b/src/util/device-actions/os-update/utils.ts
@@ -1,3 +1,4 @@
 import { HUPActionHelper } from 'balena-hup-action-utils';
 
 export const hupActionHelper = new HUPActionHelper();
+export { HUPActionError } from 'balena-hup-action-utils';

--- a/tests/integration/models/device.spec.ts
+++ b/tests/integration/models/device.spec.ts
@@ -3752,7 +3752,7 @@ describe('Device Model', function () {
 								os_version: osVersion,
 								os_variant: osVariant,
 							},
-							'2.29.2+rev1.prod',
+							{ raw_version: '2.29.2+rev1.prod' },
 							'start',
 						);
 					}).to.throw('Invalid current balenaOS version');
@@ -3779,7 +3779,7 @@ describe('Device Model', function () {
 								os_version: osVersion,
 								os_variant: osVariant,
 							},
-							'2.29.2+rev1.dev',
+							{ raw_version: '2.29.2+rev1.dev' },
 							'start',
 						);
 					}).to.throw(
@@ -3812,7 +3812,7 @@ describe('Device Model', function () {
 								os_version: osVersion,
 								os_variant: osVariant,
 							},
-							'2.29.2+rev1.prod',
+							{ raw_version: '2.29.2+rev1.prod' },
 							'start',
 						);
 					}).to.throw(
@@ -3839,7 +3839,7 @@ describe('Device Model', function () {
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
-										'1.28.0',
+										{ raw_version: '1.28.0' },
 										'start',
 									);
 								}).to.throw('Current OS version must be >= 2.14.0+rev1');
@@ -3867,7 +3867,7 @@ describe('Device Model', function () {
 										os_version: osVersion,
 										os_variant: osVariant,
 									},
-									'2.16.0+rev1',
+									{ raw_version: '2.16.0+rev1' },
 									'start',
 								);
 							}).to.throw('Current OS version must be >= 2.14.0+rev1');
@@ -3903,7 +3903,7 @@ describe('Device Model', function () {
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
-										'2.29.2+rev1.prod',
+										{ raw_version: '2.29.2+rev1.prod' },
 										'start',
 									);
 								}).to.throw('Current OS version must be >= 2.14.0+rev1');
@@ -3925,7 +3925,32 @@ describe('Device Model', function () {
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
-										'2.29.2+rev1.prod',
+										{ raw_version: '2.29.2+rev1.prod' },
+										'start',
+									);
+								}).to.not.throw();
+							}
+						});
+
+						it('should not throw when it is a valid v2 -> v2 hup, when basedOnVersion is set on a rolling release', () => {
+							for (const [osVersion, osVariant] of [
+								['Resin OS 2.14.0+rev1', 'prod'],
+								['Resin OS 2.15.1+rev1', 'prod'],
+								['Resin OS 2.16.0+rev1', 'prod'],
+								['balenaOS 2.26.0+rev1', 'prod'],
+							]) {
+								expect(() => {
+									_checkOsUpdateTarget(
+										{
+											uuid,
+											is_of__device_type: [{ slug: deviceTypeSlug }],
+											os_version: osVersion,
+											os_variant: osVariant,
+										},
+										{
+											raw_version: '2.29.2+rev1.prod',
+											basedOnVersion: '2.29.2+rev1.prod',
+										},
 										'start',
 									);
 								}).to.not.throw();
@@ -3947,7 +3972,7 @@ describe('Device Model', function () {
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
-										'2.28.0-1704382553234+rev1.prod',
+										{ raw_version: '2.28.0-1704382553234+rev1.prod' },
 										'start',
 									);
 								}).to.throw('OS downgrades are not allowed');
@@ -3963,7 +3988,7 @@ describe('Device Model', function () {
 										os_version: 'balenaOS 2.28.0+rev1',
 										os_variant: 'prod',
 									},
-									'2.29.2-1704382618288+rev1.prod',
+									{ raw_version: '2.29.2-1704382618288+rev1.prod' },
 									'start',
 								);
 							}).to.not.throw();
@@ -3978,7 +4003,7 @@ describe('Device Model', function () {
 										os_version: 'balenaOS 2.28.0-1704382553234',
 										os_variant: 'prod',
 									},
-									'2.29.2+rev1.prod',
+									{ raw_version: '2.29.2+rev1.prod' },
 									'start',
 								);
 							}).to.not.throw();
@@ -3993,11 +4018,104 @@ describe('Device Model', function () {
 										os_version: 'balenaOS 2.28.0-1704382553234',
 										os_variant: 'prod',
 									},
-									'2.29.2-1704382618288+rev1.prod',
+									{ raw_version: '2.29.2-1704382618288+rev1.prod' },
 									'start',
 								);
 							}).to.not.throw();
 						});
+
+						// ESR
+
+						const esr = {
+							v2021_04_0: {
+								raw_version: '2021.04.0.prod',
+								basedOnVersion: '2.73.15',
+							},
+							v2022_7_0: {
+								raw_version: '2022.7.0',
+								basedOnVersion: 'v2.99.27',
+							},
+						};
+
+						for (const [osVersion, osVariant, target] of [
+							['balenaOS 2.75.1+rev1', 'prod', esr.v2021_04_0],
+							['balenaOS 2.102.6', 'prod', esr.v2021_04_0],
+							['balenaOS 2.102.6', 'prod', esr.v2022_7_0],
+						] as const) {
+							it(`should throw when a rolling to ESR update would cause to a downgrade, ${osVersion}->${target.raw_version}`, () => {
+								expect(() => {
+									_checkOsUpdateTarget(
+										{
+											uuid,
+											is_of__device_type: [{ slug: deviceTypeSlug }],
+											os_version: osVersion,
+											os_variant: osVariant,
+										},
+										target,
+										'start',
+									);
+								}).to.throw('OS downgrades are not allowed');
+							});
+						}
+
+						for (const [osVersion, osVariant, target] of [
+							[`balenaOS ${esr.v2022_7_0.raw_version}`, 'prod', esr.v2021_04_0],
+						] as const) {
+							it(`should throw when an ESR to ESR update would cause to a downgrade, ${osVersion}->${target.raw_version}`, () => {
+								expect(() => {
+									_checkOsUpdateTarget(
+										{
+											uuid,
+											is_of__device_type: [{ slug: deviceTypeSlug }],
+											os_version: osVersion,
+											os_variant: osVariant,
+										},
+										target,
+										'start',
+									);
+								}).to.throw('OS downgrades are not allowed');
+							});
+						}
+
+						for (const [osVersion, osVariant, target] of [
+							['balenaOS 2.60.1+rev1', 'prod', esr.v2021_04_0],
+							['balenaOS 2.60.1+rev1', 'prod', esr.v2022_7_0],
+							['balenaOS 2.75.1+rev1', 'prod', esr.v2022_7_0],
+						] as const) {
+							it(`should not throw when a valid rolling to ESR update is triggered, ${osVersion}->${target.raw_version}`, () => {
+								expect(() => {
+									_checkOsUpdateTarget(
+										{
+											uuid,
+											is_of__device_type: [{ slug: deviceTypeSlug }],
+											os_version: osVersion,
+											os_variant: osVariant,
+										},
+										target,
+										'start',
+									);
+								}).to.not.throw();
+							});
+						}
+
+						for (const [osVersion, osVariant, target] of [
+							[`balenaOS ${esr.v2021_04_0.raw_version}`, 'prod', esr.v2022_7_0],
+						] as const) {
+							it(`should not throw when an valid ESR to ESR update is triggered, ${osVersion}->${target.raw_version}`, () => {
+								expect(() => {
+									_checkOsUpdateTarget(
+										{
+											uuid,
+											is_of__device_type: [{ slug: deviceTypeSlug }],
+											os_version: osVersion,
+											os_variant: osVariant,
+										},
+										target,
+										'start',
+									);
+								}).to.not.throw();
+							});
+						}
 
 						// dev variant
 
@@ -4017,7 +4135,7 @@ describe('Device Model', function () {
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
-										'2.29.2+rev1.dev',
+										{ raw_version: '2.29.2+rev1.dev' },
 										'start',
 									);
 								}).to.throw('Current OS version must be >= 2.14.0+rev1');
@@ -4039,7 +4157,7 @@ describe('Device Model', function () {
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
-										'2.29.2+rev1.dev',
+										{ raw_version: '2.29.2+rev1.dev' },
 										'start',
 									);
 								}).to.not.throw();
@@ -4069,7 +4187,7 @@ describe('Device Model', function () {
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
-										rawVersion,
+										{ raw_version: rawVersion },
 										'start',
 									);
 								}).to.throw();
@@ -4087,7 +4205,7 @@ describe('Device Model', function () {
 												os_version: osVersion,
 												os_variant: oppositeVariant,
 											},
-											rawVersion,
+											{ raw_version: rawVersion },
 											'pin',
 										);
 									}).to.throw();
@@ -4103,7 +4221,7 @@ describe('Device Model', function () {
 											os_version: osVersion,
 											os_variant: osVariant,
 										},
-										rawVersion,
+										{ raw_version: rawVersion },
 										'pin',
 									);
 								}).to.not.throw();


### PR DESCRIPTION


Change-type: patch
See: https://balena.fibery.io/Work/Project/1704

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
