### PR TITLE
Remove deprecation policy in favor of moving it to the product docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,20 +99,7 @@ If you face any issues, please [raise an issue](https://github.com/balena-io/bal
 
 ## Deprecation policy
 
-The balena SDK uses [semver versioning](https://semver.org/), with the concepts
-of major, minor and patch version releases.
-
-The latest release of the previous major version of the balena SDK will remain
-compatible with the balenaCloud backend services for one year from the date when
-the next major version is released.
-For example, balena SDK v12.33.4, as the latest v12 release, would remain
-compatible with the balenaCloud backend for one year from the date when v13.0.0
-is released.
-
-At the end of this period, the older major version is considered deprecated and
-some of the functionality that depends on balenaCloud services may stop working
-at any time.
-Users are encouraged to regularly update the balena SDK to the latest version.
+The deprecation policy for our SDKs can be found in our [docs](https://docs.balena.io/reference/sdk/deprecation-policy).
 
 ## Tests
 

--- a/tests/integration/models/device.spec.ts
+++ b/tests/integration/models/device.spec.ts
@@ -2200,31 +2200,18 @@ describe('Device Model', function () {
 					}
 				});
 
-				describe('Given a vpn only online device', function () {
-					before(function () {
-						return balena.pine.patch({
+				describe('Given an offline device', function () {
+					before(async function () {
+						// Bring the device online just to reactivate it
+						await balena.pine.patch({
 							resource: 'device',
 							id: this.device.id,
 							body: {
-								// this also activates the device
 								is_online: true,
 							},
 						});
-					});
-
-					for (const prop of deviceUniqueFields) {
-						it(`should return reduced-functionality when retrieving by ${prop}`, async function () {
-							const status = await balena.models.device.getStatus(
-								this.device[prop],
-							);
-							expect(status).to.equal('reduced-functionality');
-						});
-					}
-				});
-
-				describe('Given an offline device', function () {
-					before(function () {
-						return balena.pine.patch({
+						// Then disconnect the device again
+						await balena.pine.patch({
 							resource: 'device',
 							id: this.device.id,
 							body: {
@@ -2257,7 +2244,7 @@ describe('Device Model', function () {
 						$select: ['overall_status', 'overall_progress'],
 					});
 					expect(device).to.deep.equal({
-						overall_status: 'reduced-functionality',
+						overall_status: 'disconnected',
 						overall_progress: null,
 					});
 				});

--- a/tests/integration/models/os.spec.ts
+++ b/tests/integration/models/os.spec.ts
@@ -72,7 +72,7 @@ const itShouldClear = {
 	),
 	getDownloadSizeCache: itShouldClearMethodCacheFactory(
 		'balena.models.os._getDownloadSize()',
-		() => _getDownloadSize('raspberry-pi', '1.26.1'),
+		() => _getDownloadSize('raspberry-pi', '2.26.0+rev1.prod'),
 	),
 };
 
@@ -762,7 +762,7 @@ describe('OS model', function () {
 			it('should get a result for ResinOS v1', async function () {
 				const downloadSize = await balena.models.os.getDownloadSize(
 					'raspberry-pi',
-					'1.26.1',
+					'2.26.0+rev1.prod',
 				);
 				expect(downloadSize).to.be.a('number');
 			});
@@ -777,18 +777,18 @@ describe('OS model', function () {
 
 			it('should cache the results', () => {
 				return balena.models.os
-					.getDownloadSize('raspberry-pi', '1.26.1')
+					.getDownloadSize('raspberry-pi', '2.26.0+rev1.prod')
 					.then((result1) =>
 						balena.models.os
-							.getDownloadSize('raspberry-pi', '1.26.1')
+							.getDownloadSize('raspberry-pi', '2.26.0+rev1.prod')
 							.then((result2) => expect(result1).to.equal(result2)),
 					);
 			});
 
 			it('should cache download sizes independently for each version', () => {
 				return Promise.all([
-					balena.models.os.getDownloadSize('raspberry-pi', '1.26.1'),
-					balena.models.os.getDownloadSize('raspberry-pi', '2.0.6+rev3.prod'),
+					balena.models.os.getDownloadSize('raspberry-pi', '2.26.0+rev1.prod'),
+					balena.models.os.getDownloadSize('raspberry-pi', '2.29.0+rev1.prod'),
 				]).then(function ([os1Size, os2Size]) {
 					expect(os1Size).not.to.equal(os2Size);
 				});
@@ -806,9 +806,9 @@ describe('OS model', function () {
 
 	describe('balena.models.os._getDownloadSize()', function () {
 		it('should cache the results', function () {
-			const p1 = _getDownloadSize('raspberry-pi', '1.26.1');
+			const p1 = _getDownloadSize('raspberry-pi', '2.26.0+rev1.prod');
 			return p1.then(function (result1) {
-				const p2 = _getDownloadSize('raspberry-pi', '1.26.1');
+				const p2 = _getDownloadSize('raspberry-pi', '2.26.0+rev1.prod');
 				return p2.then(function (result2) {
 					expect(result1).to.equal(result2);
 					expect(p1).to.equal(p2);
@@ -1300,40 +1300,6 @@ describe('OS model', function () {
 						);
 					},
 				);
-			});
-
-			it('should be able to configure v1 image parameters', function () {
-				const configOptions = {
-					appUpdatePollInterval: 72,
-					network: 'wifi' as const,
-					wifiKey: 'foobar',
-					wifiSsid: 'foobarbaz',
-					ip: '1.2.3.4',
-					gateway: '5.6.7.8',
-					netmask: '9.10.11.12',
-					version: '1.26.1',
-					// Use a name prefix to make cleaning up the api key easier
-					provisioningKeyName: `${TEST_KEY_NAME_PREFIX}-confdl-1-26-1`,
-				};
-				return balena.models.os
-					.getConfig(ctx.application.id, configOptions)
-					.then(function (config) {
-						expect(
-							_.pick(config, ['appUpdatePollInterval', 'wifiKey', 'wifiSsid']),
-						).to.deep.equal({
-							// NOTE: the interval is converted to ms in the config object
-							appUpdatePollInterval:
-								configOptions.appUpdatePollInterval * 60 * 1000,
-							wifiKey: configOptions.wifiKey,
-							wifiSsid: configOptions.wifiSsid,
-						});
-						expect(config)
-							.to.have.property('files')
-							.that.has.property('network/network.config')
-							.that.includes(
-								`${configOptions.ip}/${configOptions.netmask}/${configOptions.gateway}`,
-							);
-					});
 			});
 
 			it('should be able to configure v2 image parameters', function () {


### PR DESCRIPTION
Change-type: patch
Connects-to: https://github.com/balena-io/docs/pull/3491
Fibery: https://balena.fibery.io/Work/Project/Move-non-reference-external-docs-directly-into-the-docs-2487
Fibery: https://balena.fibery.io/Work/Improvement/balena-io-balena-sdk-4223
Fibery: https://balena.fibery.io/Work/Improvement/Review-all-automations-with-a-focus-on-reducing-their-number-3933

Fix commit is necessary due to https://github.com/balena-io/open-balena-api/pull/1607

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
