### PR TITLE
Switch from custom `Dictionary` type to built in `Record` typing

### DIFF
--- a/src/models/balenaos-contract.ts
+++ b/src/models/balenaos-contract.ts
@@ -1,4 +1,3 @@
-import type { Dictionary } from '../../typings/utils';
 import type { Contract } from '../types/contract';
 
 // Hardcoded host OS contract, this should be moved to the Yocto build process with meta-balena.
@@ -43,7 +42,7 @@ export const BalenaOS: Contract = {
 			`To provision {{deviceType.name}}, follow the instructions using our [Jetson Flash tool](https://github.com/balena-os/jetson-flash/blob/master/docs/{{deviceType.slug}}.md) to make the process more streamlined.`,
 		],
 		usbMassStorage: [
-			`{{#each deviceType.partials.instructions}}{{{this}}} 
+			`{{#each deviceType.partials.instructions}}{{{this}}}
 			{{/each}}`,
 		],
 		edisonFlash: {
@@ -75,7 +74,7 @@ export const BalenaOS: Contract = {
 	},
 };
 
-export const aliases: Dictionary<string> = {
+export const aliases: Record<string, string> = {
 	sdcard: 'SD card',
 	usb_mass_storage: 'USB key',
 };

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -66,11 +66,7 @@ import {
 	MIN_SUPERVISOR_MC_API,
 } from './device.supervisor-api.partial';
 
-import type {
-	AtLeast,
-	Dictionary,
-	ResolvableReturnType,
-} from '../../typings/utils';
+import type { AtLeast, ResolvableReturnType } from '../../typings/utils';
 import type { DeviceType } from '../types/models';
 import type {
 	FilterObj,
@@ -314,12 +310,12 @@ const getDeviceModel = function (
 		uuidOrUuids: string[],
 		targetOsVersion: string,
 		options?: { runDetached?: boolean },
-	): Promise<Dictionary<OsUpdateActionResult>>;
+	): Promise<Record<string, OsUpdateActionResult>>;
 	async function startOsUpdate(
 		uuidOrUuids: string | string[],
 		targetOsVersion: string,
 		options: { runDetached?: boolean } = { runDetached: true },
-	): Promise<OsUpdateActionResult | Dictionary<OsUpdateActionResult>> {
+	): Promise<OsUpdateActionResult | Record<string, OsUpdateActionResult>> {
 		if (!targetOsVersion) {
 			throw new errors.BalenaInvalidParameterError(
 				'targetOsVersion',
@@ -347,7 +343,8 @@ const getDeviceModel = function (
 
 		const osUpdateHelper = await getOsUpdateHelper();
 
-		const results: Dictionary<
+		const results: Record<
+			string,
 			ResolvableReturnType<typeof osUpdateHelper.startOsUpdate>
 		> = {};
 

--- a/src/models/os.ts
+++ b/src/models/os.ts
@@ -19,11 +19,7 @@ import * as errors from 'balena-errors';
 
 import { isNotFoundResponse, onlyIf, mergePineOptions, once } from '../util';
 import type { BalenaRequestStreamResult } from 'balena-request';
-import type {
-	Dictionary,
-	ResolvableReturnType,
-	TypeOrDictionary,
-} from '../../typings/utils';
+import type { ResolvableReturnType, TypeOrRecord } from '../../typings/utils';
 import type {
 	ApplicationTag,
 	DeviceTag,
@@ -144,15 +140,15 @@ const sortVersions = (a: OsVersion, b: OsVersion) => {
  * run app containers compiled for the architectures in the values
  * @private
  */
-const archCompatibilityMap: Partial<Dictionary<string[]>> = {
+const archCompatibilityMap: Partial<Record<string, string[]>> = {
 	aarch64: ['armv7hf', 'rpi'],
 	armv7hf: ['rpi'],
 };
 
 const tagsToDictionary = (
 	tags: Array<Pick<ResourceTagBase, 'tag_key' | 'value'>>,
-): Partial<Dictionary<string>> => {
-	const result: Dictionary<string> = Object.create(null);
+): Partial<Record<string, string>> => {
+	const result: Record<string, string> = Object.create(null);
 	for (const { tag_key, value } of tags) {
 		result[tag_key] = value;
 	}
@@ -333,7 +329,7 @@ const getOsModel = function (
 	};
 
 	const _transformHostApps = (apps: HostAppInfo[]) => {
-		const osVersionsByDeviceType: Dictionary<OsVersion[]> = {};
+		const osVersionsByDeviceType: Record<string, OsVersion[]> = {};
 		for (const hostApp of apps) {
 			const hostAppDeviceType = hostApp.is_for__device_type[0]?.slug;
 			if (!hostAppDeviceType) {
@@ -360,7 +356,7 @@ const getOsModel = function (
 		deviceTypes: string[],
 		options: ODataOptionsWithoutCount<Release['Read']> | undefined,
 		convenienceFilter: 'supported' | 'include_draft' | 'all',
-	): Promise<Dictionary<OsVersion[]>> => {
+	): Promise<Record<string, OsVersion[]>> => {
 		const extraFilterOptions = {
 			...((convenienceFilter === 'supported' ||
 				convenienceFilter === 'include_draft') && {
@@ -396,7 +392,7 @@ const getOsModel = function (
 		deviceType: DT,
 		pineOptions?: undefined,
 		extraOptions?: { includeDraft?: boolean },
-	): Promise<DT extends string ? OsVersion[] : Dictionary<OsVersion[]>>;
+	): Promise<DT extends string ? OsVersion[] : Record<string, OsVersion[]>>;
 	async function getAvailableOsVersions<
 		DT extends string | string[],
 		TP extends ODataOptionsWithoutCount<Release['Read']>,
@@ -407,7 +403,7 @@ const getOsModel = function (
 	): Promise<
 		DT extends string
 			? OsVersionResponse<TP>
-			: Dictionary<OsVersionResponse<TP>>
+			: Record<string, OsVersionResponse<TP>>
 	>;
 	/**
 	 * @summary Get the supported OS versions for the provided device type(s)
@@ -437,7 +433,7 @@ const getOsModel = function (
 		pineOptions?: TP,
 		extraOptions?: { includeDraft?: boolean },
 	): Promise<
-		TypeOrDictionary<OsVersion[] | OsVersionResponse<NonNullable<TP>>>
+		TypeOrRecord<string, OsVersion[] | OsVersionResponse<NonNullable<TP>>>
 	> {
 		const singleDeviceTypeArg =
 			typeof deviceTypes === 'string' ? deviceTypes : false;
@@ -465,7 +461,7 @@ const getOsModel = function (
 	async function getAllOsVersions(
 		deviceType: string[],
 		options?: undefined,
-	): Promise<Dictionary<OsVersion[]>>;
+	): Promise<Record<string, OsVersion[]>>;
 
 	async function getAllOsVersions<
 		TP extends ODataOptionsWithoutCount<Release['Read']>,
@@ -478,7 +474,7 @@ const getOsModel = function (
 	>(
 		deviceTypes: string[],
 		options?: TP,
-	): Promise<Dictionary<OsVersionResponse<NonNullable<TP>>>>;
+	): Promise<Record<string, OsVersionResponse<NonNullable<TP>>>>;
 	/**
 	 * @summary Get all OS versions for the provided device type(s), inlcuding invalidated ones
 	 * @name getAllOsVersions
@@ -507,7 +503,7 @@ const getOsModel = function (
 		deviceTypes: string[] | string,
 		options?: TP,
 	): Promise<
-		TypeOrDictionary<OsVersionResponse<NonNullable<TP>> | OsVersion[]>
+		TypeOrRecord<string, OsVersionResponse<NonNullable<TP>> | OsVersion[]>
 	> {
 		const singleDeviceTypeArg =
 			typeof deviceTypes === 'string' ? deviceTypes : false;

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -1,6 +1,7 @@
-import type { AnyObject, Dictionary } from '../../typings/utils';
+import type { AnyObject } from '../../typings/utils';
 
-export type Partials = Dictionary<string[] | Partials>;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type -- This interface is intentionally empty to allow recursive type definitions
+export interface Partials extends Record<string, string[] | Partials> {}
 
 export interface Contract {
 	slug: string;

--- a/src/types/device-state.ts
+++ b/src/types/device-state.ts
@@ -1,19 +1,17 @@
-import type { Dictionary } from '../../typings/utils';
-
 export interface ServiceInfo {
 	imageId: number;
 	serviceName: string;
 	image: string;
 	running: boolean;
-	environment: Dictionary<string>;
-	labels: Dictionary<string>;
+	environment: Record<string, string>;
+	labels: Record<string, string>;
 }
 
 export interface AppInfo {
 	name: string;
 	commit?: string;
 	releaseId?: number;
-	services: Dictionary<ServiceInfo>;
+	services: Record<string, ServiceInfo>;
 	volumes: any;
 	networks: any;
 }
@@ -21,7 +19,7 @@ export interface AppInfo {
 export interface DependentAppInfo {
 	name: string;
 	parentApp: number;
-	config: Dictionary<string>;
+	config: Record<string, string>;
 	commit?: string;
 	releaseId?: number;
 	imageId?: number;
@@ -31,25 +29,31 @@ export interface DependentAppInfo {
 export interface DeviceState {
 	local: {
 		name: string;
-		config: Dictionary<string>;
-		apps: Dictionary<AppInfo>;
+		config: Record<string, string>;
+		apps: Record<string, AppInfo>;
 	};
 	dependent: {
-		apps: Dictionary<DependentAppInfo>;
-		devices: Dictionary<{
-			name: string;
-			apps: Dictionary<{
-				config: Dictionary<string>;
-				environment: Dictionary<string>;
-			}>;
-		}>;
+		apps: Record<string, DependentAppInfo>;
+		devices: Record<
+			string,
+			{
+				name: string;
+				apps: Record<
+					string,
+					{
+						config: Record<string, string>;
+						environment: Record<string, string>;
+					}
+				>;
+			}
+		>;
 	};
 }
 
 export interface DeviceStateV3 {
 	[deviceUuid: string]: {
 		name?: string;
-		config: Dictionary<string>;
+		config: Record<string, string>;
 		apps: {
 			[appUuid: string]: {
 				release_uuid?: string;

--- a/src/types/device-type-json.ts
+++ b/src/types/device-type-json.ts
@@ -1,5 +1,3 @@
-import type { Dictionary } from '../../typings/utils';
-
 /* types for the /device-types/v1 endppoints */
 
 export interface DeviceType {
@@ -79,7 +77,7 @@ export interface DeviceTypeOptionsGroup {
 	min?: number;
 	max?: number;
 	hidden?: boolean;
-	when?: Dictionary<number | string | boolean>;
+	when?: Record<string, number | string | boolean>;
 	choices?: string[] | number[];
-	choicesLabels?: Dictionary<string>;
+	choicesLabels?: Record<string, string>;
 }

--- a/src/util/dependent-resource.ts
+++ b/src/util/dependent-resource.ts
@@ -21,7 +21,7 @@ key-value resources directly attached to a parent (e.g. tags, config variables).
 
 import { isId, isUnauthorizedResponse, mergePineOptions } from '../util';
 import type { BalenaModel, PineClient } from '..';
-import type { Dictionary, StringKeyof } from '../../typings/utils';
+import type { StringKeyof } from '../../typings/utils';
 import type {
 	ExpandableStringKeyOf,
 	Filter,
@@ -53,7 +53,7 @@ export function buildDependentResource<T extends DependentResourceName>(
 		resourceKeyField: StringKeyof<BalenaModel[T]['Read']>; // e.g. tag_key
 		parentResourceName: ExpandableStringKeyOf<BalenaModel[T]['Read']>; // e.g. device
 		getResourceId: (
-			uuidOrIdOrDict: string | number | Dictionary<unknown>,
+			uuidOrIdOrDict: string | number | Record<string, unknown>,
 		) => Promise<number>; // e.g. getId(uuidOrIdOrDict)
 	},
 ) {
@@ -76,7 +76,7 @@ export function buildDependentResource<T extends DependentResourceName>(
 		async getAllByParent<
 			O extends ODataOptionsWithoutCount<BalenaModel[T]['Read']>,
 		>(
-			parentParam: string | number | Dictionary<unknown>,
+			parentParam: string | number | Record<string, unknown>,
 			options?: O,
 		): Promise<OptionsToResponse<BalenaModel[T]['Read'], O, undefined>> {
 			const id = await getResourceId(parentParam);
@@ -96,7 +96,7 @@ export function buildDependentResource<T extends DependentResourceName>(
 		},
 
 		async get(
-			parentParam: string | number | Dictionary<unknown>,
+			parentParam: string | number | Record<string, unknown>,
 			key: string,
 		): Promise<string | undefined> {
 			const id = await getResourceId(parentParam);
@@ -117,7 +117,7 @@ export function buildDependentResource<T extends DependentResourceName>(
 		},
 
 		async set(
-			parentParam: string | number | Dictionary<unknown>,
+			parentParam: string | number | Record<string, unknown>,
 			key: string,
 			value: string,
 		): Promise<void> {
@@ -155,7 +155,7 @@ export function buildDependentResource<T extends DependentResourceName>(
 		},
 
 		async remove(
-			parentParam: string | number | Dictionary<unknown>,
+			parentParam: string | number | Record<string, unknown>,
 			key: string,
 		): Promise<void> {
 			const parentId = await getResourceId(parentParam);

--- a/tests/integration/models/release.spec.ts
+++ b/tests/integration/models/release.spec.ts
@@ -22,7 +22,6 @@ import {
 	itShouldGetAllTagsByResource,
 } from './tags';
 import type * as tagsHelper from './tags';
-import type { Dictionary } from '../../../typings/utils';
 import type { PickDeferred } from '@balena/abstract-sql-to-typescript';
 
 const uniquePropertyNames = [
@@ -295,7 +294,8 @@ describe('Release Model', function () {
 		});
 
 		describe(`given ${uniquePropertyNames.length} draft releases`, function () {
-			const testReleaseByField: Dictionary<
+			const testReleaseByField: Record<
+				string,
 				PickDeferred<
 					BalenaSdk.Release['Read'],
 					'id' | 'commit' | 'raw_version' | 'belongs_to__application'

--- a/tests/integration/models/tags.ts
+++ b/tests/integration/models/tags.ts
@@ -2,7 +2,6 @@
 import * as _ from 'lodash';
 import { expect } from 'chai';
 import parallel from 'mocha.parallel';
-import type { Dictionary } from '../../../typings/utils';
 import { getFieldLabel, getParam } from '../utils';
 import { expectError } from '../../util';
 import type { ODataOptionsWithoutCount } from 'pinejs-client-core';
@@ -22,7 +21,7 @@ const getAllByResourceFactory = function (
 ) {
 	const propName = getAllByResourcePropNameProvider(resourceName);
 	return function (
-		idOrUniqueParam: number | string | Dictionary<unknown>,
+		idOrUniqueParam: number | string | Record<string, unknown>,
 		options?: ODataOptionsWithoutCount<ResourceTagBase>,
 	) {
 		return (model as any)[propName](idOrUniqueParam, options) as Promise<
@@ -36,12 +35,12 @@ const getTagKey = (key: string | { [key: string]: string }) =>
 
 export interface TagModelBase {
 	set(
-		uuidOrIdOrDict: string | number | Dictionary<unknown>,
+		uuidOrIdOrDict: string | number | Record<string, unknown>,
 		tagKey: string,
 		value: string,
 	): Promise<void>;
 	remove(
-		uuidOrIdOrDict: string | number | Dictionary<unknown>,
+		uuidOrIdOrDict: string | number | Record<string, unknown>,
 		tagKey: string,
 	): Promise<void>;
 }

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
 import * as _ from 'lodash';
-import type { Dictionary } from '../../typings/utils';
 import { balena } from './setup';
 
 export const getInitialOrganization = async () => {
@@ -41,7 +40,7 @@ export const getParam = <T>(
 				param[propertyEntry[1]] = param[propertyEntry[1]].__id;
 			}
 		}
-		return param as Dictionary<unknown>;
+		return param as Record<string, unknown>;
 	}
 
 	return resource[field];

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -13,15 +13,7 @@ export type PropsAssignableWithType<T, P> = {
 // backwards compatible alternative for: Extract<keyof T, string>
 export type StringKeyof<T> = keyof T & string;
 
-export interface Dictionary<T> {
-	[key: string]: T;
-}
-
-export type TypeOrDictionary<T> =
-	| T
-	| {
-			[key: string]: T;
-	  };
+export type TypeOrRecord<K extends keyof any, T> = T | Record<K, T>;
 
 export type IfDefined<T, P> = undefined extends T ? object : P;
 


### PR DESCRIPTION
This reduces the number of custom typings we maintain/need to know about

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer to an open issue that this resolved -->
HQ: <url> <!-- Refer to open HQ ticket or spec in balena-io/balena -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Includes tests
- [ ] Includes typings
- [ ] Includes updated documentation
- [ ] Includes updated build output
